### PR TITLE
Add initial version of /metrics http endpoint (#78)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS ruuvidongle_main.c time.c mqtt.c gpio.c leds.c uart.c http.c settings.c ethernet.c
+idf_component_register(SRCS ruuvidongle_main.c time.c mqtt.c gpio.c leds.c uart.c http.c settings.c ethernet.c metrics.c
 					REQUIRES mqtt lwip esp_http_client json esp32-wifi-manager ruuvi.boards.c ruuvi.endpoints.c
 					INCLUDE_DIRS "includes"
 )

--- a/main/includes/ruuvidongle.h
+++ b/main/includes/ruuvidongle.h
@@ -54,6 +54,11 @@ struct adv_report_table
     adv_report_t table[MAX_ADVS_TABLE];
 };
 
+typedef struct gw_metrics
+{
+    uint64_t received_advertisements;
+} gw_metrics_t;
+
 #define RUUVI_DONGLE_CONFIG_HEADER          (0xAABBU)
 #define RUUVI_DONGLE_CONFIG_FMT_VERSION     (0x0004U)
 
@@ -115,10 +120,12 @@ typedef enum nrf_command_t
 extern struct dongle_config m_dongle_config;
 extern EventGroupHandle_t status_bits;
 extern mac_address_str_t gw_mac_sta;
+extern gw_metrics_t gw_metrics;
 
 void mac_address_bin_init(mac_address_bin_t* p_mac, const uint8_t mac[6]);
 mac_address_str_t mac_address_to_str(const mac_address_bin_t* p_mac);
 char * ruuvi_get_conf_json();
+char * ruuvi_get_metrics();
 void settings_get_from_flash (struct dongle_config * dongle_config);
 void settings_print (struct dongle_config * config);
 int settings_clear_in_flash (void);

--- a/main/metrics.c
+++ b/main/metrics.c
@@ -1,0 +1,94 @@
+#include "ruuvidongle.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+
+#define BUF_LEN 2048
+#define METRICS_PREFIX "ruuvigw_"
+
+static const char TAG[] = "metrics";
+
+gw_metrics_t gw_metrics = {};
+
+size_t get_total_free_bytes(const uint32_t caps)
+{
+    multi_heap_info_t x;
+    heap_caps_get_info(&x, caps);
+    return x.total_free_bytes;
+}
+
+// See:
+// https://prometheus.io/docs/instrumenting/writing_exporters/
+// https://prometheus.io/docs/instrumenting/exposition_formats/
+
+int gen_metrics(char* buf, size_t limit)
+{
+    return snprintf(buf, limit,
+    METRICS_PREFIX "received_advertisements %lld\n"
+    METRICS_PREFIX "uptime_us %lld\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_EXEC\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_32BIT\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_8BIT\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_DMA\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_PID2\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_PID3\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_PID4\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_PID5\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_PID6\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_PID7\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_SPIRAM\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_INTERNAL\"} %zu\n"
+    METRICS_PREFIX "heap_free_bytes{capability=\"MALLOC_CAP_DEFAULT\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_EXEC\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_32BIT\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_8BIT\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_DMA\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_PID2\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_PID3\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_PID4\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_PID5\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_PID6\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_PID7\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_SPIRAM\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_INTERNAL\"} %zu\n"
+    METRICS_PREFIX "heap_largest_free_block_bytes{capability=\"MALLOC_CAP_DEFAULT\"} %zu\n",
+    gw_metrics.received_advertisements,
+    esp_timer_get_time(),
+    get_total_free_bytes(MALLOC_CAP_EXEC),
+    get_total_free_bytes(MALLOC_CAP_32BIT),
+    get_total_free_bytes(MALLOC_CAP_8BIT),
+    get_total_free_bytes(MALLOC_CAP_DMA),
+    get_total_free_bytes(MALLOC_CAP_PID2),
+    get_total_free_bytes(MALLOC_CAP_PID3),
+    get_total_free_bytes(MALLOC_CAP_PID4),
+    get_total_free_bytes(MALLOC_CAP_PID5),
+    get_total_free_bytes(MALLOC_CAP_PID6),
+    get_total_free_bytes(MALLOC_CAP_PID7),
+    get_total_free_bytes(MALLOC_CAP_SPIRAM),
+    get_total_free_bytes(MALLOC_CAP_INTERNAL),
+    get_total_free_bytes(MALLOC_CAP_DEFAULT),
+    heap_caps_get_largest_free_block(MALLOC_CAP_EXEC),
+    heap_caps_get_largest_free_block(MALLOC_CAP_32BIT),
+    heap_caps_get_largest_free_block(MALLOC_CAP_8BIT),
+    heap_caps_get_largest_free_block(MALLOC_CAP_DMA),
+    heap_caps_get_largest_free_block(MALLOC_CAP_PID2),
+    heap_caps_get_largest_free_block(MALLOC_CAP_PID3),
+    heap_caps_get_largest_free_block(MALLOC_CAP_PID4),
+    heap_caps_get_largest_free_block(MALLOC_CAP_PID5),
+    heap_caps_get_largest_free_block(MALLOC_CAP_PID6),
+    heap_caps_get_largest_free_block(MALLOC_CAP_PID7),
+    heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM),
+    heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+    heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT));
+}
+
+char* ruuvi_get_metrics()
+{
+    char *buf = malloc(BUF_LEN * sizeof(char));
+    int size = gen_metrics(buf, BUF_LEN);
+    if (size >= BUF_LEN) {
+        ESP_LOGW (TAG, "Initial buffer size of %d for metrics is insufficient, needed %d! Consider increasing BUF_LEN in metrics.c", BUF_LEN, size);
+        realloc(buf,(size + 1) * sizeof(char));
+        gen_metrics(buf, size + 1);
+    }
+    return buf;
+}

--- a/main/uart.c
+++ b/main/uart.c
@@ -59,6 +59,7 @@ static void bin2hex (char * const hexstr, const size_t hexstr_size, const uint8_
 static esp_err_t adv_put_to_table (const adv_report_t * const p_adv)
 {
     portENTER_CRITICAL (&adv_table_mux);
+    gw_metrics.received_advertisements++;
     bool found = false;
     esp_err_t ret = ESP_OK;
 


### PR DESCRIPTION
I guess this is more of a proposal of a way to implement metrics for health monitoring on a status page (to be implemented) as well as using standard monitoring tools. I just happened to implement this method as a little practice while exploring the project setup and structure.

This implementation produces a plaintext metric result in [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/) for direct use with compatible monitoring tools (ie. Prometheus or Zabbix) or a status page served by the GW itself (to be implemented, the status page would call the metrics endpoint periodically and update itself accordingly). The http endpoint itself is implemented in: https://github.com/ruuvi/esp32-wifi-manager/pull/27

Currently the exposed metrics are just the number of received advertisements, device uptime, and heap memory statistics for different [memory capabilities](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/mem_alloc.html#memory-capabilities), but it's easy to add more metrics to the list.
