### PR TITLE
Close #1130: tcp_transport: Log heap info on TLS errors/session tickets

### DIFF
--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -56,7 +56,7 @@ static void log_heap_info(void) {
     ESP_LOGI(TAG,
         "Cur free heap: default: max block %u, free %u; IRAM: max block %u, free %u",
         (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT),
-        (unsigned)heap_caps_get_free_size( MALLOC_CAP_DEFAULT ),
+        (unsigned)heap_caps_get_free_size(MALLOC_CAP_DEFAULT),
         (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_32BIT | MALLOC_CAP_EXEC),
         (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_32BIT | MALLOC_CAP_EXEC));
 }


### PR DESCRIPTION
Adds heap information logging to improve debugging in case of TLS connection failures and when new session tickets are received. It provides insights into memory usage at crucial points.