### PR TITLE
Fix small bugs relates to #680 and #654

### DIFF
--- a/main/leds_ctrl.c
+++ b/main/leds_ctrl.c
@@ -366,8 +366,7 @@ leds_ctrl_handle_event_in_state_flashing_nrf52_fw(
             break;
 
         case LEDS_CTRL_EVENT_NRF52_READY:
-            assert(0);
-            break;
+            return LEDS_CTRL_STATE_WAITING_CFG_READY;
 
         case LEDS_CTRL_EVENT_NRF52_FAILURE:
             return LEDS_CTRL_STATE_NRF52_FAILURE;

--- a/main/ruuvi_gateway_main.c
+++ b/main/ruuvi_gateway_main.c
@@ -354,8 +354,10 @@ static void
 cb_on_ap_sta_ip_assigned(void)
 {
     LOG_INFO("callback: on_ap_sta_ip_assigned");
-    main_task_stop_timer_hotspot_deactivation();
-    main_task_start_timer_hotspot_deactivation();
+    if (main_task_is_active_timer_hotspot_deactivation())
+    {
+        main_task_start_timer_hotspot_deactivation();
+    }
 }
 
 static void


### PR DESCRIPTION
#680: Fix: WiFi AP can be stopped after client connect/disconnect while flashing nRF52
#654: Fix: assert triggered in leds_ctrl if nRF52 is flashed on boot