### PR TITLE
[#1105] Patch components/fatfs to use 512-bytes sector size for FAT

### DIFF
--- a/components/fatfs/diskio/diskio_rawflash.c
+++ b/components/fatfs/diskio/diskio_rawflash.c
@@ -24,6 +24,7 @@ static const char* TAG = "diskio_rawflash";
 
 const esp_partition_t* ff_raw_handles[FF_VOLUMES];
 
+#define FATFS_SECTOR_SIZE (512U)
 
 DSTATUS ff_raw_initialize (BYTE pdrv)
 {
@@ -40,7 +41,7 @@ DRESULT ff_raw_read (BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
     ESP_LOGV(TAG, "ff_raw_read - pdrv=%i, sector=%i, count=%in", (unsigned int)pdrv, (unsigned int)sector, (unsigned int)count);
     const esp_partition_t* part = ff_raw_handles[pdrv];
     assert(part);
-    esp_err_t err = esp_partition_read(part, sector * SPI_FLASH_SEC_SIZE, buff, count * SPI_FLASH_SEC_SIZE);
+    esp_err_t err = esp_partition_read(part, sector * FATFS_SECTOR_SIZE, buff, count * FATFS_SECTOR_SIZE);
     if (unlikely(err != ESP_OK)) {
         ESP_LOGE(TAG, "esp_partition_read failed (0x%x)", err);
         return RES_ERROR;
@@ -63,10 +64,10 @@ DRESULT ff_raw_ioctl (BYTE pdrv, BYTE cmd, void *buff)
         case CTRL_SYNC:
             return RES_OK;
         case GET_SECTOR_COUNT:
-            *((DWORD *) buff) = part->size / SPI_FLASH_SEC_SIZE;
+            *((DWORD *) buff) = part->size / FATFS_SECTOR_SIZE;
             return RES_OK;
         case GET_SECTOR_SIZE:
-            *((WORD *) buff) = SPI_FLASH_SEC_SIZE;
+            *((WORD *) buff) = FATFS_SECTOR_SIZE;
             return RES_OK;
         case GET_BLOCK_SIZE:
             return RES_ERROR;


### PR DESCRIPTION
FAT-FS images generated by mtools have a sector size of 512 bytes. However, SPI_FLASH_SEC_SIZE is 4096. This causes memory corruption because ff_raw_read reads the required number of sectors into the buffer assuming that the FAT sector size (512 bytes) matches the flash sector size (4096 bytes).