### PR TITLE
Update GitHub action "SonarCloud Analysis" - use Java 17 (#849)

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -51,7 +51,7 @@ jobs:
           sudo locale-gen de_DE.UTF-8
 
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
 
       - name: Set IDF_PATH
         run: echo "IDF_PATH=$HOME/esp/esp-idf" >> $GITHUB_ENV


### PR DESCRIPTION
* Update GitHub action "SonarCloud Analysis" - use Java 17

* Set JAVA_HOME

* Use "sonarcloud-github-c-cpp@v2"