### PR TITLE
Fix #1278: Gateway enters reboot loop if otadata partition contains invalid data

### DIFF
--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -319,3 +319,96 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
     os_free(p_it);
     return ret;
 }
+
+static uint8_t
+get_ota_partition_count(void)
+{
+    uint16_t ota_app_count = 0;
+    while (esp_partition_find_first(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_APP_OTA_MIN + ota_app_count, NULL)
+           != NULL)
+    {
+        assert(ota_app_count < 16 && "must erase the partition before writing to it");
+        ota_app_count++;
+    }
+    return ota_app_count;
+}
+
+// Read otadata partition and fill array from two otadata structures.
+// Also return pointer to otadata info partition.
+static const esp_partition_t*
+read_otadata(esp_ota_select_entry_t* two_otadata)
+{
+    const esp_partition_t* otadata_partition = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA,
+        ESP_PARTITION_SUBTYPE_DATA_OTA,
+        NULL);
+
+    if (otadata_partition == NULL)
+    {
+        ESP_LOGE(TAG, "not found otadata");
+        return NULL;
+    }
+
+    spi_flash_mmap_handle_t ota_data_map;
+    const void*             result = NULL;
+    esp_err_t               err    = esp_partition_mmap(
+        otadata_partition,
+        0,
+        otadata_partition->size,
+        SPI_FLASH_MMAP_DATA,
+        &result,
+        &ota_data_map);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "mmap otadata filed. Err=0x%8x", err);
+        return NULL;
+    }
+    else
+    {
+        memcpy(&two_otadata[0], result, sizeof(esp_ota_select_entry_t));
+        memcpy(&two_otadata[1], result + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+        spi_flash_munmap(ota_data_map);
+    }
+    return otadata_partition;
+}
+
+esp_err_t
+esp_ota_get_state_partition_patched(const esp_partition_t* partition, esp_ota_img_states_t* ota_state)
+{
+    if (partition == NULL || ota_state == NULL)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!esp_ota_is_ota_partition(partition))
+    {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    esp_ota_select_entry_t otadata[2];
+    int                    ota_app_count = get_ota_partition_count();
+    if (read_otadata(otadata) == NULL || ota_app_count == 0)
+    {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    int  req_ota_slot = partition->subtype - ESP_PARTITION_SUBTYPE_APP_OTA_MIN;
+    bool not_found    = true;
+    for (int i = 0; i < 2; ++i)
+    {
+        int ota_slot = (otadata[i].ota_seq - 1) % ota_app_count;
+        if (ota_slot == req_ota_slot && otadata[i].crc == bootloader_common_ota_select_crc(&otadata[i]))
+        {
+            *ota_state = otadata[i].ota_state;
+            not_found  = false;
+            break;
+        }
+    }
+
+    if (not_found)
+    {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    return ESP_OK;
+}

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -16,6 +16,7 @@
 #include "esp_ota_ops.h"
 #include <stdint.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -38,10 +39,12 @@
 #include "sys/param.h"
 
 #define LOG_LOCAL_LEVEL 3
-#include "esp_log.h"
+#include "log.h"
 
 #define ESP_OTA_FLASH_ENCRYPTION_MIN_CHUNK_SIZE (16U)
 #define ESP_OTA_FLASH_ENCRYPTION_FILL           (0xFFU)
+
+#define ESP_OTA_NUM_OTA_SLOTS (2U)
 
 typedef struct ota_ops_entry_t
 {
@@ -106,7 +109,7 @@ esp_ota_begin_patched(
     if ((ESP_OK == esp_ota_get_state_partition(p_running_partition, &ota_state_running_part))
         && (ESP_OTA_IMG_PENDING_VERIFY == ota_state_running_part))
     {
-        ESP_LOGE(TAG, "Running app has not confirmed state (ESP_OTA_IMG_PENDING_VERIFY)");
+        LOG_ERR("Running app has not confirmed state (ESP_OTA_IMG_PENDING_VERIFY)");
         return ESP_ERR_OTA_ROLLBACK_INVALID_STATE;
     }
 #endif
@@ -151,7 +154,7 @@ esp_ota_write_entry(ota_ops_entry_t* const p_it, const void* const p_data, const
     if ((0 == p_it->wrote_size) && (0 == p_it->partial_bytes) && (cnt_remaining_bytes > 0)
         && (ESP_IMAGE_HEADER_MAGIC != p_data_bytes[0]))
     {
-        ESP_LOGE(TAG, "OTA image has invalid magic byte (expected 0xE9, saw 0x%02x)", p_data_bytes[0]);
+        LOG_ERR("OTA image has invalid magic byte (expected 0xE9, saw 0x%02x)", p_data_bytes[0]);
         return ESP_ERR_OTA_VALIDATE_FAILED;
     }
 
@@ -210,7 +213,7 @@ esp_ota_write_patched(const esp_ota_handle_t handle, const void* const p_data, c
 {
     if (NULL == p_data)
     {
-        ESP_LOGE(TAG, "write p_data is invalid");
+        LOG_ERR("write p_data is invalid");
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -224,7 +227,7 @@ esp_ota_write_patched(const esp_ota_handle_t handle, const void* const p_data, c
     }
 
     // if go to here ,means don't find the handle
-    ESP_LOGE(TAG, "not found the handle");
+    LOG_ERR("not found the handle");
     return ESP_ERR_INVALID_ARG;
 }
 
@@ -291,8 +294,7 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
             {
                 if (esp_image_verify(ESP_IMAGE_VERIFY, &part_pos, p_metadata) != ESP_OK)
                 {
-                    ESP_LOGE(
-                        TAG,
+                    LOG_ERR(
                         "Image verify failed for partition at address 0x%08x, size 0x%08x",
                         part_pos.offset,
                         part_pos.size);
@@ -302,8 +304,7 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
                 {
                     if (!esp_ota_helper_calc_pub_key_digest_for_app_image(p_metadata, p_pub_key_digest))
                     {
-                        ESP_LOGE(
-                            TAG,
+                        LOG_ERR(
                             "Public key digest calculation failed for partition at address 0x%08x, size 0x%08x",
                             part_pos.offset,
                             part_pos.size);
@@ -323,92 +324,148 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
 static uint8_t
 get_ota_partition_count(void)
 {
-    uint16_t ota_app_count = 0;
+    uint8_t ota_app_count = 0;
     while (esp_partition_find_first(ESP_PARTITION_TYPE_APP, ESP_PARTITION_SUBTYPE_APP_OTA_MIN + ota_app_count, NULL)
            != NULL)
     {
-        assert(ota_app_count < 16 && "must erase the partition before writing to it");
+        const uint32_t max_ota_app_count = ESP_PARTITION_SUBTYPE_APP_OTA_MAX - ESP_PARTITION_SUBTYPE_APP_OTA_MIN;
+        assert(ota_app_count < max_ota_app_count && "must erase the partition before writing to it");
         ota_app_count++;
     }
     return ota_app_count;
 }
 
-// Read otadata partition and fill array from two otadata structures.
-// Also return pointer to otadata info partition.
 static const esp_partition_t*
-read_otadata(esp_ota_select_entry_t* two_otadata)
+read_two_ota_data(esp_ota_select_entry_t* const p_two_ota_data)
 {
-    const esp_partition_t* otadata_partition = esp_partition_find_first(
+    const esp_partition_t* const p_ota_data_partition = esp_partition_find_first(
         ESP_PARTITION_TYPE_DATA,
         ESP_PARTITION_SUBTYPE_DATA_OTA,
         NULL);
 
-    if (otadata_partition == NULL)
+    if (p_ota_data_partition == NULL)
     {
-        ESP_LOGE(TAG, "not found otadata");
+        LOG_ERR("Partition with OTA data not found");
         return NULL;
     }
 
-    spi_flash_mmap_handle_t ota_data_map;
-    const void*             result = NULL;
-    esp_err_t               err    = esp_partition_mmap(
-        otadata_partition,
+    spi_flash_mmap_handle_t ota_data_map = 0;
+    const void*             p_result     = NULL;
+
+    const esp_err_t err = esp_partition_mmap(
+        p_ota_data_partition,
         0,
-        otadata_partition->size,
+        p_ota_data_partition->size,
         SPI_FLASH_MMAP_DATA,
-        &result,
+        &p_result,
         &ota_data_map);
-    if (err != ESP_OK)
+    if (ESP_OK != err)
     {
-        ESP_LOGE(TAG, "mmap otadata filed. Err=0x%8x", err);
+        LOG_ERR("mmap OTA-data failed. Err=%" PRId32, err);
         return NULL;
     }
-    else
+    if (NULL == p_result)
     {
-        memcpy(&two_otadata[0], result, sizeof(esp_ota_select_entry_t));
-        memcpy(&two_otadata[1], result + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+        LOG_ERR("mmap OTA-data returned NULL pointer");
         spi_flash_munmap(ota_data_map);
+        return NULL;
     }
-    return otadata_partition;
+    memcpy(&p_two_ota_data[0], p_result, sizeof(esp_ota_select_entry_t));
+    memcpy(&p_two_ota_data[1], (const uint8_t*)p_result + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+
+    spi_flash_munmap(ota_data_map);
+    return p_ota_data_partition;
+}
+
+static int32_t
+esp_ota_calc_slot_from_seq(const uint32_t ota_seq, const uint8_t ota_app_count)
+{
+    if (0U == ota_app_count)
+    {
+        return -1;
+    }
+    if ((UINT32_MAX == ota_seq) || (0 == ota_seq))
+    {
+        return -1;
+    }
+    return (int32_t)((ota_seq - 1U) % (uint32_t)ota_app_count);
 }
 
 esp_err_t
-esp_ota_get_state_partition_patched(const esp_partition_t* partition, esp_ota_img_states_t* ota_state)
+esp_ota_get_state_partition_patched(const esp_partition_t* const p_partition, esp_ota_img_states_t* const p_ota_state)
 {
-    if (partition == NULL || ota_state == NULL)
+    if ((NULL == p_partition) || (NULL == p_ota_state))
     {
         return ESP_ERR_INVALID_ARG;
     }
 
-    if (!esp_ota_is_ota_partition(partition))
+    if (!esp_ota_is_ota_partition(p_partition))
     {
         return ESP_ERR_NOT_SUPPORTED;
     }
 
-    esp_ota_select_entry_t otadata[2];
-    int                    ota_app_count = get_ota_partition_count();
-    if (read_otadata(otadata) == NULL || ota_app_count == 0)
+    const uint8_t ota_app_count = get_ota_partition_count();
+    if (0 == ota_app_count)
     {
+        LOG_ERR("There is no OTA app partition");
+        return ESP_ERR_NOT_FOUND;
+    }
+    LOG_INFO("### Found %" PRIu8 " OTA app partitions", ota_app_count);
+
+    esp_ota_select_entry_t ota_data[ESP_OTA_NUM_OTA_SLOTS];
+    if (NULL == read_two_ota_data(ota_data))
+    {
+        LOG_ERR("Failed to read OTA data");
         return ESP_ERR_NOT_FOUND;
     }
 
-    int  req_ota_slot = partition->subtype - ESP_PARTITION_SUBTYPE_APP_OTA_MIN;
-    bool not_found    = true;
-    for (int i = 0; i < 2; ++i)
+    LOG_DUMP_INFO(
+        (const uint8_t*)&ota_data[0],
+        sizeof(esp_ota_select_entry_t),
+        "### otadata[0]: ota_slot %" PRIi32,
+        esp_ota_calc_slot_from_seq(ota_data[0].ota_seq, ota_app_count));
+    LOG_DUMP_INFO(
+        (const uint8_t*)&ota_data[1],
+        sizeof(esp_ota_select_entry_t),
+        "### otadata[1]: ota_slot %" PRIi32,
+        esp_ota_calc_slot_from_seq(ota_data[1].ota_seq, ota_app_count));
+
+    const int32_t req_ota_slot = (int32_t)(p_partition->subtype - ESP_PARTITION_SUBTYPE_APP_OTA_MIN);
+    LOG_INFO("### Requested OTA slot %" PRIi32, req_ota_slot);
+    bool is_slot_found = false;
+    for (uint32_t i = 0; i < ESP_OTA_NUM_OTA_SLOTS; ++i)
     {
-        int ota_slot = (otadata[i].ota_seq - 1) % ota_app_count;
-        if (ota_slot == req_ota_slot && otadata[i].crc == bootloader_common_ota_select_crc(&otadata[i]))
+        const int32_t ota_slot = esp_ota_calc_slot_from_seq(ota_data[i].ota_seq, ota_app_count);
+        if (ota_slot == req_ota_slot)
         {
-            *ota_state = otadata[i].ota_state;
-            not_found  = false;
-            break;
+            // Write ota_state before checking CRC,
+            // so that the caller will be able to log the OTA state even if CRC check fails.
+            *p_ota_state = ota_data[i].ota_state;
+
+            is_slot_found = true;
+
+            const uint32_t actual_crc = bootloader_common_ota_select_crc(&ota_data[i]);
+            if (ota_data[i].crc != actual_crc)
+            {
+                LOG_ERR(
+                    "[idx=%" PRIu32 "] CRC mismatch for OTA slot %" PRIi32 ": ota_seq=0x%08" PRIx32
+                    ", ota_state=0x%08" PRIx32 ", crc=0x%08" PRIx32 ", actual crc=0x%08" PRIx32,
+                    i,
+                    req_ota_slot,
+                    ota_data[i].ota_seq,
+                    ota_data[i].ota_state,
+                    ota_data[i].crc,
+                    actual_crc);
+                continue;
+            }
+            return ESP_OK;
         }
     }
-
-    if (not_found)
+    if (is_slot_found)
     {
-        return ESP_ERR_NOT_FOUND;
+        LOG_ERR("There is no OTA slot %" PRIi32 " with valid CRC", req_ota_slot);
+        return ESP_ERR_INVALID_CRC;
     }
-
-    return ESP_OK;
+    LOG_ERR("OTA slot %" PRIi32 " not found", req_ota_slot);
+    return ESP_ERR_NOT_FOUND;
 }

--- a/main/esp_ota_ops_patched.h
+++ b/main/esp_ota_ops_patched.h
@@ -37,8 +37,61 @@ esp_ota_write_patched(const esp_ota_handle_t handle, const void* const p_data, c
 esp_err_t
 esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* const p_pub_key_digest);
 
+/**
+ * @brief Read the OTA state (e.g. NEW, PENDING_VERIFY, VALID, INVALID, ABORTED)
+ *        recorded in the @c otadata partition for a given OTA app partition.
+ *
+ * This is a patched version of @c esp_ota_get_state_partition() from ESP-IDF.
+ * Compared to the upstream implementation it:
+ *  - distinguishes "slot has no @c otadata entry" from "slot has an entry but
+ *    its CRC is invalid";
+ *  - if both @c otadata sectors map to the requested slot, prefers the entry
+ *    with a valid CRC over the one with a broken CRC;
+ *  - emits diagnostic logs (number of OTA app partitions, decoded slot for
+ *    each @c otadata entry, requested slot, mismatching CRC values) to make
+ *    field debugging of OTA state issues easier.
+ *
+ * The function performs the following steps:
+ *  1. Validates the input arguments and verifies that @p p_partition refers
+ *     to an OTA application partition
+ *     (@c ESP_PARTITION_SUBTYPE_APP_OTA_0 .. @c ESP_PARTITION_SUBTYPE_APP_OTA_MAX-1).
+ *  2. Counts the number of OTA app partitions defined in the partition table.
+ *  3. Memory-maps the @c otadata partition and copies its two
+ *     @c esp_ota_select_entry_t records into a local buffer.
+ *  4. For each of the two records, computes the OTA slot it refers to as
+ *     <tt>(ota_seq - 1) % ota_app_count</tt>. Records with @c ota_seq equal
+ *     to 0 or @c UINT32_MAX (uninitialised flash) are treated as "no slot".
+ *  5. If a record maps to the requested slot, writes its @c ota_state to
+ *     @p p_ota_state (so that the caller can log it even on CRC errors) and
+ *     validates the CRC stored in the record against the value recomputed
+ *     by @c bootloader_common_ota_select_crc(). On CRC mismatch the loop
+ *     continues so that a second, valid entry mapping to the same slot can
+ *     still be returned successfully.
+ *
+ * @param[in]  p_partition  Pointer to the OTA app partition whose state is
+ *                          being queried. Must not be NULL.
+ * @param[out] p_ota_state  Pointer that receives the OTA state on success.
+ *                          Must not be NULL. On @c ESP_ERR_INVALID_CRC the
+ *                          value of the (corrupt) @c otadata entry is still
+ *                          written, so the caller can log it. On any other
+ *                          error the contents are unspecified.
+ *
+ * @return
+ *   - @c ESP_OK                  The OTA state was read successfully and is
+ *                                stored in @p *p_ota_state.
+ *   - @c ESP_ERR_INVALID_ARG     @p p_partition or @p p_ota_state is NULL.
+ *   - @c ESP_ERR_NOT_SUPPORTED   @p p_partition is not an OTA app partition.
+ *   - @c ESP_ERR_NOT_FOUND       No OTA app partitions are defined, the
+ *                                @c otadata partition could not be read, or
+ *                                no @c otadata entry maps to the requested
+ *                                slot.
+ *   - @c ESP_ERR_INVALID_CRC     An @c otadata entry maps to the requested
+ *                                slot but its CRC is invalid (and there is
+ *                                no other entry for the same slot with a
+ *                                valid CRC).
+ */
 esp_err_t
-esp_ota_get_state_partition_patched(const esp_partition_t* partition, esp_ota_img_states_t* ota_state);
+esp_ota_get_state_partition_patched(const esp_partition_t* const p_partition, esp_ota_img_states_t* const p_ota_state);
 
 #ifdef __cplusplus
 }

--- a/main/esp_ota_ops_patched.h
+++ b/main/esp_ota_ops_patched.h
@@ -37,6 +37,9 @@ esp_ota_write_patched(const esp_ota_handle_t handle, const void* const p_data, c
 esp_err_t
 esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* const p_pub_key_digest);
 
+esp_err_t
+esp_ota_get_state_partition_patched(const esp_partition_t* partition, esp_ota_img_states_t* ota_state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -199,16 +199,16 @@ fw_update_log_running_partition_state(const esp_ota_img_states_t running_partiti
             LOG_INFO("Currently running partition state: %s", "VALID");
             break;
         case ESP_OTA_IMG_INVALID:
-            LOG_INFO("Currently running partition state: %s", "INVALID");
+            LOG_WARN("Currently running partition state: %s", "INVALID");
             break;
         case ESP_OTA_IMG_ABORTED:
-            LOG_INFO("Currently running partition state: %s", "ABORTED");
+            LOG_WARN("Currently running partition state: %s", "ABORTED");
             break;
         case ESP_OTA_IMG_UNDEFINED:
-            LOG_INFO("Currently running partition state: %s", "UNDEFINED");
+            LOG_WARN("Currently running partition state: %s", "UNDEFINED");
             break;
         default:
-            LOG_INFO("Currently running partition state: UNKNOWN (%d)", (printf_int_t)running_partition_state);
+            LOG_WARN("Currently running partition state: UNKNOWN (%d)", (printf_int_t)running_partition_state);
             break;
     }
 }
@@ -443,91 +443,112 @@ fw_update_self_check_signature(ruuvi_flash_info_t* const p_flash_info)
     return true;
 }
 
-static bool
+static void
 fw_update_set_next_ota_partition(ruuvi_flash_info_t* const p_flash_info)
 {
+    // Precondition: p_flash_info->p_running_partition != NULL
     p_flash_info->p_next_update_partition = esp_ota_get_next_update_partition(p_flash_info->p_running_partition);
     if (NULL == p_flash_info->p_next_update_partition)
     {
         LOG_ERR("Can't find next partition for updating");
-        return false;
     }
-    LOG_INFO(
-        "Next update partition: %s: address 0x%08x, size 0x%x",
-        p_flash_info->p_next_update_partition->label,
-        p_flash_info->p_next_update_partition->address,
-        p_flash_info->p_next_update_partition->size);
+    else
+    {
+        LOG_INFO(
+            "Next update partition: %s: address 0x%08x, size 0x%x",
+            p_flash_info->p_next_update_partition->label,
+            p_flash_info->p_next_update_partition->address,
+            p_flash_info->p_next_update_partition->size);
+    }
     p_flash_info->is_ota0_active = (0 == strcmp("ota_0", p_flash_info->p_running_partition->label)) ? true : false;
-    return true;
 }
 
-static bool
+static void
 fw_update_set_next_gwui_partition(ruuvi_flash_info_t* const p_flash_info)
 {
     const esp_partition_t* const p_gw_gwui = find_data_fat_partition_by_name(GW_GWUI_PARTITION);
     if (NULL == p_gw_gwui)
     {
         LOG_ERR("Can't find first partition for gwui filesystem: %s", GW_GWUI_PARTITION);
-        return false;
     }
     const esp_partition_t* const p_gw_gwui2 = find_data_fat_partition_by_name(GW_GWUI_PARTITION_2);
     if (NULL == p_gw_gwui2)
     {
         LOG_ERR("Can't find second partition for gwui filesystem: %s", GW_GWUI_PARTITION_2);
-        return false;
     }
     p_flash_info->p_cur_fatfs_gwui_partition  = p_flash_info->is_ota0_active ? p_gw_gwui : p_gw_gwui2;
     p_flash_info->p_next_fatfs_gwui_partition = p_flash_info->is_ota0_active ? p_gw_gwui2 : p_gw_gwui;
-    LOG_INFO(
-        "Cur fatfs_gwui partition: %s: address 0x%08x, size 0x%x",
-        p_flash_info->p_cur_fatfs_gwui_partition->label,
-        p_flash_info->p_cur_fatfs_gwui_partition->address,
-        p_flash_info->p_cur_fatfs_gwui_partition->size);
-    LOG_INFO(
-        "Next fatfs_gwui partition: %s: address 0x%08x, size 0x%x",
-        p_flash_info->p_next_fatfs_gwui_partition->label,
-        p_flash_info->p_next_fatfs_gwui_partition->address,
-        p_flash_info->p_next_fatfs_gwui_partition->size);
-
-    return true;
+    if (NULL != p_flash_info->p_cur_fatfs_gwui_partition)
+    {
+        LOG_INFO(
+            "Cur fatfs_gwui partition: %s: address 0x%08x, size 0x%x",
+            p_flash_info->p_cur_fatfs_gwui_partition->label,
+            p_flash_info->p_cur_fatfs_gwui_partition->address,
+            p_flash_info->p_cur_fatfs_gwui_partition->size);
+    }
+    else
+    {
+        LOG_ERR("Cur fatfs_gwui partition: <NULL>");
+    }
+    if (NULL != p_flash_info->p_next_fatfs_gwui_partition)
+    {
+        LOG_INFO(
+            "Next fatfs_gwui partition: %s: address 0x%08x, size 0x%x",
+            p_flash_info->p_next_fatfs_gwui_partition->label,
+            p_flash_info->p_next_fatfs_gwui_partition->address,
+            p_flash_info->p_next_fatfs_gwui_partition->size);
+    }
+    else
+    {
+        LOG_ERR("Next fatfs_gwui partition: <NULL>");
+    }
 }
 
-static bool
+static void
 fw_update_set_next_nrf52_partition(ruuvi_flash_info_t* const p_flash_info)
 {
     const esp_partition_t* const p_gw_nrf = find_data_fat_partition_by_name(GW_NRF_PARTITION);
     if (NULL == p_gw_nrf)
     {
         LOG_ERR("Can't find first partition for nRF52 firmware: %s", GW_NRF_PARTITION);
-        return false;
     }
     const esp_partition_t* const p_gw_nrf2 = find_data_fat_partition_by_name(GW_NRF_PARTITION_2);
     if (NULL == p_gw_nrf2)
     {
         LOG_ERR("Can't find second partition for nRF52 firmware: %s", GW_NRF_PARTITION_2);
-        return false;
     }
     p_flash_info->p_cur_fatfs_nrf52_partition  = p_flash_info->is_ota0_active ? p_gw_nrf : p_gw_nrf2;
     p_flash_info->p_next_fatfs_nrf52_partition = p_flash_info->is_ota0_active ? p_gw_nrf2 : p_gw_nrf;
 
-    LOG_INFO(
-        "Cur fatfs_nrf52 partition: %s: address 0x%08x, size 0x%x",
-        p_flash_info->p_cur_fatfs_nrf52_partition->label,
-        p_flash_info->p_cur_fatfs_nrf52_partition->address,
-        p_flash_info->p_cur_fatfs_nrf52_partition->size);
-    LOG_INFO(
-        "Next fatfs_nrf52 partition: %s: address 0x%08x, size 0x%x",
-        p_flash_info->p_next_fatfs_nrf52_partition->label,
-        p_flash_info->p_next_fatfs_nrf52_partition->address,
-        p_flash_info->p_next_fatfs_nrf52_partition->size);
-    return true;
+    if (NULL != p_flash_info->p_cur_fatfs_nrf52_partition)
+    {
+        LOG_INFO(
+            "Cur fatfs_nrf52 partition: %s: address 0x%08x, size 0x%x",
+            p_flash_info->p_cur_fatfs_nrf52_partition->label,
+            p_flash_info->p_cur_fatfs_nrf52_partition->address,
+            p_flash_info->p_cur_fatfs_nrf52_partition->size);
+    }
+    else
+    {
+        LOG_ERR("Cur fatfs_nrf52 partition: <NULL>");
+    }
+    if (NULL != p_flash_info->p_next_fatfs_nrf52_partition)
+    {
+        LOG_INFO(
+            "Next fatfs_nrf52 partition: %s: address 0x%08x, size 0x%x",
+            p_flash_info->p_next_fatfs_nrf52_partition->label,
+            p_flash_info->p_next_fatfs_nrf52_partition->address,
+            p_flash_info->p_next_fatfs_nrf52_partition->size);
+    }
+    else
+    {
+        LOG_ERR("Next fatfs_nrf52 partition: <NULL>");
+    }
 }
 
 static bool
 fw_update_read_flash_info_internal(ruuvi_flash_info_t* const p_flash_info)
 {
-    p_flash_info->is_valid = false;
-
     p_flash_info->running_partition_state = ESP_OTA_IMG_UNDEFINED;
 
     p_flash_info->p_app_desc = esp_ota_get_app_description();
@@ -537,19 +558,26 @@ fw_update_read_flash_info_internal(ruuvi_flash_info_t* const p_flash_info)
     p_flash_info->p_boot_partition = esp_ota_get_boot_partition();
     if (NULL == p_flash_info->p_boot_partition)
     {
-        LOG_ERR("There is no boot partition info");
-        return false;
+        LOG_ERR("### Boot partition: %s", "N/A");
     }
-    LOG_INFO("### Boot partition: %s", p_flash_info->p_boot_partition->label);
+    else
+    {
+        LOG_INFO(
+            "### Boot partition: %s: address 0x%08x, size 0x%x",
+            p_flash_info->p_boot_partition->label,
+            p_flash_info->p_boot_partition->address,
+            p_flash_info->p_boot_partition->size);
+    }
 
     p_flash_info->p_running_partition = esp_ota_get_running_partition();
     if (NULL == p_flash_info->p_running_partition)
     {
-        LOG_ERR("There is no running partition info");
+        LOG_ERR("### Currently running partition: %s", "Not found");
         return false;
     }
+
     LOG_INFO(
-        "Currently running partition: %s: address 0x%08x, size 0x%x",
+        "### Currently running partition: %s: address 0x%08x, size 0x%x",
         p_flash_info->p_running_partition->label,
         p_flash_info->p_running_partition->address,
         p_flash_info->p_running_partition->size);
@@ -560,26 +588,15 @@ fw_update_read_flash_info_internal(ruuvi_flash_info_t* const p_flash_info)
     if (ESP_OK != err)
     {
         LOG_ERR_ESP(err, "%s failed", "esp_ota_get_state_partition");
-        return false;
+        // The 'otadata' partition is in invalid state, so we can't determine the state of the running partition.
+        // Just try to continue executing code from the running partition
+        // and hope that on the next firmware update the 'otadata' partition will be overwritten with valid data.
     }
     fw_update_log_running_partition_state(p_flash_info->running_partition_state);
 
-    if (!fw_update_set_next_ota_partition(p_flash_info))
-    {
-        return false;
-    }
-
-    if (!fw_update_set_next_gwui_partition(p_flash_info))
-    {
-        return false;
-    }
-
-    if (!fw_update_set_next_nrf52_partition(p_flash_info))
-    {
-        return false;
-    }
-
-    p_flash_info->is_valid = true;
+    fw_update_set_next_ota_partition(p_flash_info);
+    fw_update_set_next_gwui_partition(p_flash_info);
+    fw_update_set_next_nrf52_partition(p_flash_info);
     return true;
 }
 
@@ -588,15 +605,28 @@ fw_update_read_flash_info_and_check_signatures(void)
 {
     ruuvi_flash_info_t* const p_flash_info = &g_ruuvi_flash_info;
 
-    fw_update_read_flash_info_internal(p_flash_info);
-
+    if (!fw_update_read_flash_info_internal(p_flash_info))
+    {
+        LOG_ERR("Can't get info about running partition");
+        return false;
+    }
+    if (NULL == p_flash_info->p_cur_fatfs_gwui_partition)
+    {
+        LOG_ERR("Can't find cur fatfs_gwui partition");
+        return false;
+    }
+    if (NULL == p_flash_info->p_cur_fatfs_nrf52_partition)
+    {
+        LOG_ERR("Can't find cur fatfs_nrf52 partition");
+        return false;
+    }
     if (!fw_update_self_check_signature(p_flash_info))
     {
         LOG_ERR("Self check of running partition signature failed");
         return false;
     }
 
-    return p_flash_info->is_valid;
+    return true;
 }
 
 bool
@@ -605,7 +635,9 @@ fw_update_mark_app_valid_cancel_rollback(void)
     ruuvi_flash_info_t* p_flash_info = &g_ruuvi_flash_info;
     if (ESP_OTA_IMG_PENDING_VERIFY == p_flash_info->running_partition_state)
     {
-        LOG_INFO("Mark current OTA partition valid and cancel rollback");
+        LOG_INFO(
+            "Mark current OTA partition '%s' valid and cancel rollback",
+            (NULL != p_flash_info->p_running_partition) ? p_flash_info->p_running_partition->label : "<NULL>");
         const esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
         if (ESP_OK != err)
         {
@@ -1359,7 +1391,7 @@ fw_update_invalidate_next_ota_partition(
         return false;
     }
     LOG_INFO(
-        "Erase first sector only of OTA partition '%s' (address 0x%08x, size 0x%x)",
+        "Erase first sector of OTA partition '%s' (address 0x%08x, size 0x%x)",
         p_partition_ota->label,
         p_partition_ota->address,
         p_partition_ota->size);

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -446,7 +446,7 @@ fw_update_self_check_signature(ruuvi_flash_info_t* const p_flash_info)
 static void
 fw_update_set_next_ota_partition(ruuvi_flash_info_t* const p_flash_info)
 {
-    // Precondition: p_flash_info->p_running_partition != NULL
+    assert(NULL != p_flash_info->p_running_partition);
     p_flash_info->p_next_update_partition = esp_ota_get_next_update_partition(p_flash_info->p_running_partition);
     if (NULL == p_flash_info->p_next_update_partition)
     {

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -554,7 +554,7 @@ fw_update_read_flash_info_internal(ruuvi_flash_info_t* const p_flash_info)
         p_flash_info->p_running_partition->address,
         p_flash_info->p_running_partition->size);
 
-    esp_err_t err = esp_ota_get_state_partition(
+    const esp_err_t err = esp_ota_get_state_partition_patched(
         p_flash_info->p_running_partition,
         &p_flash_info->running_partition_state);
     if (ESP_OK != err)

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -587,7 +587,7 @@ fw_update_read_flash_info_internal(ruuvi_flash_info_t* const p_flash_info)
         &p_flash_info->running_partition_state);
     if (ESP_OK != err)
     {
-        LOG_ERR_ESP(err, "%s failed", "esp_ota_get_state_partition");
+        LOG_ERR_ESP(err, "%s failed", "esp_ota_get_state_partition_patched");
         // The 'otadata' partition is in invalid state, so we can't determine the state of the running partition.
         // Just try to continue executing code from the running partition
         // and hope that on the next firmware update the 'otadata' partition will be overwritten with valid data.

--- a/main/fw_update.h
+++ b/main/fw_update.h
@@ -25,7 +25,6 @@ extern "C" {
 
 typedef struct ruuvi_flash_info_t
 {
-    bool                    is_valid;
     bool                    is_ota0_active;
     const esp_app_desc_t*   p_app_desc;
     const esp_partition_t*  p_boot_partition;

--- a/main/reset_task.c
+++ b/main/reset_task.c
@@ -312,3 +312,14 @@ gateway_restart_low_memory(void)
     gateway_restart("Low memory");
 #endif // RUUVI_GATEWAY_ENABLE_MEM_FRAGMENTATION_TEST
 }
+
+ATTR_NORETURN
+void
+gateway_restart_immediate_no_cleanup(const char* const p_msg)
+{
+    reset_info_set_sw(p_msg);
+    LOG_INFO("%s", p_msg);
+    vTaskDelay(pdMS_TO_TICKS(100)); // Give some time to print logs to UART
+
+    esp_restart();
+}

--- a/main/reset_task.h
+++ b/main/reset_task.h
@@ -35,6 +35,10 @@ gateway_restart(const char* const p_msg);
 void
 gateway_restart_low_memory(void);
 
+ATTR_NORETURN
+void
+gateway_restart_immediate_no_cleanup(const char* const p_msg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/ruuvi_gateway_main.c
+++ b/main/ruuvi_gateway_main.c
@@ -337,6 +337,7 @@ cb_after_nrf52_fw_updating(const bool flag_success)
     main_task_send_sig_deactivate_cfg_mode();
 }
 
+ATTR_NORETURN
 static void
 handle_reset_button_is_pressed_during_boot(void)
 {
@@ -366,7 +367,7 @@ handle_reset_button_is_pressed_during_boot(void)
     {
         vTaskDelay(1);
     }
-    gateway_restart("The CONFIGURE button has been released - restart system");
+    gateway_restart_immediate_no_cleanup("The CONFIGURE button has been released - restart system");
 }
 
 static void
@@ -527,7 +528,7 @@ main_task_init(void)
     if (is_configure_button_pressed)
     {
         handle_reset_button_is_pressed_during_boot();
-        return false;
+        assert(0); // handle_reset_button_is_pressed_during_boot reboots the gateway when CONFIGURE button is released
     }
 
     if (!settings_check_in_flash())

--- a/main/ruuvi_gateway_main.c
+++ b/main/ruuvi_gateway_main.c
@@ -473,25 +473,25 @@ main_task_initial_initialization(void)
     if (!main_loop_init())
     {
         LOG_ERR("%s failed", "main_loop_init");
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     if (!fw_update_read_flash_info_and_check_signatures())
     {
         LOG_ERR("%s failed", "fw_update_read_flash_info");
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     if (!event_mgr_init())
     {
         LOG_ERR("%s failed", "event_mgr_init");
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     if (!gw_status_init())
     {
         LOG_ERR("%s failed", "gw_status_init");
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     gpio_init();
@@ -506,7 +506,7 @@ main_task_init(void)
 
     if (!main_task_initial_initialization())
     {
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     const bool is_configure_button_pressed = (0 == gpio_get_level(RB_BUTTON_RESET_PIN)) ? true : false;
@@ -516,7 +516,7 @@ main_task_init(void)
     if (!reset_task_init())
     {
         LOG_ERR("Can't create thread");
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     ruuvi_nvs_init();
@@ -546,7 +546,7 @@ main_task_init(void)
     if (!ruuvi_init_gw_cfg(NULL, NULL))
     {
         LOG_ERR("%s failed", "ruuvi_init_gw_cfg");
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
 
     main_task_init_timers();
@@ -564,17 +564,9 @@ main_task_init(void)
             true))
     {
         LOG_ERR("%s failed", "nrf52fw_update_fw_if_necessary");
-        if (esp_ota_check_rollback_is_possible())
-        {
-            LOG_ERR("Firmware rollback is possible, so try to do it");
-        }
-        else
-        {
-            LOG_ERR("Firmware rollback is not possible");
-        }
         gw_status_clear_nrf_status();
         leds_notify_nrf52_failure();
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
     gw_status_set_nrf_status();
     leds_notify_nrf52_ready();
@@ -603,7 +595,7 @@ main_task_init(void)
     {
         LOG_ERR("%s failed", "network_subsystem_init");
         gw_cfg_unlock_ro(&p_gw_cfg);
-        return false;
+        return false; // app_main() will roll back the firmware.
     }
     gw_cfg_unlock_ro(&p_gw_cfg);
 
@@ -616,8 +608,17 @@ app_main(void)
 {
     if (!main_task_init())
     {
-        LOG_ERR("main_task_init failed - try to rollback firmware");
-        reset_info_set_sw("Rollback firmware");
+        LOG_ERR("main_task_init failed");
+        if (esp_ota_check_rollback_is_possible())
+        {
+            LOG_ERR("Firmware rollback is possible, so try to do it");
+            reset_info_set_sw("Rollback firmware");
+        }
+        else
+        {
+            LOG_ERR("Firmware rollback is not possible");
+            reset_info_set_sw("Rollback firmware (impossible, plain restart)");
+        }
         const esp_err_t err = esp_ota_mark_app_invalid_rollback_and_reboot();
         if (0 != err)
         {
@@ -629,11 +630,17 @@ app_main(void)
     }
     else
     {
-        if (settings_read_flag_rebooting_after_auto_update())
+        const bool is_upstream_used = gw_cfg_get_http_use_http_ruuvi() || gw_cfg_get_http_use_http()
+                                      || gw_cfg_get_mqtt_use_mqtt(); // Do not take into account statistics endpoint
+        const bool is_rebooted_after_autoupdate = settings_read_flag_rebooting_after_auto_update();
+        if (is_rebooted_after_autoupdate)
         {
-            // If rebooting after auto firmware update, fw_update_mark_app_valid_cancel_rollback should be called by
-            // http_post_advs or mqtt_event_handler after successful network communication with the server.
             settings_write_flag_rebooting_after_auto_update(false);
+        }
+        if (is_upstream_used && is_rebooted_after_autoupdate)
+        {
+            LOG_INFO("Rebooted after firmware autoupdate and upstream is used");
+            LOG_INFO("http_post_advs or mqtt_event_handler will mark app valid and cancel rollback");
         }
         else
         {


### PR DESCRIPTION
# Problem

When the otadata partition contained invalid data (e.g. a stale or corrupt CRC, or an ota_seq value that did not map to any existing OTA slot), the gateway crashed with a NULL-pointer dereference during boot and then entered a reboot loop:
1. On boot, esp_ota_get_boot_partition() could not decode the otadata sector and returned NULL. Other ESP-IDF helpers that consult otadata (e.g. esp_ota_get_next_update_partition(), the upstream esp_ota_get_state_partition()) returned NULL or an error for the same reason.
2. The patched esp_ota_get_state_partition() could not distinguish a missing entry from an entry with a bad CRC, so it just returned ESP_ERR_NOT_FOUND and the real cause stayed invisible in the logs.
3. fw_update_read_flash_info_internal() stored those NULLs into g_ruuvi_flash_info but did not propagate the failure consistently; downstream code (fw_update_self_check_signature(), fw_update_restore_nrf52_wl_area_if_needed(), fw_update_check_fatfs_partition_signature(), the LOG_INFO lines that print partition->label / address / size) then dereferenced those NULL pointers and the gateway panicked.
4. After the panic, the bootloader rebooted into the other OTA slot which, in field reports, suffered from the same corrupt otadata situation, the same NULL-dereference happened again, the device panicked again, and so on indefinitely — a reboot loop from which the gateway could not recover because it never reached the network stage where a new firmware could overwrite the broken otadata.

The root cause is structural: the boot path conflated several independent partition-table checks under a single is_valid flag and assumed that all esp_partition_t* fields were non-NULL on success, while several call sites dereferenced those fields without any guard. Combined with the patched esp_ota_get_state_partition_patched() not surfacing the otadata-CRC problem, the device had neither a safe execution path nor any way to diagnose what had gone wrong from logs.

# Goal of this PR

Stop the NULL-dereference crash on boot when the otadata partition is invalid, so the device exits the reboot loop, stays reachable on the network, and can be recovered automatically by the next firmware update.

When the otadata partition is unreadable / corrupt, the device must:
1. Not crash — every consumer of the partition-info struct must either be reached only when its inputs are known to be non-NULL, or guard the pointer itself.
2. Continue booting the currently-running app (which is, by definition, executable — we are already running it) instead of triggering rollback, since the other slot is just as likely to fail.
3. Log the underlying cause (missing entry vs. bad CRC, with the affected slot, stored vs. recomputed CRC, etc.) so the problem is obvious in field logs.
4. Stay online so that the next firmware update can overwrite the broken otadata sector and recover the device automatically.

Main fix — [#1278] fw_update: keep booting on non-fatal flash-info failures

**main/fw_update.c, main/fw_update.h**

This is the commit that actually closes the issue. It eliminates the NULL-dereferences and removes the unconditional rollback that produced the reboot loop.
- fw_update_set_next_{ota,gwui,nrf52}_partition() are changed from bool-returning to void. On failure they record NULL in the corresponding p_{cur,next}_* fields of ruuvi_flash_info_t, log a LOG_ERR, and all of their own log lines are NULL-guarded so they cannot crash regardless of what the partition table looks like.
- fw_update_read_flash_info_internal():
  - no longer crashes on a missing boot partition — only logs an error;
  - no longer aborts if esp_ota_get_state_partition_patched() fails; a comment explicitly explains that the otadata sector is then assumed to be in an invalid state and that the next firmware update will overwrite it;
  - no longer aborts on missing "next" OTA / GWUI / nRF52 partitions;
  - still returns false only for the one truly unrecoverable case ("the running partition cannot be obtained").
- fw_update_read_flash_info_and_check_signatures() performs the hard preconditions required by the on-boot signature self-check (p_running_partition, p_cur_fatfs_gwui_partition, p_cur_fatfs_nrf52_partition all non-NULL) before entering fw_update_self_check_signature(). This is what eliminates the NULL-dereferences in fw_update_self_check_signature() / fw_update_restore_nrf52_wl_area_if_needed() / fw_update_check_fatfs_partition_signature() that previously crashed the gateway.
- ruuvi_flash_info_t::is_valid is removed — the previous all-or-nothing semantics were exactly what hid the NULL-deref hazard and forced the reboot loop.
- fw_update_mark_app_valid_cancel_rollback() logs the label of the current OTA partition (NULL-guarded) so field logs show which slot was confirmed.
- fw_update_log_running_partition_state() promotes the INVALID / ABORTED / UNDEFINED / UNKNOWN cases from LOG_INFO to LOG_WARN, so an invalid otadata state is immediately visible in field logs.
- Minor: "Erase first sector only of OTA partition '%s'" → "Erase first sector of OTA partition '%s'".

## Supporting changes

### **esp_ota_get_state_partition_patched()** diagnostics and CRC handling

**main/esp_ota_ops_patched.c, main/esp_ota_ops_patched.h**

Needed so that, after the boot path stops crashing on bad otadata, the actual reason can be identified in logs.
- New private helpers:
  - read_two_ota_data() — mmaps the otadata partition, NULL-checks the mapped pointer, copies both esp_ota_select_entry_t records into a caller-provided buffer, and always unmaps before returning.
  - esp_ota_calc_slot_from_seq() — converts an ota_seq value into a slot index and rejects the "uninitialised flash" sentinels (ota_seq == 0 and ota_seq == UINT32_MAX).
- Replaced the magic constant 2 with ESP_OTA_NUM_OTA_SLOTS. Tightened const-correctness, zero-initialised the mmap handle, switched to Yoda comparisons (project style), fixed the pre-existing "mmap OTA-data filed" typo, and used <inttypes.h> format macros (PRIi32 / PRIu8 / PRIx32 / PRId32) for all 32-bit / 8-bit prints, including esp_err_t.
- esp_ota_get_state_partition_patched() now:
  - logs the number of OTA app partitions, the decoded slot for each otadata entry and the requested slot via the log.h wrappers;
  - writes *p_ota_state before validating the CRC, so the caller can still log the (possibly corrupt) state on CRC errors;
  - on CRC mismatch, continues scanning the remaining otadata entry and returns ESP_ERR_INVALID_CRC only if no entry mapping to the requested slot has a valid CRC;
  - returns ESP_ERR_NOT_FOUND when no otadata entry maps to the requested slot at all (unchanged behaviour for that case).
- Full Doxygen block on the declaration in esp_ota_ops_patched.h listing the algorithm, parameters and complete set of return codes (ESP_OK, ESP_ERR_INVALID_ARG, ESP_ERR_NOT_SUPPORTED, ESP_ERR_NOT_FOUND, ESP_ERR_INVALID_CRC).

### Unified rollback decision in app_main() and post-auto-update fix
**main/ruuvi_gateway_main.c**
- Every failure path of main_task_init() / main_task_initial_initialization() now reaches the same rollback block in app_main(). The "Firmware rollback is possible / is not possible" diagnostic is moved out of the nRF52-update failure branch and printed for every failure mode. Each return false; is annotated with // app_main() will roll back the firmware.
- The recorded reset reason now differentiates "Rollback firmware" from "Rollback firmware (impossible, plain restart)" so post-mortem analysis from NVS reset_info is unambiguous — particularly useful when investigating reboot-loop reports.
- The post-auto-update "do not mark the app valid yet" branch is now taken only if at least one upstream is configured (HTTP-Ruuvi, custom HTTP or MQTT — the statistics endpoint is deliberately excluded, see inline comment). When no upstream is configured, fw_update_mark_app_valid_cancel_rollback() is called immediately after boot, otherwise the device would silently roll back after every auto-update.
- The "rebooting after auto-update" NVS flag is now cleared whenever it is set, regardless of whether an upstream is configured.

### Safer early-boot reboot helper
**main/reset_task.c, main/reset_task.h, main/ruuvi_gateway_main.c**

- New gateway_restart_immediate_no_cleanup() — ATTR_NORETURN, calls esp_restart() directly without going through the reset task, event manager or WiFi shutdown. Intended for early-boot paths where those subsystems are not yet (or no longer) running.
- handle_reset_button_is_pressed_during_boot() is marked ATTR_NORETURN and uses this helper instead of gateway_restart(); the caller protects itself with assert(0).

