### PR TITLE
Close #726: Log info about stack usage by threads

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -17,6 +17,8 @@ idf_component_register(
             event_mgr.h
             flashfatfs.c
             flashfatfs.h
+            freertos_task_stack_size.c
+            freertos_task_stack_size.h
             fw_update.c
             fw_update.h
             fw_ver.c
@@ -89,6 +91,8 @@ idf_component_register(
             reset_reason.h
             reset_task.c
             reset_task.h
+            runtime_stat.c
+            runtime_stat.h
             ruuvi_device_id.c
             ruuvi_device_id.h
             ruuvi_gateway_main.c

--- a/main/freertos_task_stack_size.c
+++ b/main/freertos_task_stack_size.c
@@ -1,0 +1,182 @@
+/*
+    FreeRTOS V8.2.0 - Copyright (C) 2015 Real Time Engineers Ltd.
+    All rights reserved
+
+    VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
+
+    This file is part of the FreeRTOS distribution.
+
+    FreeRTOS is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License (version 2) as published by the
+    Free Software Foundation >>!AND MODIFIED BY!<< the FreeRTOS exception.
+
+    ***************************************************************************
+    >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+    >>!   distribute a combined work that includes FreeRTOS without being   !<<
+    >>!   obliged to provide the source code for proprietary components     !<<
+    >>!   outside of the FreeRTOS kernel.                                   !<<
+    ***************************************************************************
+
+    FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+    link: http://www.freertos.org/a00114.html
+
+    ***************************************************************************
+     *                                                                       *
+     *    FreeRTOS provides completely free yet professionally developed,    *
+     *    robust, strictly quality controlled, supported, and cross          *
+     *    platform software that is more than just the market leader, it     *
+     *    is the industry's de facto standard.                               *
+     *                                                                       *
+     *    Help yourself get started quickly while simultaneously helping     *
+     *    to support the FreeRTOS project by purchasing a FreeRTOS           *
+     *    tutorial book, reference manual, or both:                          *
+     *    http://www.FreeRTOS.org/Documentation                              *
+     *                                                                       *
+    ***************************************************************************
+
+    http://www.FreeRTOS.org/FAQHelp.html - Having a problem?  Start by reading
+    the FAQ page "My application does not run, what could be wrong?".  Have you
+    defined configASSERT()?
+
+    http://www.FreeRTOS.org/support - In return for receiving this top quality
+    embedded software for free we request you assist our global community by
+    participating in the support forum.
+
+    http://www.FreeRTOS.org/training - Investing in training allows your team to
+    be as productive as possible as early as possible.  Now you can receive
+    FreeRTOS training directly from Richard Barry, CEO of Real Time Engineers
+    Ltd, and the world's leading authority on the world's leading RTOS.
+
+    http://www.FreeRTOS.org/plus - A selection of FreeRTOS ecosystem products,
+    including FreeRTOS+Trace - an indispensable productivity tool, a DOS
+    compatible FAT file system, and our tiny thread aware UDP/IP stack.
+
+    http://www.FreeRTOS.org/labs - Where new FreeRTOS products go to incubate.
+    Come and try FreeRTOS+TCP, our new open source TCP/IP stack for FreeRTOS.
+
+    http://www.OpenRTOS.com - Real Time Engineers ltd. license FreeRTOS to High
+    Integrity Systems ltd. to sell under the OpenRTOS brand.  Low cost OpenRTOS
+    licenses offer ticketed support, indemnification and commercial middleware.
+
+    http://www.SafeRTOS.com - High Integrity Systems also provide a safety
+    engineered and independently SIL3 certified version for use in safety and
+    mission critical applications that require provable dependability.
+
+    1 tab == 4 spaces!
+*/
+
+/**
+ * FreeRTOS V8.2.0 lacks an implementation of uxTaskGetStackSize.
+ * To address this, certain type declarations were copied from freertos/tasks.c
+ */
+
+#include "freertos_task_stack_size.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#define prvGetTCBFromHandle(pxHandle) (((pxHandle) == NULL) ? (TCB_t*)xTaskGetCurrentTaskHandle() : (TCB_t*)(pxHandle))
+
+typedef enum
+{
+    eNotWaitingNotification = 0,
+    eWaitingNotification,
+    eNotified
+} eNotifyValue;
+
+typedef struct tskTaskControlBlock
+{
+    volatile StackType_t* pxTopOfStack; /*< Points to the location of the last item placed on the tasks stack.  THIS
+                                           MUST BE THE FIRST MEMBER OF THE TCB STRUCT. */
+
+#if (portUSING_MPU_WRAPPERS == 1)
+    xMPU_SETTINGS xMPUSettings; /*< The MPU settings are defined as part of the port layer.  THIS MUST BE THE SECOND
+                                   MEMBER OF THE TCB STRUCT. */
+#endif
+
+    ListItem_t xGenericListItem; /*< The list that the state list item of a task is reference from denotes the state of
+                                    that task (Ready, Blocked, Suspended ). */
+    ListItem_t   xEventListItem; /*< Used to reference a task from an event list. */
+    UBaseType_t  uxPriority;     /*< The priority of the task.  0 is the lowest priority. */
+    StackType_t* pxStack;        /*< Points to the start of the stack. */
+    char         pcTaskName[configMAX_TASK_NAME_LEN];
+    /*< Descriptive name given to the task when created.  Facilitates debugging only. */ /*lint !e971 Unqualified
+                                                                                            char types are allowed
+                                                                                            for strings and single
+                                                                                            characters only. */
+    BaseType_t xCoreID; /*< Core this task is pinned to */
+    /* If this moves around (other than pcTaskName size changes), please change the define in xtensa_vectors.S as well.
+     */
+#if (portSTACK_GROWTH > 0 || configENABLE_TASK_SNAPSHOT == 1)
+    StackType_t*
+        pxEndOfStack; /*< Points to the end of the stack on architectures where the stack grows up from low memory. */
+#endif
+
+#if (portCRITICAL_NESTING_IN_TCB == 1)
+    UBaseType_t uxCriticalNesting; /*< Holds the critical section nesting depth for ports that do not maintain their own
+                                      count in the port layer. */
+    uint32_t uxOldInterruptState;  /*< Interrupt state before the outer taskEnterCritical was called */
+#endif
+
+#if (configUSE_TRACE_FACILITY == 1)
+    UBaseType_t uxTCBNumber;  /*< Stores a number that increments each time a TCB is created.  It allows debuggers to
+                                 determine when a task has been deleted and then recreated. */
+    UBaseType_t uxTaskNumber; /*< Stores a number specifically for use by third party trace code. */
+#endif
+
+#if (configUSE_MUTEXES == 1)
+    UBaseType_t
+        uxBasePriority; /*< The priority last assigned to the task - used by the priority inheritance mechanism. */
+    UBaseType_t uxMutexesHeld;
+#endif
+
+#if (configUSE_APPLICATION_TASK_TAG == 1)
+    TaskHookFunction_t pxTaskTag;
+#endif
+
+#if (configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0)
+    void* pvThreadLocalStoragePointers[configNUM_THREAD_LOCAL_STORAGE_POINTERS];
+#if (configTHREAD_LOCAL_STORAGE_DELETE_CALLBACKS)
+    TlsDeleteCallbackFunction_t pvThreadLocalStoragePointersDelCallback[configNUM_THREAD_LOCAL_STORAGE_POINTERS];
+#endif
+#endif
+
+#if (configGENERATE_RUN_TIME_STATS == 1)
+    uint32_t ulRunTimeCounter; /*< Stores the amount of time the task has spent in the Running state. */
+#endif
+
+#if (configUSE_NEWLIB_REENTRANT == 1)
+    /* Allocate a Newlib reent structure that is specific to this task.
+    Note Newlib support has been included by popular demand, but is not
+    used by the FreeRTOS maintainers themselves.  FreeRTOS is not
+    responsible for resulting newlib operation.  User must be familiar with
+    newlib and must provide system-wide implementations of the necessary
+    stubs. Be warned that (at the time of writing) the current newlib design
+    implements a system-wide malloc() that must be provided with locks. */
+    struct _reent xNewLib_reent;
+#endif
+
+#if (configUSE_TASK_NOTIFICATIONS == 1)
+    volatile uint32_t     ulNotifiedValue;
+    volatile eNotifyValue eNotifyState;
+#endif
+
+    /* See the comments above the definition of
+    tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE. */
+#if (tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0)
+    uint8_t ucStaticallyAllocated; /*< Set to pdTRUE if the task is a statically allocated to ensure no attempt is made
+                                      to free the memory. */
+#endif
+
+} tskTCB;
+
+typedef tskTCB TCB_t;
+
+UBaseType_t
+uxTaskGetStackSize(TaskHandle_t xTask)
+{
+    const TCB_t*      pxTCB    = prvGetTCBFromHandle(xTask);
+    const UBaseType_t uxReturn = (pxTCB->pxEndOfStack - pxTCB->pxStack);
+    return uxReturn;
+}

--- a/main/freertos_task_stack_size.h
+++ b/main/freertos_task_stack_size.h
@@ -1,0 +1,92 @@
+/*
+    FreeRTOS V8.2.0 - Copyright (C) 2015 Real Time Engineers Ltd.
+    All rights reserved
+
+    VISIT http://www.FreeRTOS.org TO ENSURE YOU ARE USING THE LATEST VERSION.
+
+    This file is part of the FreeRTOS distribution.
+
+    FreeRTOS is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License (version 2) as published by the
+    Free Software Foundation >>!AND MODIFIED BY!<< the FreeRTOS exception.
+
+    ***************************************************************************
+    >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+    >>!   distribute a combined work that includes FreeRTOS without being   !<<
+    >>!   obliged to provide the source code for proprietary components     !<<
+    >>!   outside of the FreeRTOS kernel.                                   !<<
+    ***************************************************************************
+
+    FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+    link: http://www.freertos.org/a00114.html
+
+    ***************************************************************************
+     *                                                                       *
+     *    FreeRTOS provides completely free yet professionally developed,    *
+     *    robust, strictly quality controlled, supported, and cross          *
+     *    platform software that is more than just the market leader, it     *
+     *    is the industry's de facto standard.                               *
+     *                                                                       *
+     *    Help yourself get started quickly while simultaneously helping     *
+     *    to support the FreeRTOS project by purchasing a FreeRTOS           *
+     *    tutorial book, reference manual, or both:                          *
+     *    http://www.FreeRTOS.org/Documentation                              *
+     *                                                                       *
+    ***************************************************************************
+
+    http://www.FreeRTOS.org/FAQHelp.html - Having a problem?  Start by reading
+    the FAQ page "My application does not run, what could be wrong?".  Have you
+    defined configASSERT()?
+
+    http://www.FreeRTOS.org/support - In return for receiving this top quality
+    embedded software for free we request you assist our global community by
+    participating in the support forum.
+
+    http://www.FreeRTOS.org/training - Investing in training allows your team to
+    be as productive as possible as early as possible.  Now you can receive
+    FreeRTOS training directly from Richard Barry, CEO of Real Time Engineers
+    Ltd, and the world's leading authority on the world's leading RTOS.
+
+    http://www.FreeRTOS.org/plus - A selection of FreeRTOS ecosystem products,
+    including FreeRTOS+Trace - an indispensable productivity tool, a DOS
+    compatible FAT file system, and our tiny thread aware UDP/IP stack.
+
+    http://www.FreeRTOS.org/labs - Where new FreeRTOS products go to incubate.
+    Come and try FreeRTOS+TCP, our new open source TCP/IP stack for FreeRTOS.
+
+    http://www.OpenRTOS.com - Real Time Engineers ltd. license FreeRTOS to High
+    Integrity Systems ltd. to sell under the OpenRTOS brand.  Low cost OpenRTOS
+    licenses offer ticketed support, indemnification and commercial middleware.
+
+    http://www.SafeRTOS.com - High Integrity Systems also provide a safety
+    engineered and independently SIL3 certified version for use in safety and
+    mission critical applications that require provable dependability.
+
+    1 tab == 4 spaces!
+*/
+
+/**
+ * FreeRTOS V8.2.0 lacks an implementation of uxTaskGetStackSize.
+ * This file contains the implementation of this function.
+ */
+
+#ifndef FREERTOS_TASK_STACK_SIZE_H
+#define FREERTOS_TASK_STACK_SIZE_H
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+UBaseType_t
+uxTaskGetStackSize(TaskHandle_t xTask);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FREERTOS_TASK_STACK_SIZE_H

--- a/main/reset_task.c
+++ b/main/reset_task.c
@@ -16,6 +16,7 @@
 #include "mqtt.h"
 #include "event_mgr.h"
 #include "reset_info.h"
+#include "runtime_stat.h"
 
 #define LOG_LOCAL_LEVEL LOG_LEVEL_INFO
 #include "log.h"
@@ -163,6 +164,7 @@ reset_task_handle_sig(const reset_task_sig_e reset_task_sig)
             break;
         case RESET_TASK_SIG_RESTART:
             LOG_WARN("RESET_TASK_SIG_RESTART");
+            log_runtime_statistics();
             // leds_task can be blocked for 25 ms when the red LED is on/off,
             // so we need to wait some time to give leds_task time
             // to complete the current operation and turn off the green and red LEDs

--- a/main/runtime_stat.c
+++ b/main/runtime_stat.c
@@ -17,25 +17,96 @@
 
 static const char TAG[] = "runtime_stat";
 
-extern UBaseType_t
-uxTaskGetStackSize(TaskHandle_t xTask);
+enum
+{
+    RUNTIME_STAT_MAX_NUM_TASKS = 24,
+};
+
+typedef struct RuntimeStatTaskInfo_t
+{
+    UBaseType_t task_number;
+    uint32_t    runtime_counter;
+} RuntimeStatTaskInfo_t;
+
+typedef uint32_t RuntimeStatTaskInfoIdx_t;
+
+static RuntimeStatTaskInfoIdx_t
+runtime_stat_find_task_info(
+    const RuntimeStatTaskInfo_t* const p_arr_of_tasks,
+    const uint32_t                     max_num_tasks,
+    const UBaseType_t                  task_num)
+{
+    for (RuntimeStatTaskInfoIdx_t i = 0; i < max_num_tasks; ++i)
+    {
+        const RuntimeStatTaskInfo_t* const p_task_info = &p_arr_of_tasks[i];
+        if (task_num == p_task_info->task_number)
+        {
+            return i;
+        }
+    }
+    return UINT32_MAX;
+}
+
+static RuntimeStatTaskInfoIdx_t
+runtime_stat_add_task_info(
+    RuntimeStatTaskInfo_t* const p_arr_of_tasks,
+    const uint32_t               max_num_tasks,
+    const UBaseType_t            task_num,
+    const uint32_t               runtime_counter)
+{
+    for (RuntimeStatTaskInfoIdx_t i = 0; i < max_num_tasks; ++i)
+    {
+        RuntimeStatTaskInfo_t* const p_task_info = &p_arr_of_tasks[i];
+        if (0 == p_task_info->task_number)
+        {
+            p_task_info->task_number     = task_num;
+            p_task_info->runtime_counter = runtime_counter;
+            return i;
+        }
+    }
+    return UINT32_MAX;
+}
+
+static void
+runtime_stat_remove_deleted_tasks_info(
+    RuntimeStatTaskInfo_t* const p_arr_of_tasks,
+    const uint32_t               max_num_tasks,
+    const uint32_t               task_info_bit_mask)
+{
+    for (RuntimeStatTaskInfoIdx_t i = 0; i < max_num_tasks; ++i)
+    {
+        RuntimeStatTaskInfo_t* const p_task_info = &p_arr_of_tasks[i];
+        if (0 == (task_info_bit_mask & (1U << i)))
+        {
+            p_task_info->task_number     = 0;
+            p_task_info->runtime_counter = 0;
+        }
+    }
+}
 
 void
 log_runtime_statistics(void)
 {
-    uint32_t      num_tasks      = 24;
-    TaskStatus_t* p_arr_of_tasks = os_calloc(num_tasks, sizeof(*p_arr_of_tasks));
+    static RuntimeStatTaskInfo_t g_tasks_info[RUNTIME_STAT_MAX_NUM_TASKS] = { 0 };
+
+    TaskStatus_t* p_arr_of_tasks = os_calloc(RUNTIME_STAT_MAX_NUM_TASKS, sizeof(*p_arr_of_tasks));
     if (NULL == p_arr_of_tasks)
     {
         LOG_ERR("Can't allocate memory");
         return;
     }
 
-    uint32_t total_time = 0;
+    static uint32_t prev_total_time = 0;
+    uint32_t        total_time      = 0;
 
-    num_tasks = uxTaskGetSystemState(p_arr_of_tasks, num_tasks, &total_time);
+    const uint32_t num_tasks = uxTaskGetSystemState(p_arr_of_tasks, RUNTIME_STAT_MAX_NUM_TASKS, &total_time);
 
-    LOG_INFO("======== totalTime %8u =================================================", (printf_uint_t)total_time);
+    const uint32_t total_time_delta = total_time - prev_total_time;
+    prev_total_time                 = total_time;
+
+    LOG_INFO(
+        "======== totalTime %8u =================================================",
+        (printf_uint_t)total_time_delta);
     LOG_INFO("|  #  |    Task name     | Pri | Stat|    cnt    |  %%  |        Stack       |");
 
     if (num_tasks == 0)
@@ -44,76 +115,119 @@ log_runtime_statistics(void)
         os_free(p_arr_of_tasks);
         return;
     }
-    if (total_time == 0)
-    {
-        LOG_ERR("Total time is zero");
-        os_free(p_arr_of_tasks);
-        return;
-    }
+    uint32_t task_info_bit_mask = 0;
     for (uint32_t task_idx = 0; task_idx < num_tasks; task_idx++)
     {
-        TaskStatus_t*     pTaskStatus = &p_arr_of_tasks[task_idx];
-        const UBaseType_t stackSize   = uxTaskGetStackSize(pTaskStatus->xHandle);
-        /* What percentage of the total run time has the task used?
-         This will always be rounded down to the nearest integer.
-         ulTotalRunTimeDiv100 has already been divided by 100. */
-        const uint32_t ulStatsAsPercentage = (pTaskStatus->ulRunTimeCounter * 100 + total_time / 2) / total_time;
+        TaskStatus_t* p_task_status = &p_arr_of_tasks[task_idx];
 
-        const char* taskStatus = "";
-        switch (pTaskStatus->eCurrentState)
-        {
-            case eReady:
-                taskStatus = "Rdy";
-                break;
-            case eBlocked:
-                taskStatus = "Blk";
-                break;
-            case eSuspended:
-                taskStatus = "Sus";
-                break;
-            case eDeleted:
-                taskStatus = "Del";
-                break;
-            default:
-                taskStatus = "???";
-                break;
-        }
+        RuntimeStatTaskInfoIdx_t task_info_idx = runtime_stat_find_task_info(
+            g_tasks_info,
+            sizeof(g_tasks_info) / sizeof(*g_tasks_info),
+            p_task_status->xTaskNumber);
 
-        const size_t taskNameLen = strlen(pTaskStatus->pcTaskName);
-        if ((ulStatsAsPercentage > 0UL) || (0 == pTaskStatus->ulRunTimeCounter))
+        RuntimeStatTaskInfo_t* const p_task_info = (task_info_idx < sizeof(g_tasks_info) / sizeof(*g_tasks_info))
+                                                       ? &g_tasks_info[task_info_idx]
+                                                       : NULL;
+
+        const uint32_t runtime_counter_delta = p_task_status->ulRunTimeCounter
+                                               - ((NULL != p_task_info) ? p_task_info->runtime_counter : 0);
+        if (NULL != p_task_info)
         {
-            LOG_INFO(
-                "|%4u | %s%*s | %3u | %s |%10u |%3u%% |%5d of %5u (%2u%%)|",
-                (printf_uint_t)pTaskStatus->xTaskNumber,
-                pTaskStatus->pcTaskName,
-                16 - taskNameLen,
-                "",
-                (printf_uint_t)pTaskStatus->uxBasePriority,
-                taskStatus,
-                (printf_uint_t)pTaskStatus->ulRunTimeCounter,
-                (printf_uint_t)ulStatsAsPercentage,
-                (printf_int_t)(stackSize - pTaskStatus->usStackHighWaterMark),
-                (printf_uint_t)stackSize,
-                (printf_uint_t)((stackSize - pTaskStatus->usStackHighWaterMark) * 100 / stackSize));
+            p_task_info->runtime_counter = p_task_status->ulRunTimeCounter;
         }
         else
         {
-            /* If the percentage is zero here then the task has
-             consumed less than 1% of the total run time. */
+            task_info_idx = runtime_stat_add_task_info(
+                g_tasks_info,
+                sizeof(g_tasks_info) / sizeof(*g_tasks_info),
+                p_task_status->xTaskNumber,
+                p_task_status->ulRunTimeCounter);
+        }
+        if (UINT32_MAX != task_info_idx)
+        {
+            task_info_bit_mask |= 1U << task_info_idx;
+        }
+
+        const UBaseType_t stack_size = uxTaskGetStackSize(p_task_status->xHandle);
+
+        const uint32_t percentage_of_cpu_usage = (total_time_delta != 0)
+                                                     ? (runtime_counter_delta * 100 + total_time_delta / 2)
+                                                           / total_time_delta
+                                                     : UINT32_MAX;
+
+        const char* p_task_status_str = "";
+        switch (p_task_status->eCurrentState)
+        {
+            case eReady:
+                p_task_status_str = "Rdy";
+                break;
+            case eBlocked:
+                p_task_status_str = "Blk";
+                break;
+            case eSuspended:
+                p_task_status_str = "Sus";
+                break;
+            case eDeleted:
+                p_task_status_str = "Del";
+                break;
+            default:
+                p_task_status_str = "???";
+                break;
+        }
+
+        const size_t task_name_len = strlen(p_task_status->pcTaskName);
+        if (UINT32_MAX == percentage_of_cpu_usage)
+        {
+            LOG_INFO(
+                "|%4u | %s%*s | %3u | %s |%10u |  -  |%5d of %5u (%2u%%)|",
+                (printf_uint_t)p_task_status->xTaskNumber,
+                p_task_status->pcTaskName,
+                16 - task_name_len,
+                "",
+                (printf_uint_t)p_task_status->uxBasePriority,
+                p_task_status_str,
+                runtime_counter_delta,
+                (printf_int_t)(stack_size - p_task_status->usStackHighWaterMark),
+                (printf_uint_t)stack_size,
+                (printf_uint_t)((stack_size - p_task_status->usStackHighWaterMark) * 100 / stack_size));
+        }
+        else if ((percentage_of_cpu_usage > 0UL) || (0 == runtime_counter_delta))
+        {
+            LOG_INFO(
+                "|%4u | %s%*s | %3u | %s |%10u |%3u%% |%5d of %5u (%2u%%)|",
+                (printf_uint_t)p_task_status->xTaskNumber,
+                p_task_status->pcTaskName,
+                16 - task_name_len,
+                "",
+                (printf_uint_t)p_task_status->uxBasePriority,
+                p_task_status_str,
+                (printf_uint_t)runtime_counter_delta,
+                (printf_uint_t)percentage_of_cpu_usage,
+                (printf_int_t)(stack_size - p_task_status->usStackHighWaterMark),
+                (printf_uint_t)stack_size,
+                (printf_uint_t)((stack_size - p_task_status->usStackHighWaterMark) * 100 / stack_size));
+        }
+        else
+        {
+            /* If the percentage is zero here then the task has consumed less than 1% of the total run time. */
             LOG_INFO(
                 "|%4u | %s%*s | %3u | %s |%10u | <1%% |%5d of %5u (%2u%%)|",
-                (printf_uint_t)pTaskStatus->xTaskNumber,
-                pTaskStatus->pcTaskName,
-                16 - taskNameLen,
+                (printf_uint_t)p_task_status->xTaskNumber,
+                p_task_status->pcTaskName,
+                16 - task_name_len,
                 "",
-                (printf_uint_t)pTaskStatus->uxBasePriority,
-                taskStatus,
-                pTaskStatus->ulRunTimeCounter,
-                (printf_int_t)(stackSize - pTaskStatus->usStackHighWaterMark),
-                (printf_uint_t)stackSize,
-                (printf_uint_t)((stackSize - pTaskStatus->usStackHighWaterMark) * 100 / stackSize));
+                (printf_uint_t)p_task_status->uxBasePriority,
+                p_task_status_str,
+                runtime_counter_delta,
+                (printf_int_t)(stack_size - p_task_status->usStackHighWaterMark),
+                (printf_uint_t)stack_size,
+                (printf_uint_t)((stack_size - p_task_status->usStackHighWaterMark) * 100 / stack_size));
         }
     }
+    runtime_stat_remove_deleted_tasks_info(
+        g_tasks_info,
+        sizeof(g_tasks_info) / sizeof(*g_tasks_info),
+        task_info_bit_mask);
     LOG_INFO("=============================================================================");
     os_free(p_arr_of_tasks);
 }

--- a/main/runtime_stat.c
+++ b/main/runtime_stat.c
@@ -1,0 +1,119 @@
+/**
+ * @file runtime_stat.c
+ * @author TheSomeMan
+ * @date 2023-03-28
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ */
+
+#include "runtime_stat.h"
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos_task_stack_size.h"
+#include "os_malloc.h"
+
+#define LOG_LOCAL_LEVEL LOG_LEVEL_INFO
+#include "log.h"
+
+static const char TAG[] = "runtime_stat";
+
+extern UBaseType_t
+uxTaskGetStackSize(TaskHandle_t xTask);
+
+void
+log_runtime_statistics(void)
+{
+    uint32_t      num_tasks      = 24;
+    TaskStatus_t* p_arr_of_tasks = os_calloc(num_tasks, sizeof(*p_arr_of_tasks));
+    if (NULL == p_arr_of_tasks)
+    {
+        LOG_ERR("Can't allocate memory");
+        return;
+    }
+
+    uint32_t total_time = 0;
+
+    num_tasks = uxTaskGetSystemState(p_arr_of_tasks, num_tasks, &total_time);
+
+    LOG_INFO("======== totalTime %8u =================================================", (printf_uint_t)total_time);
+    LOG_INFO("|  #  |    Task name     | Pri | Stat|    cnt    |  %%  |        Stack       |");
+
+    if (num_tasks == 0)
+    {
+        LOG_ERR("The arr of tasks is too small");
+        os_free(p_arr_of_tasks);
+        return;
+    }
+    if (total_time == 0)
+    {
+        LOG_ERR("Total time is zero");
+        os_free(p_arr_of_tasks);
+        return;
+    }
+    for (uint32_t task_idx = 0; task_idx < num_tasks; task_idx++)
+    {
+        TaskStatus_t*     pTaskStatus = &p_arr_of_tasks[task_idx];
+        const UBaseType_t stackSize   = uxTaskGetStackSize(pTaskStatus->xHandle);
+        /* What percentage of the total run time has the task used?
+         This will always be rounded down to the nearest integer.
+         ulTotalRunTimeDiv100 has already been divided by 100. */
+        const uint32_t ulStatsAsPercentage = (pTaskStatus->ulRunTimeCounter * 100 + total_time / 2) / total_time;
+
+        const char* taskStatus = "";
+        switch (pTaskStatus->eCurrentState)
+        {
+            case eReady:
+                taskStatus = "Rdy";
+                break;
+            case eBlocked:
+                taskStatus = "Blk";
+                break;
+            case eSuspended:
+                taskStatus = "Sus";
+                break;
+            case eDeleted:
+                taskStatus = "Del";
+                break;
+            default:
+                taskStatus = "???";
+                break;
+        }
+
+        const size_t taskNameLen = strlen(pTaskStatus->pcTaskName);
+        if ((ulStatsAsPercentage > 0UL) || (0 == pTaskStatus->ulRunTimeCounter))
+        {
+            LOG_INFO(
+                "|%4u | %s%*s | %3u | %s |%10u |%3u%% |%5d of %5u (%2u%%)|",
+                (printf_uint_t)pTaskStatus->xTaskNumber,
+                pTaskStatus->pcTaskName,
+                16 - taskNameLen,
+                "",
+                (printf_uint_t)pTaskStatus->uxBasePriority,
+                taskStatus,
+                (printf_uint_t)pTaskStatus->ulRunTimeCounter,
+                (printf_uint_t)ulStatsAsPercentage,
+                (printf_int_t)(stackSize - pTaskStatus->usStackHighWaterMark),
+                (printf_uint_t)stackSize,
+                (printf_uint_t)((stackSize - pTaskStatus->usStackHighWaterMark) * 100 / stackSize));
+        }
+        else
+        {
+            /* If the percentage is zero here then the task has
+             consumed less than 1% of the total run time. */
+            LOG_INFO(
+                "|%4u | %s%*s | %3u | %s |%10u | <1%% |%5d of %5u (%2u%%)|",
+                (printf_uint_t)pTaskStatus->xTaskNumber,
+                pTaskStatus->pcTaskName,
+                16 - taskNameLen,
+                "",
+                (printf_uint_t)pTaskStatus->uxBasePriority,
+                taskStatus,
+                pTaskStatus->ulRunTimeCounter,
+                (printf_int_t)(stackSize - pTaskStatus->usStackHighWaterMark),
+                (printf_uint_t)stackSize,
+                (printf_uint_t)((stackSize - pTaskStatus->usStackHighWaterMark) * 100 / stackSize));
+        }
+    }
+    LOG_INFO("=============================================================================");
+    os_free(p_arr_of_tasks);
+}

--- a/main/runtime_stat.h
+++ b/main/runtime_stat.h
@@ -1,0 +1,22 @@
+/**
+ * @file runtime_stat.h
+ * @author TheSomeMan
+ * @date 2023-03-28
+ * @copyright Ruuvi Innovations Ltd, license BSD-3-Clause.
+ */
+
+#ifndef RUUVI_RUNTIME_STAT_H
+#define RUUVI_RUNTIME_STAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+log_runtime_statistics(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUUVI_RUNTIME_STAT_H


### PR DESCRIPTION
Example of runtime stat log:
```
I (367073) runtime_stat: [main/1] ======== totalTime 366147464 =================================================
I (367073) runtime_stat: [main/1] |  #  |    Task name     | Pri | Stat|    cnt    |  %  |        Stack       |
I (367084) runtime_stat: [main/1] |   2 | main             |   1 | Rdy |   5441539 |  1% | 3516 of  4092 (85%)|
I (367094) runtime_stat: [main/1] |   3 | IDLE0            |   0 | Rdy | 345222637 | <1% |  736 of  1532 (48%)|
I (367105) runtime_stat: [main/1] |   4 | Tmr Svc          |  24 | Blk |    369846 | <1% |  816 of  3068 (26%)|
I (367116) runtime_stat: [main/1] |  12 | tiT              |  18 | Blk |    817872 | <1% | 2336 of  3580 (65%)|
I (367127) runtime_stat: [main/1] |  13 | http_server      |   4 | Blk |     83808 | <1% | 2092 of 20476 (10%)|
I (367137) runtime_stat: [main/1] |   8 | uart_rx_task     |   7 | Blk |    475969 | <1% |  956 of  6140 (15%)|
I (367148) runtime_stat: [main/1] |   9 | rx_parse_task    |   7 | Blk |   4226051 |  1% | 3164 of  4092 (77%)|
I (367159) runtime_stat: [main/1] |   6 | reset_task       |   1 | Sus |     43210 | <1% | 2020 of  4092 (49%)|
I (367170) runtime_stat: [main/1] |  15 | wifi_manager     |   5 | Blk |     42890 | <1% | 2016 of  4092 (49%)|
I (367180) runtime_stat: [main/1] |  14 | wifi             |  23 | Blk |    251471 | <1% | 2156 of  6652 (32%)|
I (367191) runtime_stat: [main/1] |  16 | emac_rx          |  15 | Sus |    254312 | <1% | 1208 of  4092 (29%)|
I (367202) runtime_stat: [main/1] |   7 | adv_post_task    |   5 | Sus |   8094108 |  2% | 3628 of  4092 (88%)|
I (367213) runtime_stat: [main/1] |  17 | mdns             |   1 | Blk |    105449 | <1% | 2164 of  4092 (52%)|
I (367224) runtime_stat: [main/1] |   5 | leds_task        |   6 | Sus |    328649 | <1% | 2048 of  3068 (66%)|
I (367234) runtime_stat: [main/1] |   1 | esp_timer        |  22 | Blk |    306658 | <1% |  892 of  4092 (21%)|
I (367245) runtime_stat: [main/1] |  11 | sys_evt          |  20 | Blk |     72988 | <1% | 2364 of  2812 (84%)|
I (367256) runtime_stat: [main/1] |  10 | time_task        |   1 | Sus |      8062 | <1% | 2080 of  3068 (67%)|
I (367267) runtime_stat: [main/1] =============================================================================
```