### PR TITLE
Write MACs as AA:BB:CC:DD:EE:FF

### DIFF
--- a/main/ruuvi_gateway_main.c
+++ b/main/ruuvi_gateway_main.c
@@ -103,7 +103,7 @@ mac_address_to_str(const mac_address_bin_t *p_mac)
     snprintf(
         mac_str.str_buf,
         sizeof(mac_str.str_buf),
-        "%02x:%02x:%02x:%02x:%02x:%02x",
+        "%02X:%02X:%02X:%02X:%02X:%02X",
         mac[0],
         mac[1],
         mac[2],


### PR DESCRIPTION
Matches the Ruuvi Station app format and comment at https://github.com/ruuvi/ruuvi.gateway_esp.c/blob/044e19268b528afc679c558c91c1cb02303b6782/main/includes/ruuvi_gateway.h#L49. Related issue #118 .