### PR TITLE
Close #1281: Automatically create GitHub Release and upload firmware ZIP asset on tag builds

### DIFF
--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -15,7 +15,19 @@ jobs:
     name: Build Firmware (dev)
     environment: dev
     runs-on: ubuntu-22.04
-    # Default (read-only) GITHUB_TOKEN; release publishing happens in a separate job.
+    # Use the default GITHUB_TOKEN permissions for this job; release publishing happens in a separate job.
+    env:
+      # Single source of truth for the files shipped as both the workflow
+      # artifact and the contents of the release zip. Keep paths relative to
+      # the repository root and inside the `build/` directory.
+      RELEASE_FILES: |
+        build/ruuvi_gateway_esp.bin
+        build/binaries_v1.9.2/bootloader.bin
+        build/partition_table/partition-table.bin
+        build/ota_data_initial.bin
+        build/fatfs_nrf52.bin
+        build/fatfs_gwui.bin
+        build/gw_cfg_def.bin
 
     steps:
       - name: Check out code
@@ -102,14 +114,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ruuvi_gateway_fw
-          path: |
-            build/ruuvi_gateway_esp.bin
-            build/binaries_v1.9.2/bootloader.bin
-            build/partition_table/partition-table.bin
-            build/ota_data_initial.bin
-            build/fatfs_nrf52.bin
-            build/fatfs_gwui.bin
-            build/gw_cfg_def.bin
+          path: ${{ env.RELEASE_FILES }}
 
       - name: Create release zip
         id: create_zip
@@ -126,20 +131,14 @@ jobs:
           ARTIFACT_NAME="ruuvi_gateway_fw-dev_${SAFE_TAG}"
           DST="$ARTIFACT_NAME"
           mkdir -p "$DST"
-          paths=(
-            "build/ruuvi_gateway_esp.bin"
-            "build/binaries_v1.9.2/bootloader.bin"
-            "build/partition_table/partition-table.bin"
-            "build/ota_data_initial.bin"
-            "build/fatfs_nrf52.bin"
-            "build/fatfs_gwui.bin"
-            "build/gw_cfg_def.bin"
-          )
-          for rel in "${paths[@]}"; do
+          # File list is provided by the job-level RELEASE_FILES env var
+          # (single source of truth shared with the "Upload artifact" step).
+          while IFS= read -r rel; do
+            [ -z "$rel" ] && continue
             dst_path="$DST/${rel#build/}"
             mkdir -p "$(dirname "$dst_path")"
             cp "$rel" "$dst_path"
-          done
+          done <<< "$RELEASE_FILES"
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
           zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -1,4 +1,4 @@
-name: Build Firmware
+name: Build Firmware (dev)
 
 on:
   push:
@@ -12,9 +12,11 @@ on:
 
 jobs:
   build:
-    name: Build firmware (dev)
+    name: Build Firmware (dev)
     environment: dev
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
 
     steps:
       - name: Check out code
@@ -109,3 +111,55 @@ jobs:
             build/fatfs_nrf52.bin
             build/fatfs_gwui.bin
             build/gw_cfg_def.bin
+
+      - name: Create release zip
+        id: create_zip
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          ARTIFACT_NAME="ruuvi_gateway_fw-dev_${TAG}"
+          DST="$ARTIFACT_NAME"
+          mkdir -p "$DST"
+          paths=(
+            "build/ruuvi_gateway_esp.bin"
+            "build/binaries_v1.9.2/bootloader.bin"
+            "build/partition_table/partition-table.bin"
+            "build/ota_data_initial.bin"
+            "build/fatfs_nrf52.bin"
+            "build/fatfs_gwui.bin"
+            "build/gw_cfg_def.bin"
+          )
+          for rel in "${paths[@]}"; do
+            dst_path="$DST/${rel#build/}"
+            mkdir -p "$(dirname "$dst_path")"
+            cp "$rel" "$dst_path"
+          done
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
+          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Create release and upload asset
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
+        shell: bash
+        run: |
+          set -xe
+          command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
+          # create if missing; on failure re-check to tolerate races with the other workflow
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+              echo "Create failed; rechecking..."
+              if ! gh release view "$TAG" >/dev/null 2>&1; then
+                echo "Release still missing; aborting."
+                exit 1
+              fi
+            fi
+          fi
+          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -15,8 +15,7 @@ jobs:
     name: Build Firmware (dev)
     environment: dev
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
+    # Default (read-only) GITHUB_TOKEN; release publishing happens in a separate job.
 
     steps:
       - name: Check out code
@@ -142,24 +141,52 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
-      - name: Create release and upload asset
+      - name: Upload release zip as workflow artifact
         if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruuvi_gateway_fw-dev-release-zip
+          path: ${{ steps.create_zip.outputs.artifact_path }}
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    name: Publish GitHub Release (dev)
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ruuvi_gateway_fw-dev_${{ github.ref_name }}
+    steps:
+      - name: Download release zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ruuvi_gateway_fw-dev-release-zip
+          path: release_asset
+
+      - name: Create release and upload asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races with the other workflow
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}.zip"
+          if [ ! -f "$ARTIFACT_PATH" ]; then
+            echo "Artifact not found at $ARTIFACT_PATH"; ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # create if missing; on failure re-check to tolerate races with the prod workflow
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -29,6 +29,12 @@ jobs:
         build/fatfs_gwui.bin
         build/gw_cfg_def.bin
 
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -159,11 +165,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
     env:
       TAG: ${{ github.ref_name }}
-      # Keep in sync with the sanitization in the build job's "Create release zip" step.
-      ARTIFACT_NAME: ruuvi_gateway_fw-dev_${{ replace(github.ref_name, '/', '_') }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
     steps:
       - name: Download release zip artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -141,6 +141,10 @@ jobs:
           # (single source of truth shared with the "Upload artifact" step).
           while IFS= read -r rel; do
             [ -z "$rel" ] && continue
+            if [ ! -f "$rel" ]; then
+              echo "Missing release file: $rel" >&2
+              exit 1
+            fi
             dst_path="$DST/${rel#build/}"
             mkdir -p "$(dirname "$dst_path")"
             cp "$rel" "$dst_path"

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -117,7 +117,7 @@ jobs:
           cd ..
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload release zip as workflow artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ruuvi_gateway_fw-dev-release-zip
           path: ${{ steps.create_zip.outputs.artifact_path }}
@@ -172,7 +172,7 @@ jobs:
       ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
     steps:
       - name: Download release zip artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ruuvi_gateway_fw-dev-release-zip
           path: release_asset

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -119,7 +119,11 @@ jobs:
         shell: bash
         run: |
           set -xeuo pipefail
-          ARTIFACT_NAME="ruuvi_gateway_fw-dev_${TAG}"
+          # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize so
+          # the zip filename and uploaded asset name stay a single path component
+          # and the dev/prod naming scheme remains unique.
+          SAFE_TAG="${TAG//\//_}"
+          ARTIFACT_NAME="ruuvi_gateway_fw-dev_${SAFE_TAG}"
           DST="$ARTIFACT_NAME"
           mkdir -p "$DST"
           paths=(
@@ -159,7 +163,8 @@ jobs:
       contents: write
     env:
       TAG: ${{ github.ref_name }}
-      ARTIFACT_NAME: ruuvi_gateway_fw-dev_${{ github.ref_name }}
+      # Keep in sync with the sanitization in the build job's "Create release zip" step.
+      ARTIFACT_NAME: ruuvi_gateway_fw-dev_${{ replace(github.ref_name, '/', '_') }}
     steps:
       - name: Download release zip artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -1,4 +1,4 @@
-name: Build Firmware
+name: Build Firmware (prod)
 
 on:
   push:
@@ -9,9 +9,11 @@ on:
 
 jobs:
   build:
-    name: Build firmware (prod)
+    name: Build Firmware (prod)
     environment: prod
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
 
     steps:
       - name: Check out code
@@ -106,3 +108,55 @@ jobs:
             build/fatfs_nrf52.bin
             build/fatfs_gwui.bin
             build/gw_cfg_def.bin
+
+      - name: Create release zip
+        id: create_zip
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          ARTIFACT_NAME="ruuvi_gateway_fw-prod_${TAG}"
+          DST="$ARTIFACT_NAME"
+          mkdir -p "$DST"
+          paths=(
+            "build/ruuvi_gateway_esp.bin"
+            "build/binaries_v1.9.2/bootloader.bin"
+            "build/partition_table/partition-table.bin"
+            "build/ota_data_initial.bin"
+            "build/fatfs_nrf52.bin"
+            "build/fatfs_gwui.bin"
+            "build/gw_cfg_def.bin"
+          )
+          for rel in "${paths[@]}"; do
+            dst_path="$DST/${rel#build/}"
+            mkdir -p "$(dirname "$dst_path")"
+            cp "$rel" "$dst_path"
+          done
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
+          zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Create release and upload asset
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
+        shell: bash
+        run: |
+          set -xe
+          command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
+          # create if missing; on failure re-check to tolerate races with the other workflow
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+              echo "Create failed; rechecking..."
+              if ! gh release view "$TAG" >/dev/null 2>&1; then
+                echo "Release still missing; aborting."
+                exit 1
+              fi
+            fi
+          fi
+          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -138,6 +138,10 @@ jobs:
           # (single source of truth shared with the "Upload artifact" step).
           while IFS= read -r rel; do
             [ -z "$rel" ] && continue
+            if [ ! -f "$rel" ]; then
+              echo "Missing release file: $rel" >&2
+              exit 1
+            fi
             dst_path="$DST/${rel#build/}"
             mkdir -p "$(dirname "$dst_path")"
             cp "$rel" "$dst_path"

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -12,8 +12,7 @@ jobs:
     name: Build Firmware (prod)
     environment: prod
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
+    # Default (read-only) GITHUB_TOKEN; release publishing happens in a separate job.
 
     steps:
       - name: Check out code
@@ -139,24 +138,52 @@ jobs:
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
           echo "artifact_path=$ARTIFACT_PATH" >> "$GITHUB_OUTPUT"
 
-      - name: Create release and upload asset
+      - name: Upload release zip as workflow artifact
         if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruuvi_gateway_fw-prod-release-zip
+          path: ${{ steps.create_zip.outputs.artifact_path }}
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    name: Publish GitHub Release (prod)
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.ref_name }}
+      ARTIFACT_NAME: ruuvi_gateway_fw-prod_${{ github.ref_name }}
+    steps:
+      - name: Download release zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ruuvi_gateway_fw-prod-release-zip
+          path: release_asset
+
+      - name: Create release and upload asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          ARTIFACT_PATH: ${{ steps.create_zip.outputs.artifact_path }}
         shell: bash
         run: |
           set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          # create if missing; on failure re-check to tolerate races with the other workflow
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            if ! gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease; then
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}.zip"
+          if [ ! -f "$ARTIFACT_PATH" ]; then
+            echo "Artifact not found at $ARTIFACT_PATH"; ls -la "$GITHUB_WORKSPACE/release_asset" || true
+            exit 1
+          fi
+          # create if missing; on failure re-check to tolerate races with the dev workflow
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
               echo "Create failed; rechecking..."
-              if ! gh release view "$TAG" >/dev/null 2>&1; then
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                 echo "Release still missing; aborting."
                 exit 1
               fi
             fi
           fi
-          gh release upload "$TAG" "$ARTIFACT_PATH" --clobber
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -26,6 +26,12 @@ jobs:
         build/fatfs_gwui.bin
         build/gw_cfg_def.bin
 
+    outputs:
+      # Exposes the sanitized release zip name (without .zip suffix) so the
+      # release job can locate the downloaded artifact without re-implementing
+      # the sanitization logic.
+      release_zip_name: ${{ steps.create_zip.outputs.artifact_name }}
+
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -156,11 +162,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
     env:
       TAG: ${{ github.ref_name }}
-      # Keep in sync with the sanitization in the build job's "Create release zip" step.
-      ARTIFACT_NAME: ruuvi_gateway_fw-prod_${{ replace(github.ref_name, '/', '_') }}
+      ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
     steps:
       - name: Download release zip artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -116,7 +116,11 @@ jobs:
         shell: bash
         run: |
           set -xeuo pipefail
-          ARTIFACT_NAME="ruuvi_gateway_fw-prod_${TAG}"
+          # github.ref_name may contain '/' (e.g. "release/v1.2.3"); sanitize so
+          # the zip filename and uploaded asset name stay a single path component
+          # and the dev/prod naming scheme remains unique.
+          SAFE_TAG="${TAG//\//_}"
+          ARTIFACT_NAME="ruuvi_gateway_fw-prod_${SAFE_TAG}"
           DST="$ARTIFACT_NAME"
           mkdir -p "$DST"
           paths=(
@@ -156,7 +160,8 @@ jobs:
       contents: write
     env:
       TAG: ${{ github.ref_name }}
-      ARTIFACT_NAME: ruuvi_gateway_fw-prod_${{ github.ref_name }}
+      # Keep in sync with the sanitization in the build job's "Create release zip" step.
+      ARTIFACT_NAME: ruuvi_gateway_fw-prod_${{ replace(github.ref_name, '/', '_') }}
     steps:
       - name: Download release zip artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -12,7 +12,19 @@ jobs:
     name: Build Firmware (prod)
     environment: prod
     runs-on: ubuntu-22.04
-    # Default (read-only) GITHUB_TOKEN; release publishing happens in a separate job.
+    # Use the default GITHUB_TOKEN permissions for this job; release publishing happens in a separate job.
+    env:
+      # Single source of truth for the files shipped as both the workflow
+      # artifact and the contents of the release zip. Keep paths relative to
+      # the repository root and inside the `build/` directory.
+      RELEASE_FILES: |
+        build/ruuvi_gateway_esp.bin
+        build/binaries_v1.9.2/bootloader.bin
+        build/partition_table/partition-table.bin
+        build/ota_data_initial.bin
+        build/fatfs_nrf52.bin
+        build/fatfs_gwui.bin
+        build/gw_cfg_def.bin
 
     steps:
       - name: Check out code
@@ -99,14 +111,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ruuvi_gateway_fw
-          path: |
-            build/ruuvi_gateway_esp.bin
-            build/binaries_v1.9.2/bootloader.bin
-            build/partition_table/partition-table.bin
-            build/ota_data_initial.bin
-            build/fatfs_nrf52.bin
-            build/fatfs_gwui.bin
-            build/gw_cfg_def.bin
+          path: ${{ env.RELEASE_FILES }}
 
       - name: Create release zip
         id: create_zip
@@ -123,20 +128,14 @@ jobs:
           ARTIFACT_NAME="ruuvi_gateway_fw-prod_${SAFE_TAG}"
           DST="$ARTIFACT_NAME"
           mkdir -p "$DST"
-          paths=(
-            "build/ruuvi_gateway_esp.bin"
-            "build/binaries_v1.9.2/bootloader.bin"
-            "build/partition_table/partition-table.bin"
-            "build/ota_data_initial.bin"
-            "build/fatfs_nrf52.bin"
-            "build/fatfs_gwui.bin"
-            "build/gw_cfg_def.bin"
-          )
-          for rel in "${paths[@]}"; do
+          # File list is provided by the job-level RELEASE_FILES env var
+          # (single source of truth shared with the "Upload artifact" step).
+          while IFS= read -r rel; do
+            [ -z "$rel" ] && continue
             dst_path="$DST/${rel#build/}"
             mkdir -p "$(dirname "$dst_path")"
             cp "$rel" "$dst_path"
-          done
+          done <<< "$RELEASE_FILES"
           ARTIFACT_PATH="$GITHUB_WORKSPACE/$ARTIFACT_NAME.zip"
           zip -r -q "$ARTIFACT_PATH" "$ARTIFACT_NAME"
           echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -114,7 +114,7 @@ jobs:
           cd ..
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload release zip as workflow artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ruuvi_gateway_fw-prod-release-zip
           path: ${{ steps.create_zip.outputs.artifact_path }}
@@ -169,7 +169,7 @@ jobs:
       ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
     steps:
       - name: Download release zip artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ruuvi_gateway_fw-prod-release-zip
           path: release_asset


### PR DESCRIPTION
# Summary

Extends both firmware build workflows so that pushing a git tag automatically
creates a GitHub Release and attaches a ZIP archive of the firmware binaries to
it. The per-run workflow artifact upload is preserved unchanged.

Both `.github/workflows/build-fw-dev.yml` and `.github/workflows/build-fw-prod.yml`
are modified symmetrically.

# Workflow structure

Each workflow now has two jobs:

1. **`build`** — runs on every triggering event (push, PR, manual dispatch).
   Uses the default `GITHUB_TOKEN` permissions; **no elevated scopes**. On tag
   pushes it additionally creates the release zip and uploads it as a short-lived
   workflow artifact for the next job to consume.

2. **`release`** — new job, `needs: build`, gated by
   `if: startsWith(github.ref, 'refs/tags/')`. This is the **only** job that
   holds `contents: write`. It downloads the zip artifact and publishes it as a
   GitHub Release asset.

# Detailed step changes

### `build` job

- Added a job-level `env.RELEASE_FILES` block — the **single source of truth**
  for the list of artifact files (newline-separated). Consumed both by the
  existing `Upload artifact` step (`path: ${{ env.RELEASE_FILES }}`) and by the
  new zip step (parsed line-by-line in bash). No more drifting duplicated lists.
- Exposed `outputs.release_zip_name` so the `release` job can locate the
  downloaded artifact without re-implementing tag sanitization.
- New step **Create release zip** (tag pushes only):
  - Sanitizes the tag for filesystem use: `SAFE_TAG="${TAG//\//_}"` (handles tags
    like `release/v1.2.3` which would otherwise create nested subdirectories and
    break the asset name).
  - Builds `ruuvi_gateway_fw-<dev|prod>_<SAFE_TAG>/` and copies the files listed
    in `RELEASE_FILES`, preserving their subpaths beneath `build/`
    (e.g. `binaries_v1.9.2/bootloader.bin`, `partition_table/partition-table.bin`).
  - **Explicit pre-copy existence check** with a clear error message
    (`Missing release file: <path>`) so missing build outputs on a tag run are
    easy to diagnose, instead of a generic `cp: cannot stat …`.
  - Zips the directory into `$GITHUB_WORKSPACE/<artifact_name>.zip` and exports
    the path / name via step outputs.
- New step **Upload release zip as workflow artifact** (tag pushes only):
  uploads the zip with `name: ruuvi_gateway_fw-<dev|prod>-release-zip`,
  `if-no-files-found: error`, `retention-days: 1` — short retention because it
  is just a handoff to the release job.

### `release` job (new)

- `runs-on: ubuntu-22.04`
- `needs: build`
- `if: startsWith(github.ref, 'refs/tags/')`
- `permissions:`
  - `contents: write` — create release and upload assets.
  - `actions: read` — required to download the workflow artifact (declaring
    `permissions:` strips every scope not explicitly listed to `none`, so
    `actions: read` must be granted explicitly).
- Reads the sanitized name from `needs.build.outputs.release_zip_name`.
- Steps:
  - `actions/download-artifact@v8` — fetches the release zip artifact.
  - `Create release and upload asset` — uses the `gh` CLI:
    - `gh release view "$TAG"` first; if missing,
      `gh release create "$TAG" --title "$TAG" --notes "Automated release" --prerelease`.
    - If the create call fails (the other workflow won the race), re-check
      `gh release view`; if the release now exists, proceed; otherwise fail.
    - `gh release upload "$TAG" <zip> --clobber` so a re-run replaces an
      existing asset of the same name. (The two workflows upload differently
      named zips, so they do not overwrite each other.)
    - All `gh` calls pass `--repo "$GITHUB_REPOSITORY"` (no checkout is
      performed in this job).

# Security model (defense in depth)

The release publishing logic was deliberately split into a dedicated job to
minimise the blast radius of the write-scoped `GITHUB_TOKEN`:

- The `build` job runs third-party code (ESP-IDF tooling, `pip install bincopy`,
  project build scripts) and is reachable from `pull_request` events. It runs
  with the default token permissions — **no `contents: write`**.
- The `release` job runs only on tag pushes (which require maintainer access),
  performs **no checkout** and **no build**, and is the only place where the
  write-scoped token is materialised. It uses an `actions: read` +
  `contents: write` scope set with everything else implicitly `none`.

This addresses the review concern that a job-level `contents: write` on the
build job would expose a write-scoped token to PRs from in-repo branches and to
the entire third-party-heavy build environment.

# Race condition handling

A tag push triggers both workflows in parallel. Both `release` jobs attempt to
create the same GitHub Release; only one succeeds. The loser's
`gh release create` returns non-zero; the job then re-checks `gh release view`
and, if the release now exists (created by the other workflow), proceeds to
upload its own zip. Each workflow uploads a uniquely named asset
(`ruuvi_gateway_fw-dev_*.zip` vs `ruuvi_gateway_fw-prod_*.zip`), so the two
uploads never collide.

# Resulting release assets

For a tag `v1.17.1`, the auto-created prerelease will contain:

- `ruuvi_gateway_fw-dev_v1.17.1.zip` (from the dev workflow)
- `ruuvi_gateway_fw-prod_v1.17.1.zip` (from the prod workflow)

Each zip contains the same 7 firmware files that are uploaded as the
per-run workflow artifact, with their relative paths under `build/` preserved.

# What is intentionally not changed

- The existing `Upload artifact` step (per-run workflow artifact named
  `ruuvi_gateway_fw`) is unchanged in both files — same files, same name. It
  now reads the file list from the shared `RELEASE_FILES` env var instead of
  an inline literal list, but the resulting artifact is identical.
- Behaviour on non-tag pushes (`master` pushes, PRs, manual dispatch) is
  unchanged — the new steps and the `release` job are gated by
  `startsWith(github.ref, 'refs/tags/')`.
- The git/Release tag name (`$TAG` passed to `gh release …`) is **not**
  sanitized — it must match the actual git ref. Sanitization is applied only
  to the filename / directory name where filesystem-unsafe characters matter.

# Action / runtime upgrades (Node.js 24 readiness)

GitHub runners deprecated Node.js 20 for JavaScript-based actions (default
flips to Node 24 on 2026-06-16, Node 20 removed on 2026-09-16). Bumped to
versions that run on Node 24 by default:

- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8`

Compatibility review against our usage:

- `upload-artifact`: we only use `name`, `path`, `if-no-files-found`,
  `retention-days`. All unchanged across v4 → v7. The optional `archive: false`
  direct-upload mode added in v7 is not used.
- `download-artifact`: we download by `name` (not `artifact-ids`), so the v5
  breaking change does not apply. v8 enables hash-mismatch errors by default,
  which is a security improvement with no behaviour change unless a transfer
  is actually corrupted.

Pinning uses the major tag (`@v7`, `@v8`) so patch fixes are picked up
automatically, matching the existing convention for the other actions in the
workflow (`actions/checkout@v6`, `actions/setup-python@v6`, `actions/cache@v5`).

# Testing

- **Non-tag commit / PR / manual dispatch**: the new steps and the `release`
  job are skipped via the `if:` guard; the existing `Upload artifact` step
  still runs and produces the same per-run artifact as before.
- **Tag push** (e.g. `v1.17.1-test`): expect an automatically-created
  prerelease tagged `v1.17.1-test` with both
  `ruuvi_gateway_fw-dev_v1.17.1-test.zip` and
  `ruuvi_gateway_fw-prod_v1.17.1-test.zip` attached.
- **Tag with `/` in the name** (e.g. `release/v1.2.3`): the zip filename is
  produced as `ruuvi_gateway_fw-<dev|prod>_release_v1.2.3.zip`; the GitHub
  Release itself still uses the original `release/v1.2.3` tag.
- **Race**: both workflows running concurrently for the same tag — one
  creates the release, the other reuses it; both assets are present.
- **Missing build output**: the `Create release zip` step fails fast with
  `Missing release file: <path>` instead of a generic `cp` error.
