### PR TITLE
#101: Fix vulnerability (the use of this insecure "sprintf" function), update esp32-wifi-manager (fix security hotspots)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,7 @@
 idf_component_register(
         SRCS
+            bin2hex.c
+            bin2hex.h
             ruuvi_gateway_main.c
             time.c
             mqtt.c

--- a/main/bin2hex.c
+++ b/main/bin2hex.c
@@ -1,0 +1,24 @@
+/**
+ * @file bin2hex.c
+ * @author TheSomeMan
+ * @date 2020-08-27
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ */
+
+#include "bin2hex.h"
+#include "str_buf.h"
+
+void
+bin2hex(char *const p_hex_str, const size_t hex_str_size, const uint8_t *const p_bin_buf, const size_t bin_buf_len)
+{
+    str_buf_t str_buf = STR_BUF_INIT(p_hex_str, hex_str_size);
+
+    for (size_t i = 0; i < bin_buf_len; i++)
+    {
+        if (str_buf_get_len(&str_buf) + 3 > hex_str_size)
+        {
+            break;
+        }
+        str_buf_printf(&str_buf, "%02X", p_bin_buf[i]);
+    }
+}

--- a/main/bin2hex.h
+++ b/main/bin2hex.h
@@ -1,0 +1,35 @@
+/**
+ * @file bin2hex.h
+ * @author TheSomeMan
+ * @date 2020-08-27
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ */
+
+#ifndef RUUVI_GATEWAY_ESP_BIN2HEX_H
+#define RUUVI_GATEWAY_ESP_BIN2HEX_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Print given binary into hex string.
+ *
+ * Example {0xA0, 0xBB, 0x31} -> "A0BB31"
+ *
+ * @param[out] p_hex_str Pointer to string to print into. Must be at least 2 * bin_buf_len + 1 bytes long.
+ * @param[in]  hex_str_size Size of hex_str in bytes.
+ * @param[in]  p_bin_buf Pointer to the binary to print from.
+ * @param[in]  bin_buf_len Size of the binary buffer in bytes.
+ */
+void
+bin2hex(char *const p_hex_str, const size_t hex_str_size, const uint8_t *const p_bin_buf, const size_t bin_buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUUVI_GATEWAY_ESP_BIN2HEX_H

--- a/main/uart.c
+++ b/main/uart.c
@@ -18,6 +18,7 @@
 #include "ruuvi_board_gwesp.h"
 #include "ruuvi_endpoints.h"
 #include "ruuvi_endpoint_ca_uart.h"
+#include "bin2hex.h"
 
 //#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
 
@@ -31,31 +32,6 @@ portMUX_TYPE    adv_table_mux = portMUX_INITIALIZER_UNLOCKED;
 
 struct adv_report_table adv_reports;
 struct adv_report_table adv_reports_buf;
-
-/**
- * @brief Print given binary into hex string.
- *
- * Example {0xA0, 0xBB, 0x31} -> "A0BB31"
- *
- * @param[out] hexstr String to print into. Must be at least 2 * binlen + 1 bytes long.
- * @param[in]  bin Binary to print from.
- * @param[in]  binlen Size of binary in bytes.
- */
-static void
-bin2hex(char *const hexstr, const size_t hexstr_size, const uint8_t *const bin, size_t binlen)
-{
-    size_t ii = 0;
-    for (ii = 0; ii < binlen; ii++)
-    {
-        if ((2 * ii + 3) > hexstr_size)
-        {
-            break;
-        }
-        sprintf(hexstr + (2 * ii), "%02X", bin[ii]);
-    }
-
-    hexstr[2 * ii] = 0;
-}
 
 static esp_err_t
 adv_put_to_table(const adv_report_t *const p_adv)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,13 @@ add_definitions(
 enable_testing()
 add_subdirectory(googletest)
 add_subdirectory(Posix_GCC_Simulator)
+add_subdirectory(test_bin2hex)
 add_subdirectory(test_leds)
+
+add_test(NAME test_bin2hex
+        COMMAND ruuvi_gateway_esp-test-bin2hex
+            --gtest_output=xml:$<TARGET_FILE_DIR:ruuvi_gateway_esp-test-bin2hex>/gtestresults.xml
+)
 
 add_test(NAME test_leds
         COMMAND ruuvi_gateway_esp-test-leds

--- a/tests/test_bin2hex/CMakeLists.txt
+++ b/tests/test_bin2hex/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(ruuvi_gateway_esp-test-bin2hex)
+set(ProjectId ruuvi_gateway_esp-test-bin2hex)
+
+add_executable(${ProjectId}
+        test_bin2hex.cpp
+        ../../main/bin2hex.c
+        ../../main/bin2hex.h
+        ../../components/esp32-wifi-manager/src/str_buf.c
+        ../../components/esp32-wifi-manager/src/str_buf.h
+)
+
+set_target_properties(${ProjectId} PROPERTIES
+        C_STANDARD 11
+        CXX_STANDARD 14
+)
+
+target_include_directories(${ProjectId} PUBLIC
+        ${gtest_SOURCE_DIR}/include
+        ${gtest_SOURCE_DIR}
+        ../../main
+        ../../components/esp32-wifi-manager/src
+        include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(${ProjectId} PUBLIC
+        RUUVI_TESTS_BIN2HEX=1
+)
+
+target_compile_options(${ProjectId} PUBLIC
+        -g3
+        -ggdb
+        -fprofile-arcs
+        -ftest-coverage
+        --coverage
+)
+
+# CMake has a target_link_options starting from version 3.13
+#target_link_options(${ProjectId} PUBLIC
+#        --coverage
+#)
+
+target_link_libraries(${ProjectId}
+        gtest
+        gtest_main
+        gcov
+        --coverage
+)

--- a/tests/test_bin2hex/test_bin2hex.cpp
+++ b/tests/test_bin2hex/test_bin2hex.cpp
@@ -1,0 +1,88 @@
+/**
+ * @file test_bin2hex.cpp
+ * @author TheSomeMan
+ * @date 2020-08-27
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ */
+
+#include "gtest/gtest.h"
+#include "bin2hex.h"
+#include <string>
+
+using namespace std;
+
+/*** Google-test class implementation *********************************************************************************/
+
+class TestBin2Hex : public ::testing::Test
+{
+private:
+protected:
+    void
+    SetUp() override
+    {
+    }
+
+    void
+    TearDown() override
+    {
+    }
+
+public:
+    TestBin2Hex();
+
+    ~TestBin2Hex() override;
+};
+
+TestBin2Hex::TestBin2Hex()
+    : Test()
+{
+}
+
+TestBin2Hex::~TestBin2Hex() = default;
+
+/*** Unit-Tests *******************************************************************************************************/
+
+TEST_F(TestBin2Hex, test_1) // NOLINT
+{
+    char          hex_str_buf[10];
+    const uint8_t bin_buf[1] = { 0x01 };
+
+    bin2hex(hex_str_buf, sizeof(hex_str_buf), bin_buf, sizeof(bin_buf));
+    ASSERT_EQ(string("01"), string(hex_str_buf));
+}
+
+TEST_F(TestBin2Hex, test_2) // NOLINT
+{
+    char          hex_str_buf[10];
+    const uint8_t bin_buf[2] = { 0x01, 0xAA };
+
+    bin2hex(hex_str_buf, sizeof(hex_str_buf), bin_buf, sizeof(bin_buf));
+    ASSERT_EQ(string("01AA"), string(hex_str_buf));
+}
+
+TEST_F(TestBin2Hex, test_5_with_overflow_size_9) // NOLINT
+{
+    char          hex_str_buf[9];
+    const uint8_t bin_buf[5] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+    bin2hex(hex_str_buf, sizeof(hex_str_buf), bin_buf, sizeof(bin_buf));
+    ASSERT_EQ(string("01020304"), string(hex_str_buf));
+}
+
+TEST_F(TestBin2Hex, test_5_with_overflow_size_10) // NOLINT
+{
+    char          hex_str_buf[10];
+    const uint8_t bin_buf[5] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+    bin2hex(hex_str_buf, sizeof(hex_str_buf), bin_buf, sizeof(bin_buf));
+    ASSERT_EQ(string("01020304"), string(hex_str_buf));
+}
+
+TEST_F(TestBin2Hex, test_5_without_overflow_size_11) // NOLINT
+{
+    char          hex_str_buf[11];
+    const uint8_t bin_buf[5] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+    bin2hex(hex_str_buf, sizeof(hex_str_buf), bin_buf, sizeof(bin_buf));
+    ASSERT_EQ(string("0102030405"), string(hex_str_buf));
+}


### PR DESCRIPTION
Fix vulnerability: remove the use of this insecure "sprintf" function.
Update esp32-wifi-manager: fix security hotspots: refactoring of unsafe strcpy and strncpy usage.