### PR TITLE
Fix #1053: ESP_ERR_MBEDTLS_SSL_HANDSHAKE_FAILED on HTTP endpoint validation "*.logic.azure.com" because new random number is generated on second "Client Hello"

### DIFF
--- a/components/mbedtls/mbedtls/library/ssl_client.c
+++ b/components/mbedtls/mbedtls/library/ssl_client.c
@@ -820,10 +820,15 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
         (ssl->handshake->cookie == NULL))
 #endif
     {
-        ret = ssl_generate_random(ssl);
-        if (ret != 0) {
-            MBEDTLS_SSL_DEBUG_RET(1, "Random bytes generation failed", ret);
-            return ret;
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+        if (ssl->handshake->hello_retry_request_count == 0)
+#endif
+        {
+            ret = ssl_generate_random(ssl);
+            if (ret != 0) {
+                MBEDTLS_SSL_DEBUG_RET(1, "Random bytes generation failed", ret);
+                return ret;
+            }
         }
     }
 


### PR DESCRIPTION


Port commit "Do not generate new random number while receiving HRR": https://github.com/Mbed-TLS/mbedtls/commit/35178fe7ecd473328248c3f0cc0dc3a0603d2a21