### PR TITLE
Fix #560: Use-after-free bug: Async DNS query can call a callback after the connection is closed

### DIFF
--- a/components/esp-tls_patched/esp_tls.h
+++ b/components/esp-tls_patched/esp_tls.h
@@ -28,6 +28,8 @@
 #include "mbedtls/error.h"
 #include "mbedtls/certs.h"
 #include "mbedtls/timing.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #elif CONFIG_ESP_TLS_USING_WOLFSSL
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/ssl.h"
@@ -294,6 +296,15 @@ typedef struct esp_tls_cfg_server {
 } esp_tls_cfg_server_t;
 #endif /* ! CONFIG_ESP_TLS_SERVER */
 
+typedef struct esp_tls esp_tls_t;
+
+typedef struct esp_tls_async_dns_req_info_t
+{
+    bool flag_busy;
+    SemaphoreHandle_t p_dns_mutex;
+    esp_tls_t *tls;
+} esp_tls_async_dns_req_info_t;
+
 /**
  * @brief      ESP-TLS Connection Handle
  */
@@ -358,11 +369,11 @@ typedef struct esp_tls {
 #endif
     TickType_t timer_start;
     ip_addr_t remote_ip;
-    StaticSemaphore_t dns_mutex_mem;
     SemaphoreHandle_t dns_mutex;
     ip_addr_t dns_cb_remote_ip;
     bool dns_cb_status;
     bool dns_cb_ready;
+    esp_tls_async_dns_req_info_t* p_async_dns_req_info;
 } esp_tls_t;
 
 

--- a/components/tcp_transport_patched/transport_ssl.c
+++ b/components/tcp_transport_patched/transport_ssl.c
@@ -244,6 +244,19 @@ static int ssl_close(esp_transport_handle_t t)
     int ret = -1;
     transport_ssl_t *ssl = esp_transport_get_context_data(t);
     if (ssl->ssl_initialized) {
+        if (NULL == ssl->tls)
+        {
+            ESP_LOGW(TAG, "[%s] %s: tls=NULL", pcTaskGetTaskName(NULL) ? pcTaskGetTaskName(NULL) : "???", __func__);
+        }
+        else
+        {
+            ESP_LOGI(
+                TAG,
+                "[%s] %s: tls=%p",
+                pcTaskGetTaskName(NULL) ? pcTaskGetTaskName(NULL) : "???",
+                __func__,
+                ssl->tls);
+        }
         ret = esp_tls_conn_destroy(ssl->tls);
         ssl->conn_state = TRANS_SSL_INIT;
         ssl->ssl_initialized = false;


### PR DESCRIPTION
Sometimes after WiFi disconnection an async DNS query remains active and when the callback is called, it causes assertion fail when accessing the mutex