### PR TITLE
Close #1274: Add ESP_LOGE diagnostics to mbedTLS error paths and promote TLS buffer log level to INFO

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -729,9 +729,11 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
     if (config->keep_alive_enable == true) {
         esp_transport_ssl_set_keep_alive(ssl, &client->keep_alive_cfg);
     }
-    ESP_LOGI(TAG, "%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
-             __func__, config->ssl_buf_cfg.p_ssl_in_buf, config->ssl_buf_cfg.ssl_in_buf_len, config->ssl_buf_cfg.ssl_in_content_len,
-             config->ssl_buf_cfg.p_ssl_out_buf, config->ssl_buf_cfg.ssl_out_buf_len, config->ssl_buf_cfg.ssl_out_content_len);
+    ESP_LOGI(TAG, "%s: esp_transport_ssl_set_buffer: ssl_in_buf %zu bytes (content %zu bytes), ssl_out_buf %zu bytes (content %zu bytes)",
+             __func__, config->ssl_buf_cfg.ssl_in_buf_len, config->ssl_buf_cfg.ssl_in_content_len,
+             config->ssl_buf_cfg.ssl_out_buf_len, config->ssl_buf_cfg.ssl_out_content_len);
+    ESP_LOGD(TAG, "%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p, ssl_out_buf=%p",
+             __func__, config->ssl_buf_cfg.p_ssl_in_buf, config->ssl_buf_cfg.p_ssl_out_buf);
     if (!esp_transport_ssl_set_buffer(ssl, &config->ssl_buf_cfg)) {
         ESP_LOGE(TAG, "%s: esp_transport_ssl_set_buffer failed: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
                  __func__, config->ssl_buf_cfg.p_ssl_in_buf, config->ssl_buf_cfg.ssl_in_buf_len, config->ssl_buf_cfg.ssl_in_content_len,

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -729,7 +729,7 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
     if (config->keep_alive_enable == true) {
         esp_transport_ssl_set_keep_alive(ssl, &client->keep_alive_cfg);
     }
-    ESP_LOGD(TAG, "%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
+    ESP_LOGI(TAG, "%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
              __func__, config->ssl_buf_cfg.p_ssl_in_buf, config->ssl_buf_cfg.ssl_in_buf_len, config->ssl_buf_cfg.ssl_in_content_len,
              config->ssl_buf_cfg.p_ssl_out_buf, config->ssl_buf_cfg.ssl_out_buf_len, config->ssl_buf_cfg.ssl_out_content_len);
     if (!esp_transport_ssl_set_buffer(ssl, &config->ssl_buf_cfg)) {

--- a/components/mbedtls/mbedtls/library/ssl_cache.c
+++ b/components/mbedtls/mbedtls/library/ssl_cache.c
@@ -33,6 +33,11 @@
 
 #include <string.h>
 
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char TAG[] = "ssl_cache";
+#endif
+
 void mbedtls_ssl_cache_init(mbedtls_ssl_cache_context *cache)
 {
     memset(cache, 0, sizeof(mbedtls_ssl_cache_context));
@@ -303,6 +308,10 @@ int mbedtls_ssl_cache_set(void *data,
     }
 
     if (session_id_len > sizeof(cur->session_id)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: session_id_len > sizeof(cur->session_id): %zu > %zu",
+                 __func__, session_id_len, sizeof(cur->session_id));
+#endif
         ret = MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         goto exit;
     }

--- a/components/mbedtls/mbedtls/library/ssl_client.c
+++ b/components/mbedtls/mbedtls/library/ssl_client.c
@@ -35,6 +35,11 @@
 #include "ssl_tls13_keys.h"
 #include "ssl_debug_helpers.h"
 
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char TAG[] = "ssl_client";
+#endif
+
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_write_hostname_ext(mbedtls_ssl_context *ssl,
@@ -921,6 +926,9 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
             MBEDTLS_SSL_DEBUG_MSG(
                 1, ("Hostname mismatch the session ticket, "
                     "disable session resumption."));
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: Hostname mismatch the session ticket, disable session resumption.", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
     } else {

--- a/components/mbedtls/mbedtls/library/ssl_client.c
+++ b/components/mbedtls/mbedtls/library/ssl_client.c
@@ -927,7 +927,7 @@ static int ssl_prepare_client_hello(mbedtls_ssl_context *ssl)
                 1, ("Hostname mismatch the session ticket, "
                     "disable session resumption."));
 #ifdef ESP_PLATFORM
-            ESP_LOGE(TAG, "%s: Hostname mismatch the session ticket, disable session resumption.", __func__);
+            ESP_LOGE(TAG, "%s: Hostname mismatch in the session ticket; disable session resumption", __func__);
 #endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }

--- a/components/mbedtls/mbedtls/library/ssl_cookie.c
+++ b/components/mbedtls/mbedtls/library/ssl_cookie.c
@@ -35,6 +35,11 @@
 
 #include <string.h>
 
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char TAG[] = "ssl_cookie";
+#endif
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "md_psa.h"
 /* Define a local translating function to save code size by not using too many
@@ -123,6 +128,9 @@ int mbedtls_ssl_cookie_setup(mbedtls_ssl_cookie_ctx *ctx,
 
     alg = mbedtls_md_psa_alg_from_type(COOKIE_MD);
     if (alg == 0) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: alg == 0", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -208,6 +216,9 @@ int mbedtls_ssl_cookie_write(void *p_ctx,
     unsigned long t;
 
     if (ctx == NULL || cli_id == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ctx == NULL || cli_id == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -299,6 +310,9 @@ int mbedtls_ssl_cookie_check(void *p_ctx,
     unsigned long cur_time, cookie_time;
 
     if (ctx == NULL || cli_id == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ctx == NULL || cli_id == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 

--- a/components/mbedtls/mbedtls/library/ssl_msg.c
+++ b/components/mbedtls/mbedtls/library/ssl_msg.c
@@ -48,6 +48,11 @@
 #include "mbedtls/oid.h"
 #endif
 
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char TAG[] = "ssl_msg";
+#endif
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
@@ -977,6 +982,10 @@ int mbedtls_ssl_encrypt_buf(mbedtls_ssl_context *ssl,
                                   " too large, maximum %" MBEDTLS_PRINTF_SIZET,
                                   rec->data_len,
                                   (size_t) ssl_out_content_len));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Record content %" MBEDTLS_PRINTF_SIZET " too large, maximum %" MBEDTLS_PRINTF_SIZET,
+                 __func__, rec->data_len, (size_t) ssl_out_content_len);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2174,11 +2183,17 @@ int mbedtls_ssl_fetch_input(mbedtls_ssl_context *ssl, size_t nb_want)
 
     if (ssl->f_recv == NULL && ssl->f_recv_timeout == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Bad usage of mbedtls_ssl_set_bio() "));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad usage of mbedtls_ssl_set_bio()", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (nb_want > in_buf_len - (size_t) (ssl->in_hdr - ssl->in_buf)) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("requesting more data than fits"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: requesting more data than fits", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2372,6 +2387,9 @@ int mbedtls_ssl_flush_output(mbedtls_ssl_context *ssl)
 
     if (ssl->f_send == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Bad usage of mbedtls_ssl_set_bio() "));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad usage of mbedtls_ssl_set_bio()", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2869,6 +2887,11 @@ int mbedtls_ssl_write_handshake_msg_ext(mbedtls_ssl_context *ssl,
                                           MBEDTLS_PRINTF_SIZET,
                                           hs_len,
                                           (size_t) (ssl_out_content_len - 12)));
+#ifdef ESP_PLATFORM
+                ESP_LOGE(TAG, "%s: DTLS handshake message too large: " "size %" MBEDTLS_PRINTF_SIZET
+                         ", maximum %" MBEDTLS_PRINTF_SIZET,
+                         __func__, hs_len, (size_t) (ssl_out_content_len - 12));
+#endif
                 return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
             }
 
@@ -5111,6 +5134,9 @@ int mbedtls_ssl_send_alert_message(mbedtls_ssl_context *ssl,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
     if (ssl == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -5688,6 +5714,9 @@ int mbedtls_ssl_read(mbedtls_ssl_context *ssl, unsigned char *buf, size_t len)
     size_t n;
 
     if (ssl == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -5910,6 +5939,11 @@ static int ssl_write_real(mbedtls_ssl_context *ssl,
                                       "maximum fragment length: %" MBEDTLS_PRINTF_SIZET
                                       " > %" MBEDTLS_PRINTF_SIZET,
                                       len, max_len));
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: fragment larger than the (negotiated) "
+                     "maximum fragment length: %" MBEDTLS_PRINTF_SIZET " > %" MBEDTLS_PRINTF_SIZET,
+                     __func__, len, max_len);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         } else
 #endif
@@ -5958,6 +5992,9 @@ int mbedtls_ssl_write(mbedtls_ssl_context *ssl, const unsigned char *buf, size_t
     MBEDTLS_SSL_DEBUG_MSG(2, ("=> write"));
 
     if (ssl == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -5990,6 +6027,9 @@ int mbedtls_ssl_close_notify(mbedtls_ssl_context *ssl)
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
     if (ssl == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 

--- a/components/mbedtls/mbedtls/library/ssl_ticket.c
+++ b/components/mbedtls/mbedtls/library/ssl_ticket.c
@@ -30,6 +30,11 @@
 
 #include <string.h>
 
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char TAG[] = "ssl_ticket";
+#endif
+
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
@@ -234,10 +239,16 @@ int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context *ctx,
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
     if (mbedtls_ssl_cipher_to_psa(cipher, TICKET_AUTH_TAG_BYTES,
                                   &alg, &key_type, &key_bits) != PSA_SUCCESS) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_ssl_cipher_to_psa failed", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (PSA_ALG_IS_AEAD(alg) == 0) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: PSA_ALG_IS_AEAD(alg) == 0", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #else
@@ -246,6 +257,10 @@ int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context *ctx,
     if (mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_GCM &&
         mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_CCM &&
         mbedtls_cipher_info_get_mode(cipher_info) != MBEDTLS_MODE_CHACHAPOLY) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_cipher_info_get_mode(cipher_info) = %u",
+                 __func__, (unsigned)mbedtls_cipher_info_get_mode(cipher_info));
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -253,6 +268,9 @@ int mbedtls_ssl_ticket_setup(mbedtls_ssl_ticket_context *ctx,
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if (key_bits > 8 * MAX_KEY_BYTES) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: key_bits > 8 * MAX_KEY_BYTES: %zu > %u", __func__, key_bits, (unsigned)(8 * MAX_KEY_BYTES));
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -324,6 +342,9 @@ int mbedtls_ssl_ticket_write(void *p_ticket,
     *tlen = 0;
 
     if (ctx == NULL || ctx->f_rng == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ctx == NULL || ctx->f_rng == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -439,10 +460,16 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
 #endif
 
     if (ctx == NULL || ctx->f_rng == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ctx == NULL || ctx->f_rng == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (len < TICKET_MIN_LEN) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: len < TICKET_MIN_LEN: %zu < %u", __func__, len, (unsigned)TICKET_MIN_LEN);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -459,6 +486,10 @@ int mbedtls_ssl_ticket_parse(void *p_ticket,
     enc_len = (enc_len_p[0] << 8) | enc_len_p[1];
 
     if (len != TICKET_MIN_LEN + enc_len) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: len != TICKET_MIN_LEN + enc_len: %zu != %u + %zu",
+                 __func__, len, (unsigned)TICKET_MIN_LEN, enc_len);
+#endif
         ret = MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         goto cleanup;
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -52,7 +52,7 @@
 
 #ifdef ESP_PLATFORM
 #include "esp_log.h"
-static const char *TAG = "ssl_tls";
+static const char TAG[] = "ssl_tls";
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -101,11 +101,17 @@ int mbedtls_ssl_conf_cid(mbedtls_ssl_config *conf,
                          int ignore_other_cid)
 {
     if (len > MBEDTLS_SSL_CID_IN_LEN_MAX) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: len > %u", __func__, MBEDTLS_SSL_CID_IN_LEN_MAX);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (ignore_other_cid != MBEDTLS_SSL_UNEXPECTED_CID_FAIL &&
         ignore_other_cid != MBEDTLS_SSL_UNEXPECTED_CID_IGNORE) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ignore_other_cid = %d", __func__, ignore_other_cid);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -120,6 +126,9 @@ int mbedtls_ssl_set_cid(mbedtls_ssl_context *ssl,
                         size_t own_cid_len)
 {
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: conf->transport != %d", __func__, MBEDTLS_SSL_TRANSPORT_DATAGRAM);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -135,6 +144,10 @@ int mbedtls_ssl_set_cid(mbedtls_ssl_context *ssl,
         MBEDTLS_SSL_DEBUG_MSG(3, ("CID length %u does not match CID length %u in config",
                                   (unsigned) own_cid_len,
                                   (unsigned) ssl->conf->cid_len));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: CID length %u does not match CID length %u in config",
+                 __func__, (unsigned) own_cid_len, (unsigned) ssl->conf->cid_len);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -154,6 +167,9 @@ int mbedtls_ssl_get_own_cid(mbedtls_ssl_context *ssl,
     *enabled = MBEDTLS_SSL_CID_DISABLED;
 
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: conf->transport != %d", __func__, MBEDTLS_SSL_TRANSPORT_DATAGRAM);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -185,6 +201,10 @@ int mbedtls_ssl_get_peer_cid(mbedtls_ssl_context *ssl,
 
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM ||
         mbedtls_ssl_is_handshake_over(ssl) == 0) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: conf->transport != %d or mbedtls_ssl_is_handshake_over == 0",
+                 __func__, MBEDTLS_SSL_TRANSPORT_DATAGRAM);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -1783,6 +1803,9 @@ int mbedtls_ssl_set_session(mbedtls_ssl_context *ssl, const mbedtls_ssl_session 
         session == NULL ||
         ssl->session_negotiate == NULL ||
         ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad input param", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -1801,6 +1824,9 @@ int mbedtls_ssl_set_session(mbedtls_ssl_context *ssl, const mbedtls_ssl_session 
                 MBEDTLS_SSL_VERSION_TLS1_3) != 0) {
             MBEDTLS_SSL_DEBUG_MSG(4, ("%d is not a valid TLS 1.3 ciphersuite.",
                                       session->ciphersuite));
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: %d is not a valid TLS 1.3 ciphersuite", __func__, session->ciphersuite);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
     }
@@ -2059,11 +2085,17 @@ int mbedtls_ssl_set_hs_ecjpake_password(mbedtls_ssl_context *ssl,
     psa_status_t status;
 
     if (ssl->handshake == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl->handshake == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     /* Empty password is not valid  */
     if ((pw == NULL) || (pw_len == 0)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Empty password is not valid", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2094,10 +2126,16 @@ int mbedtls_ssl_set_hs_ecjpake_password_opaque(mbedtls_ssl_context *ssl,
     psa_status_t status;
 
     if (ssl->handshake == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl->handshake == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (mbedtls_svc_key_id_is_null(pwd)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_svc_key_id_is_null", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2117,11 +2155,17 @@ int mbedtls_ssl_set_hs_ecjpake_password(mbedtls_ssl_context *ssl,
     mbedtls_ecjpake_role role;
 
     if (ssl->handshake == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl->handshake == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     /* Empty password is not valid  */
     if ((pw == NULL) || (pw_len == 0)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Empty password is not valid", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2199,6 +2243,9 @@ static int ssl_conf_set_psk_identity(mbedtls_ssl_config *conf,
         psk_identity_len           == 0    ||
         (psk_identity_len >> 16) != 0    ||
         psk_identity_len > mbedtls_ssl_conf_get_out_content_len(conf)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad psk_identity, psk_identity_len=%zu", __func__, psk_identity_len);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2226,12 +2273,21 @@ int mbedtls_ssl_conf_psk(mbedtls_ssl_config *conf,
 
     /* Check and set raw PSK */
     if (psk == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: psk == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     if (psk_len == 0) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: psk_len == 0", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     if (psk_len > MBEDTLS_PSK_MAX_LEN) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: psk_len > %d", __func__, MBEDTLS_PSK_MAX_LEN);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2282,10 +2338,16 @@ int mbedtls_ssl_set_hs_psk(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
     if (psk == NULL || ssl->handshake == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: psk == NULL || ssl->handshake == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (psk_len > MBEDTLS_PSK_MAX_LEN) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: psk_len > %d", __func__, MBEDTLS_PSK_MAX_LEN);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2349,6 +2411,9 @@ int mbedtls_ssl_conf_psk_opaque(mbedtls_ssl_config *conf,
 
     /* Check and set opaque PSK */
     if (mbedtls_svc_key_id_is_null(psk)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_svc_key_id_is_null", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     conf->psk_opaque = psk;
@@ -2368,6 +2433,9 @@ int mbedtls_ssl_set_hs_psk_opaque(mbedtls_ssl_context *ssl,
 {
     if ((mbedtls_svc_key_id_is_null(psk)) ||
         (ssl->handshake == NULL)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_svc_key_id_is_null || ssl->handshake == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -2542,6 +2610,9 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
     *olen = 0;
 
     if (session->resumption_key_len > MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: session->resumption_key_len > %d", __func__, MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     needed += session->resumption_key_len;  /* resumption_key */
@@ -2562,6 +2633,10 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 
         /* Check size_t overflow */
         if (session->ticket_len > SIZE_MAX - needed) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: session->ticket_len %zu > %zu",
+                     __func__, session->ticket_len, (size_t)(SIZE_MAX - needed));
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -2616,6 +2691,10 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 
         if (session->ticket_len > 0) {
             if (session->ticket_len > sizeof(session->ticket.buf)) {
+#ifdef ESP_PLATFORM
+                ESP_LOGE(TAG, "%s: session->ticket_len %zu > sizeof(session->ticket.buf) %zu",
+                         __func__, session->ticket_len, sizeof(session->ticket.buf));
+#endif
                 return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
             }
             memcpy(p, session->ticket.buf, session->ticket_len);
@@ -2635,6 +2714,9 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
     const unsigned char *end = buf + len;
 
     if (end - p < 9) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: end - p < 9", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     session->endpoint = p[0];
@@ -2647,10 +2729,17 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
     p += 9;
 
     if (end - p < session->resumption_key_len) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: end - p < session->resumption_key_len", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     if (sizeof(session->resumption_key) < session->resumption_key_len) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: sizeof(session->resumption_key) < session->resumption_key_len: %zu < %zu",
+                 __func__, sizeof(session->resumption_key), (size_t)session->resumption_key_len);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     memcpy(session->resumption_key, p, session->resumption_key_len);
@@ -2659,6 +2748,9 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
 #if defined(MBEDTLS_HAVE_TIME) && defined(MBEDTLS_SSL_SRV_C)
     if (session->endpoint == MBEDTLS_SSL_IS_SERVER) {
         if (end - p < 8) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 8", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         session->start = MBEDTLS_GET_UINT64_BE(p, 0);
@@ -2672,15 +2764,25 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
         defined(MBEDTLS_SSL_SESSION_TICKETS)
         /* load host name */
         if (end - p < 2) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 2", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         const size_t hostname_len_with_null = MBEDTLS_GET_UINT16_BE(p, 0);
         p += 2;
 
         if (end - p < (long int) hostname_len_with_null) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < hostname_len_with_null %zu", __func__, hostname_len_with_null);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         if (hostname_len_with_null > (MBEDTLS_SSL_MAX_HOST_NAME_LEN+1)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: hostname_len_with_null %zu > %zu",
+                     __func__, hostname_len_with_null, (size_t)(MBEDTLS_SSL_MAX_HOST_NAME_LEN+1));
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         if (hostname_len_with_null > 0) {
@@ -2694,24 +2796,36 @@ static int ssl_tls13_session_load(mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_HAVE_TIME)
         if (end - p < 8) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 8", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         session->ticket_received = MBEDTLS_GET_UINT64_BE(p, 0);
         p += 8;
 #endif
         if (end - p < 4) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 4", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         session->ticket_lifetime = MBEDTLS_GET_UINT32_BE(p, 0);
         p += 4;
 
         if (end - p <  2) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 2", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         session->ticket_len = MBEDTLS_GET_UINT16_BE(p, 0);
         p += 2;
 
         if (end - p < (long int) session->ticket_len) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < ticket_len %zu", __func__, session->ticket_len);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         if (session->ticket_len > 0) {
@@ -3026,6 +3140,10 @@ int mbedtls_ssl_set_hostname(mbedtls_ssl_context *ssl, const char *hostname)
         hostname_len = strlen(hostname);
 
         if (hostname_len > MBEDTLS_SSL_MAX_HOST_NAME_LEN) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: hostname_len > MBEDTLS_SSL_MAX_HOST_NAME_LEN: %zu > %zu",
+                     __func__, hostname_len, (size_t)MBEDTLS_SSL_MAX_HOST_NAME_LEN);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
     }
@@ -3076,6 +3194,9 @@ int mbedtls_ssl_conf_alpn_protocols(mbedtls_ssl_config *conf, const char **proto
         if ((cur_len == 0) ||
             (cur_len > MBEDTLS_SSL_MAX_ALPN_NAME_LEN) ||
             (tot_len > MBEDTLS_SSL_MAX_ALPN_LIST_LEN)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: Bad len: cur_len %zu, tot_len %zu", __func__, cur_len, tot_len);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
     }
@@ -3103,6 +3224,9 @@ int mbedtls_ssl_dtls_srtp_set_mki_value(mbedtls_ssl_context *ssl,
                                         uint16_t mki_len)
 {
     if (mki_len > MBEDTLS_TLS_SRTP_MAX_MKI_LENGTH) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mki_len %u > %u", __func__, (unsigned)mki_len, (unsigned)MBEDTLS_TLS_SRTP_MAX_MKI_LENGTH);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3137,6 +3261,9 @@ int mbedtls_ssl_conf_dtls_srtp_protection_profiles(mbedtls_ssl_config *conf,
     if (list_size > MBEDTLS_TLS_SRTP_MAX_PROFILE_LIST_LENGTH) {
         conf->dtls_srtp_profile_list = NULL;
         conf->dtls_srtp_profile_list_len = 0;
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: list_size %zu > %zu", __func__, list_size, (size_t)MBEDTLS_TLS_SRTP_MAX_PROFILE_LIST_LENGTH);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3200,6 +3327,9 @@ int mbedtls_ssl_conf_max_frag_len(mbedtls_ssl_config *conf, unsigned char mfl_co
 {
     if (mfl_code >= MBEDTLS_SSL_MAX_FRAG_LEN_INVALID ||
         ssl_mfl_code_to_length(mfl_code) > MBEDTLS_TLS_EXT_ADV_CONTENT_LEN) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad mfl_code: %u", __func__, (unsigned)mfl_code);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3537,6 +3667,9 @@ int mbedtls_ssl_get_session(const mbedtls_ssl_context *ssl,
         dst == NULL ||
         ssl->session == NULL ||
         ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad params", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3718,6 +3851,10 @@ static int ssl_session_save(const mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
         case MBEDTLS_SSL_VERSION_TLS1_2:
             if (session->ticket_len > sizeof(session->ticket.buf)) {
+#ifdef ESP_PLATFORM
+                ESP_LOGE(TAG, "%s: session->ticket_len > sizeof(session->ticket.buf): %zu > %zu",
+                         __func__, session->ticket_len, sizeof(session->ticket.buf));
+#endif
                 return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
             }
             used += ssl_tls12_session_save(session, p, remaining_len);
@@ -3784,6 +3921,9 @@ static int ssl_session_load(mbedtls_ssl_session *session,
          */
 
         if ((size_t) (end - p) < sizeof(ssl_serialized_session_header)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: (end - p) < sizeof(ssl_serialized_session_header)", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -3798,6 +3938,9 @@ static int ssl_session_load(mbedtls_ssl_session *session,
      * TLS version identifier
      */
     if (1 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 1 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     session->tls_version = (mbedtls_ssl_protocol_version) (0x0300 | *p++);
@@ -3816,6 +3959,9 @@ static int ssl_session_load(mbedtls_ssl_session *session,
 #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 
         default:
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: Unknown tls_version=%u", __func__, session->tls_version);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 }
@@ -3883,6 +4029,9 @@ int mbedtls_ssl_handshake_step(mbedtls_ssl_context *ssl)
         ssl->conf      == NULL                       ||
         ssl->handshake == NULL                       ||
         ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad params", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3958,6 +4107,11 @@ int mbedtls_ssl_handshake_step(mbedtls_ssl_context *ssl)
     }
 
 cleanup:
+    if (MBEDTLS_ERR_SSL_BAD_INPUT_DATA == ret) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: MBEDTLS_ERR_SSL_BAD_INPUT_DATA", __func__);
+#endif
+    }
     return ret;
 }
 
@@ -3971,6 +4125,9 @@ int mbedtls_ssl_handshake(mbedtls_ssl_context *ssl)
     /* Sanity checks */
 
     if (ssl == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3979,6 +4136,9 @@ int mbedtls_ssl_handshake(mbedtls_ssl_context *ssl)
         (ssl->f_set_timer == NULL || ssl->f_get_timer == NULL)) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("You must use "
                                   "mbedtls_ssl_set_timer_cb() for DTLS"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: You must use mbedtls_ssl_set_timer_cb() for DTLS", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
@@ -4080,6 +4240,9 @@ int mbedtls_ssl_renegotiate(mbedtls_ssl_context *ssl)
     int ret = MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
 
     if (ssl == NULL || ssl->conf == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ssl == NULL || ssl->conf == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4087,6 +4250,9 @@ int mbedtls_ssl_renegotiate(mbedtls_ssl_context *ssl)
     /* On server, just send the request */
     if (ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER) {
         if (mbedtls_ssl_is_handshake_over(ssl) == 0) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: mbedtls_ssl_is_handshake_over(ssl) == 0", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -4108,6 +4274,9 @@ int mbedtls_ssl_renegotiate(mbedtls_ssl_context *ssl)
      */
     if (ssl->renego_status != MBEDTLS_SSL_RENEGOTIATION_IN_PROGRESS) {
         if (mbedtls_ssl_is_handshake_over(ssl) == 0) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: mbedtls_ssl_is_handshake_over(ssl) == 0", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -4419,45 +4588,72 @@ int mbedtls_ssl_context_save(mbedtls_ssl_context *ssl,
     /* The initial handshake must be over */
     if (mbedtls_ssl_is_handshake_over(ssl) == 0) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Initial handshake isn't over"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Initial handshake isn't over", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     if (ssl->handshake != NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Handshake isn't completed"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Handshake isn't completed", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     /* Double-check that sub-structures are indeed ready */
     if (ssl->transform == NULL || ssl->session == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Serialised structures aren't ready"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Serialised structures aren't ready", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     /* There must be no pending incoming or outgoing data */
     if (mbedtls_ssl_check_pending(ssl) != 0) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("There is pending incoming data"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: There is pending incoming data", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     if (ssl->out_left != 0) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("There is pending outgoing data"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: There is pending outgoing data", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     /* Protocol must be DTLS, not TLS */
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Only DTLS is supported"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Only DTLS is supported", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     /* Version must be 1.2 */
     if (ssl->tls_version != MBEDTLS_SSL_VERSION_TLS1_2) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Only version 1.2 supported"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Only version 1.2 supported", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     /* We must be using an AEAD ciphersuite */
     if (mbedtls_ssl_transform_uses_aead(ssl->transform) != 1) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Only AEAD ciphersuites supported"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Only AEAD ciphersuites supported", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     /* Renegotiation must not be enabled */
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
     if (ssl->conf->disable_renegotiation != MBEDTLS_SSL_RENEGOTIATION_DISABLED) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("Renegotiation must not be enabled"));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Renegotiation must not be enabled", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #endif
@@ -4618,6 +4814,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      */
     if (ssl->state != MBEDTLS_SSL_HELLO_REQUEST ||
         ssl->session != NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: Bad context", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4633,6 +4832,10 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
         ssl->conf->max_tls_version < MBEDTLS_SSL_VERSION_TLS1_2 ||
         ssl->conf->min_tls_version > MBEDTLS_SSL_VERSION_TLS1_2
         ) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: transport=%u, max_tls_version=%u, min_tls_version=%u",
+                 __func__, ssl->conf->transport, ssl->conf->max_tls_version, ssl->conf->min_tls_version);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4642,6 +4845,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      * Check version identifier
      */
     if ((size_t) (end - p) < sizeof(ssl_serialized_context_header)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < sizeof(ssl_serialized_context_header)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4655,6 +4861,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      * Session
      */
     if ((size_t) (end - p) < 4) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < 4", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4669,6 +4878,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
     ssl->session_negotiate = NULL;
 
     if ((size_t) (end - p) < session_len) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < session_len", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4696,11 +4908,17 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_PROTO_TLS1_2)
     prf_func = ssl_tls12prf_from_cs(ssl->session->ciphersuite);
     if (prf_func == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: prf_func == NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     /* Read random bytes and populate structure */
     if ((size_t) (end - p) < sizeof(ssl->transform->randbytes)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < sizeof(ssl->transform->randbytes)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4724,12 +4942,18 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
     /* Read connection IDs and store them */
     if ((size_t) (end - p) < 1) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < 1", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
     ssl->transform->in_cid_len = *p++;
 
     if ((size_t) (end - p) < ssl->transform->in_cid_len + 1u) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < ssl->transform->in_cid_len + 1u", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4739,6 +4963,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
     ssl->transform->out_cid_len = *p++;
 
     if ((size_t) (end - p) < ssl->transform->out_cid_len) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < ssl->transform->out_cid_len", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4750,6 +4977,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      * Saved fields from top-level ssl_context structure
      */
     if ((size_t) (end - p) < 4) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < 4", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4758,6 +4988,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
     if ((size_t) (end - p) < 16) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < 16", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4770,6 +5003,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if ((size_t) (end - p) < 1) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < 1", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4777,6 +5013,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 
     if ((size_t) (end - p) < sizeof(ssl->cur_out_ctr)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < sizeof(ssl->cur_out_ctr)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
     memcpy(ssl->cur_out_ctr, p, sizeof(ssl->cur_out_ctr));
@@ -4784,6 +5023,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if ((size_t) (end - p) < 2) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: (end - p) < 2", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -4797,6 +5039,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
         const char **cur;
 
         if ((size_t) (end - p) < 1) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: (end - p) < 1", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -4815,6 +5060,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
 
         /* can only happen on conf mismatch */
         if (alpn_len != 0 && ssl->alpn_chosen == NULL) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: alpn_len != 0 && ssl->alpn_chosen == NULL", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -4853,6 +5101,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
      * Done - should have consumed entire buffer
      */
     if (p != end) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: p != end", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -6822,6 +7073,9 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl, mbedtls_key_excha
 #if defined(MBEDTLS_KEY_EXCHANGE_PSK_ENABLED)
     if (key_ex == MBEDTLS_KEY_EXCHANGE_PSK) {
         if (end - p < 2) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 2", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -6829,6 +7083,9 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl, mbedtls_key_excha
         p += 2;
 
         if (end < p || (size_t) (end - p) < psk_len) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end < p || (size_t) (end - p) < psk_len", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -6843,6 +7100,9 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl, mbedtls_key_excha
          * and is 48 bytes long
          */
         if (end - p < 2) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: end - p < 2", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -6895,6 +7155,9 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl, mbedtls_key_excha
 
     /* opaque psk<0..2^16-1>; */
     if (end - p < 2) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: end - p < 2", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -6902,6 +7165,9 @@ int mbedtls_ssl_psk_derive_premaster(mbedtls_ssl_context *ssl, mbedtls_key_excha
     p += 2;
 
     if (end < p || (size_t) (end - p) < psk_len) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: end < p || (size_t) (end - p) < psk_len", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -8263,6 +8529,9 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     if (ciphersuite_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("ciphersuite info for %d not found",
                                   ciphersuite));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ciphersuite info for %d not found", __func__, ciphersuite);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -8292,6 +8561,9 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     if (cipher_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("cipher info for %u not found",
                                   ciphersuite_info->cipher));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: cipher info for %u not found", __func__, ciphersuite_info->cipher);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -8301,6 +8573,9 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     if (mac_alg == 0) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_md_psa_alg_from_type for %u not found",
                                   (unsigned) ciphersuite_info->mac));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_md_psa_alg_from_type for %u not found", __func__, (unsigned) ciphersuite_info->mac);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #else
@@ -8308,6 +8583,9 @@ static int ssl_tls12_populate_transform(mbedtls_ssl_transform *transform,
     if (md_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("mbedtls_md info for %u not found",
                                   (unsigned) ciphersuite_info->mac));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: mbedtls_md info for %u not found", __func__, (unsigned) ciphersuite_info->mac);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -9088,6 +9366,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
      */
 #if defined(MBEDTLS_HAVE_TIME)
     if (8 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 8 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9101,6 +9382,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
      * Basic mandatory fields
      */
     if (2 + 1 + 32 + 48 + 4 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 2 + 1 + 32 + 48 + 4 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9137,6 +9421,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
 #if defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
     /* Deserialize CRT from the end of the ticket. */
     if (3 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 3 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9147,6 +9434,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
         int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
         if (cert_len > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: cert_len > (size_t) (end - p)", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -9178,6 +9468,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
 #else /* MBEDTLS_SSL_KEEP_PEER_CERTIFICATE */
     /* Deserialize CRT digest from the end of the ticket. */
     if (2 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 2 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9188,13 +9481,22 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
         const mbedtls_md_info_t *md_info =
             mbedtls_md_info_from_type(session->peer_cert_digest_type);
         if (md_info == NULL) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: md_info == NULL", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         if (session->peer_cert_digest_len != mbedtls_md_get_size(md_info)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: session->peer_cert_digest_len != mbedtls_md_get_size(md_info)", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
         if (session->peer_cert_digest_len > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: session->peer_cert_digest_len > (size_t) (end - p)", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
 
@@ -9216,6 +9518,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
      */
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && defined(MBEDTLS_SSL_CLI_C)
     if (3 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 3 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9224,6 +9529,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
 
     if (session->ticket_len != 0) {
         if (session->ticket_len > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: session->ticket_len > (size_t) (end - p)", __func__);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
         if (session->ticket_len <= sizeof(session->ticket.buf)) {
@@ -9245,6 +9553,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
     }
 
     if (4 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 4 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9257,6 +9568,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
      */
 #if defined(MBEDTLS_SSL_MAX_FRAGMENT_LENGTH)
     if (1 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 1 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9265,6 +9579,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
 
 #if defined(MBEDTLS_SSL_ENCRYPT_THEN_MAC)
     if (1 > (size_t) (end - p)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: 1 > (size_t) (end - p)", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9273,6 +9590,9 @@ static int ssl_tls12_session_load(mbedtls_ssl_session *session,
 
     /* Done, should have consumed entire buffer */
     if (p != end) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: p != end", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -9641,6 +9961,9 @@ int mbedtls_ssl_session_set_hostname(mbedtls_ssl_session *session,
         hostname_len = strlen(p_hostname->buf);
 
         if (hostname_len > MBEDTLS_SSL_MAX_HOST_NAME_LEN) {
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: hostname_len %zu > %zu", __func__, hostname_len, (size_t)MBEDTLS_SSL_MAX_HOST_NAME_LEN);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
         }
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -169,7 +169,8 @@ int mbedtls_ssl_get_own_cid(mbedtls_ssl_context *ssl,
 
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: conf->transport != %d", __func__, MBEDTLS_SSL_TRANSPORT_DATAGRAM);
+        ESP_LOGE(TAG, "%s: conf->transport %u != %u",
+                 __func__, (unsigned)ssl->conf->transport, (unsigned)MBEDTLS_SSL_TRANSPORT_DATAGRAM);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -203,8 +204,9 @@ int mbedtls_ssl_get_peer_cid(mbedtls_ssl_context *ssl,
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM ||
         mbedtls_ssl_is_handshake_over(ssl) == 0) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: conf->transport != %d or mbedtls_ssl_is_handshake_over == 0",
-                 __func__, MBEDTLS_SSL_TRANSPORT_DATAGRAM);
+        ESP_LOGE(TAG, "%s: conf->transport %u != %u or mbedtls_ssl_is_handshake_over %d == 0",
+                 __func__, (unsigned)ssl->conf->transport, (unsigned)MBEDTLS_SSL_TRANSPORT_DATAGRAM,
+                 mbedtls_ssl_is_handshake_over(ssl));
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -2287,7 +2289,7 @@ int mbedtls_ssl_conf_psk(mbedtls_ssl_config *conf,
     }
     if (psk_len > MBEDTLS_PSK_MAX_LEN) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: psk_len > %d", __func__, MBEDTLS_PSK_MAX_LEN);
+        ESP_LOGE(TAG, "%s: psk_len %zu > %u", __func__, psk_len, (unsigned)MBEDTLS_PSK_MAX_LEN);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -2347,7 +2349,7 @@ int mbedtls_ssl_set_hs_psk(mbedtls_ssl_context *ssl,
 
     if (psk_len > MBEDTLS_PSK_MAX_LEN) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: psk_len > %d", __func__, MBEDTLS_PSK_MAX_LEN);
+        ESP_LOGE(TAG, "%s: psk_len %zu > %u", __func__, psk_len, (unsigned)MBEDTLS_PSK_MAX_LEN);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -204,7 +204,7 @@ int mbedtls_ssl_get_peer_cid(mbedtls_ssl_context *ssl,
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM ||
         mbedtls_ssl_is_handshake_over(ssl) == 0) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: conf->transport %u != %u or mbedtls_ssl_is_handshake_over %d == 0",
+        ESP_LOGE(TAG, "%s: invalid state: conf->transport=%u (expected %u), handshake_over=%d",
                  __func__, (unsigned)ssl->conf->transport, (unsigned)MBEDTLS_SSL_TRANSPORT_DATAGRAM,
                  mbedtls_ssl_is_handshake_over(ssl));
 #endif
@@ -3983,7 +3983,7 @@ static int ssl_session_load(mbedtls_ssl_session *session,
 
         default:
 #ifdef ESP_PLATFORM
-            ESP_LOGE(TAG, "%s: Unknown tls_version=%u", __func__, session->tls_version);
+            ESP_LOGE(TAG, "%s: Unknown tls_version=%u", __func__, (unsigned)session->tls_version);
 #endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -4852,7 +4852,9 @@ static int ssl_context_load(mbedtls_ssl_context *ssl,
         ) {
 #ifdef ESP_PLATFORM
         ESP_LOGE(TAG, "%s: transport=%u, max_tls_version=%u, min_tls_version=%u",
-                 __func__, ssl->conf->transport, ssl->conf->max_tls_version, ssl->conf->min_tls_version);
+                 __func__, (unsigned)ssl->conf->transport,
+                 (unsigned)ssl->conf->max_tls_version,
+                 (unsigned)ssl->conf->min_tls_version);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -2614,7 +2614,9 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 
     if (session->resumption_key_len > MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: session->resumption_key_len > %d", __func__, MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN);
+        ESP_LOGE(TAG, "%s: session->resumption_key_len %u > %u",
+                 __func__, (unsigned)session->resumption_key_len,
+                 (unsigned)MBEDTLS_SSL_TLS1_3_TICKET_RESUMPTION_KEY_LEN);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -1808,11 +1808,24 @@ int mbedtls_ssl_set_session(mbedtls_ssl_context *ssl, const mbedtls_ssl_session 
         ssl->conf == NULL ||
         ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: Bad input param: ssl=%p, session=%p, ssl->session_negotiate=%p, ssl->conf=%p, ssl->conf->endpoint=%u",
-                 __func__, ssl, session,
-                 (NULL != ssl) ? ssl->session_negotiate : NULL,
-                 (NULL != ssl) ? ssl->conf : NULL,
-                 (unsigned)(((NULL != ssl) && (NULL != ssl->conf)) ? ssl->conf->endpoint : 0));
+        if (session == NULL) {
+            ESP_LOGE(TAG, "%s: session is NULL", __func__);
+        }
+        if (ssl == NULL) {
+            ESP_LOGE(TAG, "%s: ssl is NULL", __func__);
+        } else {
+            if (ssl->session_negotiate == NULL) {
+                ESP_LOGE(TAG, "%s: ssl->session_negotiate is NULL", __func__);
+            }
+            if (ssl->conf == NULL) {
+                ESP_LOGE(TAG, "%s: ssl->conf is NULL", __func__);
+            } else {
+                if (ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
+                    ESP_LOGE(TAG, "%s: ssl->conf->endpoint %u != %u",
+                             __func__, (unsigned)ssl->conf->endpoint, (unsigned)MBEDTLS_SSL_IS_CLIENT);
+                }
+            }
+        }
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -4117,11 +4130,6 @@ int mbedtls_ssl_handshake_step(mbedtls_ssl_context *ssl)
     }
 
 cleanup:
-    if (MBEDTLS_ERR_SSL_BAD_INPUT_DATA == ret) {
-#ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: MBEDTLS_ERR_SSL_BAD_INPUT_DATA", __func__);
-#endif
-    }
     return ret;
 }
 

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -102,7 +102,7 @@ int mbedtls_ssl_conf_cid(mbedtls_ssl_config *conf,
 {
     if (len > MBEDTLS_SSL_CID_IN_LEN_MAX) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: len > %u", __func__, MBEDTLS_SSL_CID_IN_LEN_MAX);
+        ESP_LOGE(TAG, "%s: len %zu > %u", __func__, len, (unsigned)MBEDTLS_SSL_CID_IN_LEN_MAX);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -127,7 +127,8 @@ int mbedtls_ssl_set_cid(mbedtls_ssl_context *ssl,
 {
     if (ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: conf->transport != %d", __func__, MBEDTLS_SSL_TRANSPORT_DATAGRAM);
+        ESP_LOGE(TAG, "%s: conf->transport %u != %u",
+                 __func__, (unsigned)ssl->conf->transport, (unsigned)MBEDTLS_SSL_TRANSPORT_DATAGRAM);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls.c
@@ -1805,9 +1805,14 @@ int mbedtls_ssl_set_session(mbedtls_ssl_context *ssl, const mbedtls_ssl_session 
     if (ssl == NULL ||
         session == NULL ||
         ssl->session_negotiate == NULL ||
+        ssl->conf == NULL ||
         ssl->conf->endpoint != MBEDTLS_SSL_IS_CLIENT) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: Bad input param", __func__);
+        ESP_LOGE(TAG, "%s: Bad input param: ssl=%p, session=%p, ssl->session_negotiate=%p, ssl->conf=%p, ssl->conf->endpoint=%u",
+                 __func__, ssl, session,
+                 (NULL != ssl) ? ssl->session_negotiate : NULL,
+                 (NULL != ssl) ? ssl->conf : NULL,
+                 (unsigned)(((NULL != ssl) && (NULL != ssl->conf)) ? ssl->conf->endpoint : 0));
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/components/mbedtls/mbedtls/library/ssl_tls12_client.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls12_client.c
@@ -379,6 +379,10 @@ static int ssl_write_session_ticket_ext(mbedtls_ssl_context *ssl,
     unsigned char *p = buf;
     size_t tlen = ssl->session_negotiate->ticket_len;
     if (tlen > sizeof(ssl->session_negotiate->ticket.buf)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ticket length %zu bytes > buf size %zu bytes",
+                 __func__, tlen, sizeof(ssl->session_negotiate->ticket.buf));
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -1372,6 +1376,9 @@ static int ssl_parse_server_hello(mbedtls_ssl_context *ssl)
                               ("ciphersuite info for %04x not found", (unsigned int) i));
         mbedtls_ssl_send_alert_message(ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                        MBEDTLS_SSL_ALERT_MSG_INTERNAL_ERROR);
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ciphersuite info for %04x not found", __func__, (unsigned int) i);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -3628,6 +3635,9 @@ int mbedtls_ssl_handshake_client_step(mbedtls_ssl_context *ssl)
 
         default:
             MBEDTLS_SSL_DEBUG_MSG(1, ("invalid state %d", ssl->state));
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: invalid state %d", __func__, ssl->state);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 

--- a/components/mbedtls/mbedtls/library/ssl_tls13_client.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls13_client.c
@@ -153,6 +153,9 @@ static int ssl_tls13_parse_alpn_ext(mbedtls_ssl_context *ssl,
 
     /* If we didn't send it, the server shouldn't send it */
     if (ssl->conf->alpn_list == NULL) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: alpn_list is NULL", __func__);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -186,6 +189,10 @@ static int ssl_tls13_parse_alpn_ext(mbedtls_ssl_context *ssl,
         }
     }
 
+#ifdef ESP_PLATFORM
+    ESP_LOGE(TAG, "%s: The server chosen protocol '%.*s' is not in our list",
+             __func__, (int)protocol_name_len, (const char*)p);
+#endif
     return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
 }
 #endif /* MBEDTLS_SSL_ALPN */
@@ -3076,6 +3083,9 @@ int mbedtls_ssl_tls13_handshake_client_step(mbedtls_ssl_context *ssl)
 
         default:
             MBEDTLS_SSL_DEBUG_MSG(1, ("invalid state %d", ssl->state));
+#ifdef ESP_PLATFORM
+            ESP_LOGE(TAG, "%s: invalid state %d", __func__, ssl->state);
+#endif
             return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 

--- a/components/mbedtls/mbedtls/library/ssl_tls13_keys.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls13_keys.c
@@ -36,6 +36,11 @@
 #include "psa/crypto.h"
 #include "md_psa.h"
 
+#ifdef ESP_PLATFORM
+#include "esp_log.h"
+static const char TAG[] = "ssl_tls13_keys";
+#endif
+
 /* Define a local translating function to save code size by not using too many
  * arguments in each translating place. */
 static int local_err_translation(psa_status_t status)
@@ -181,6 +186,9 @@ int mbedtls_ssl_tls13_hkdf_expand_label(
     }
 
     if (!PSA_ALG_IS_HASH(hash_alg)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: The alg 0x%x is not hash alg", __func__, hash_alg);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -362,6 +370,9 @@ int mbedtls_ssl_tls13_evolve_secret(
         PSA_KEY_DERIVATION_OPERATION_INIT;
 
     if (!PSA_ALG_IS_HASH(hash_alg)) {
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: The alg 0x%x is not hash alg", __func__, hash_alg);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -966,6 +977,9 @@ int mbedtls_ssl_tls13_populate_transform(
     if (ciphersuite_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("ciphersuite info for %d not found",
                                   ciphersuite));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: ciphersuite info for %d not found", __func__, ciphersuite);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
@@ -974,6 +988,9 @@ int mbedtls_ssl_tls13_populate_transform(
     if (cipher_info == NULL) {
         MBEDTLS_SSL_DEBUG_MSG(1, ("cipher info for %u not found",
                                   ciphersuite_info->cipher));
+#ifdef ESP_PLATFORM
+        ESP_LOGE(TAG, "%s: cipher info for %u not found", __func__, ciphersuite_info->cipher);
+#endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 

--- a/components/mbedtls/mbedtls/library/ssl_tls13_keys.c
+++ b/components/mbedtls/mbedtls/library/ssl_tls13_keys.c
@@ -187,7 +187,7 @@ int mbedtls_ssl_tls13_hkdf_expand_label(
 
     if (!PSA_ALG_IS_HASH(hash_alg)) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: The alg 0x%x is not hash alg", __func__, hash_alg);
+        ESP_LOGE(TAG, "%s: The algorithm 0x%x is not a hash algorithm", __func__, hash_alg);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
@@ -371,7 +371,7 @@ int mbedtls_ssl_tls13_evolve_secret(
 
     if (!PSA_ALG_IS_HASH(hash_alg)) {
 #ifdef ESP_PLATFORM
-        ESP_LOGE(TAG, "%s: The alg 0x%x is not hash alg", __func__, hash_alg);
+        ESP_LOGE(TAG, "%s: The algorithm 0x%x is not a hash algorithm", __func__, hash_alg);
 #endif
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }

--- a/components/mqtt/esp-mqtt/mqtt_client.c
+++ b/components/mqtt/esp-mqtt/mqtt_client.c
@@ -236,10 +236,12 @@ static esp_err_t esp_mqtt_set_ssl_transport_properties(esp_transport_list_handle
 {
     esp_transport_handle_t ssl = esp_transport_list_get_transport(transport_list, "mqtts");
 
-    MQTT_LOGI("%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
+    MQTT_LOGI("%s: esp_transport_ssl_set_buffer: ssl_in_buf %zu bytes (content %zu bytes), ssl_out_buf %zu bytes (content %zu bytes)",
              __func__,
-             cfg->ssl_buf_cfg.p_ssl_in_buf, cfg->ssl_buf_cfg.ssl_in_buf_len, cfg->ssl_buf_cfg.ssl_in_content_len,
-             cfg->ssl_buf_cfg.p_ssl_out_buf, cfg->ssl_buf_cfg.ssl_out_buf_len, cfg->ssl_buf_cfg.ssl_out_content_len);
+             cfg->ssl_buf_cfg.ssl_in_buf_len, cfg->ssl_buf_cfg.ssl_in_content_len,
+             cfg->ssl_buf_cfg.ssl_out_buf_len, cfg->ssl_buf_cfg.ssl_out_content_len);
+    MQTT_LOGD("%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p, ssl_out_buf=%p",
+             __func__, cfg->ssl_buf_cfg.p_ssl_in_buf, cfg->ssl_buf_cfg.p_ssl_out_buf);
     if (!esp_transport_ssl_set_buffer(ssl, &cfg->ssl_buf_cfg)) {
         MQTT_LOGE("%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
                  __func__,

--- a/components/mqtt/esp-mqtt/mqtt_client.c
+++ b/components/mqtt/esp-mqtt/mqtt_client.c
@@ -236,7 +236,7 @@ static esp_err_t esp_mqtt_set_ssl_transport_properties(esp_transport_list_handle
 {
     esp_transport_handle_t ssl = esp_transport_list_get_transport(transport_list, "mqtts");
 
-    MQTT_LOGD("%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
+    MQTT_LOGI("%s: esp_transport_ssl_set_buffer: ssl_in_buf=%p %zu bytes (content %zu bytes), ssl_out_buf=%p %zu bytes (content %zu bytes)",
              __func__,
              cfg->ssl_buf_cfg.p_ssl_in_buf, cfg->ssl_buf_cfg.ssl_in_buf_len, cfg->ssl_buf_cfg.ssl_in_content_len,
              cfg->ssl_buf_cfg.p_ssl_out_buf, cfg->ssl_buf_cfg.ssl_out_buf_len, cfg->ssl_buf_cfg.ssl_out_content_len);

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -1080,7 +1080,7 @@ bool esp_transport_ssl_set_buffer(esp_transport_handle_t t, const esp_transport_
         ESP_TRANSPORT_LOGE_FUNC("Pointer to buffer configuration is NULL");
         return false;
     }
-    ESP_TRANSPORT_LOGD("[%s] Configure TLS I/O buffers: in_buf=%p %zu bytes (content len %zu), out_buf=%p %zu bytes (content len %zu)",
+    ESP_TRANSPORT_LOGI("[%s] Configure TLS I/O buffers: in_buf=%p %zu bytes (content len %zu), out_buf=%p %zu bytes (content len %zu)",
                        esp_tls_get_hostname(ssl->tls),
                        p_buf_cfg->p_ssl_in_buf,
                        p_buf_cfg->ssl_in_buf_len,

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -1080,14 +1080,14 @@ bool esp_transport_ssl_set_buffer(esp_transport_handle_t t, const esp_transport_
         ESP_TRANSPORT_LOGE_FUNC("Pointer to buffer configuration is NULL");
         return false;
     }
-    ESP_TRANSPORT_LOGI("[%s] Configure TLS I/O buffers: in_buf=%p %zu bytes (content len %zu), out_buf=%p %zu bytes (content len %zu)",
+    ESP_TRANSPORT_LOGI("[%s] Configure TLS I/O buffers: in_buf %zu bytes (content len %zu), out_buf %zu bytes (content len %zu)",
                        esp_tls_get_hostname(ssl->tls),
-                       p_buf_cfg->p_ssl_in_buf,
                        p_buf_cfg->ssl_in_buf_len,
                        p_buf_cfg->ssl_in_content_len,
-                       p_buf_cfg->p_ssl_out_buf,
                        p_buf_cfg->ssl_out_buf_len,
                        p_buf_cfg->ssl_out_content_len);
+    ESP_TRANSPORT_LOGD("[%s] Configure TLS I/O buffers: in_buf=%p, out_buf=%p",
+                       esp_tls_get_hostname(ssl->tls), p_buf_cfg->p_ssl_in_buf, p_buf_cfg->p_ssl_out_buf);
     if ((NULL == p_buf_cfg->p_ssl_in_buf) && (NULL == p_buf_cfg->p_ssl_out_buf) && (0 == p_buf_cfg->ssl_in_buf_len)
             && (0 == p_buf_cfg->ssl_out_buf_len) && (0 == p_buf_cfg->ssl_in_content_len)
             && (0 == p_buf_cfg->ssl_out_content_len)) {


### PR DESCRIPTION
Add ESP_LOGE logging to all MBEDTLS_ERR_SSL_BAD_INPUT_DATA error return paths across mbedTLS SSL library files, guarded by #ifdef ESP_PLATFORM. This makes it possible to diagnose TLS failures on ESP32 without enabling verbose mbedTLS debug output, which is too heavy for production firmware.

Affected mbedTLS files:
- ssl_cache.c, ssl_client.c, ssl_cookie.c, ssl_msg.c, ssl_ticket.c, ssl_tls.c, ssl_tls12_client.c, ssl_tls13_client.c, ssl_tls13_keys.c

Each error log includes the function name (__func__) and, where relevant, the values that caused the validation failure (buffer sizes, lengths, cipher IDs, etc.).

Additionally, promote TLS I/O buffer configuration log messages from DEBUG to INFO level in esp_http_client, mqtt_client, and transport_ssl so that buffer allocation details are visible in normal operation logs.