### PR TITLE
Fix #1280: otadata corruption after bootloader fallback from a failed firmware updat

### DIFF
--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -88,44 +88,46 @@ esp_ota_is_ota_partition(const esp_partition_t* p)
 // Read otadata partition and fill array from two otadata structures.
 // Also return pointer to otadata info partition.
 static const esp_partition_t*
-read_otadata(esp_ota_select_entry_t* two_otadata)
+read_otadata(esp_ota_select_entry_t* const p_two_ota_data)
 {
-    const esp_partition_t* otadata_partition = esp_partition_find_first(
+    const esp_partition_t* const p_ota_data_partition = esp_partition_find_first(
         ESP_PARTITION_TYPE_DATA,
         ESP_PARTITION_SUBTYPE_DATA_OTA,
         NULL);
 
-    if (otadata_partition == NULL)
+    if (NULL == p_ota_data_partition)
     {
-        ESP_LOGE(TAG, "otadata partition not found");
+        LOG_ERR("Partition with OTA data not found");
         return NULL;
     }
 
-    spi_flash_mmap_handle_t ota_data_map;
-    const void*             result = NULL;
-    const esp_err_t         err    = esp_partition_mmap(
-        otadata_partition,
+    spi_flash_mmap_handle_t ota_data_map = 0;
+    const void*             p_result     = NULL;
+
+    const esp_err_t err = esp_partition_mmap(
+        p_ota_data_partition,
         0,
-        otadata_partition->size,
+        p_ota_data_partition->size,
         SPI_FLASH_MMAP_DATA,
-        &result,
+        &p_result,
         &ota_data_map);
-    if (err != ESP_OK)
+    if (ESP_OK != err)
     {
-        ESP_LOGE(TAG, "mmap otadata failed. Err=%" PRId32, err);
+        LOG_ERR("mmap OTA-data failed. Err=%" PRId32, err);
         return NULL;
     }
-    if (NULL == result)
+    if (NULL == p_result)
     {
-        ESP_LOGE(TAG, "mmap otadata returned NULL pointer");
+        LOG_ERR("mmap OTA-data returned NULL pointer");
         spi_flash_munmap(ota_data_map);
         return NULL;
     }
-    const uint8_t* const p_otadata = (const uint8_t*)result;
-    memcpy(&two_otadata[0], p_otadata, sizeof(esp_ota_select_entry_t));
-    memcpy(&two_otadata[1], p_otadata + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+    const uint8_t* const p_otadata = (const uint8_t*)p_result;
+    memcpy(&p_two_ota_data[0], p_otadata, sizeof(esp_ota_select_entry_t));
+    memcpy(&p_two_ota_data[1], p_otadata + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+
     spi_flash_munmap(ota_data_map);
-    return otadata_partition;
+    return p_ota_data_partition;
 }
 
 static esp_err_t
@@ -664,48 +666,6 @@ esp_ota_set_boot_partition_patched(const esp_partition_t* partition)
     return esp_rewrite_ota_data(partition->subtype);
 }
 
-static const esp_partition_t*
-read_two_ota_data(esp_ota_select_entry_t* const p_two_ota_data)
-{
-    const esp_partition_t* const p_ota_data_partition = esp_partition_find_first(
-        ESP_PARTITION_TYPE_DATA,
-        ESP_PARTITION_SUBTYPE_DATA_OTA,
-        NULL);
-
-    if (NULL == p_ota_data_partition)
-    {
-        LOG_ERR("Partition with OTA data not found");
-        return NULL;
-    }
-
-    spi_flash_mmap_handle_t ota_data_map = 0;
-    const void*             p_result     = NULL;
-
-    const esp_err_t err = esp_partition_mmap(
-        p_ota_data_partition,
-        0,
-        p_ota_data_partition->size,
-        SPI_FLASH_MMAP_DATA,
-        &p_result,
-        &ota_data_map);
-    if (ESP_OK != err)
-    {
-        LOG_ERR("mmap OTA-data failed. Err=%" PRId32, err);
-        return NULL;
-    }
-    if (NULL == p_result)
-    {
-        LOG_ERR("mmap OTA-data returned NULL pointer");
-        spi_flash_munmap(ota_data_map);
-        return NULL;
-    }
-    memcpy(&p_two_ota_data[0], p_result, sizeof(esp_ota_select_entry_t));
-    memcpy(&p_two_ota_data[1], (const uint8_t*)p_result + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
-
-    spi_flash_munmap(ota_data_map);
-    return p_ota_data_partition;
-}
-
 static int32_t
 esp_ota_calc_slot_from_seq(const uint32_t ota_seq, const uint8_t ota_app_count)
 {
@@ -742,7 +702,7 @@ esp_ota_get_state_partition_patched(const esp_partition_t* const p_partition, es
     LOG_INFO("### Found %" PRIu8 " OTA app partitions", ota_app_count);
 
     esp_ota_select_entry_t ota_data[ESP_OTA_NUM_OTA_SLOTS];
-    if (NULL == read_two_ota_data(ota_data))
+    if (NULL == read_otadata(ota_data))
     {
         LOG_ERR("Failed to read OTA data");
         return ESP_ERR_NOT_FOUND;

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -401,12 +401,12 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
 
 static esp_err_t
 rewrite_ota_seq(
-    esp_ota_select_entry_t* two_otadata,
-    uint32_t                seq,
-    uint8_t                 sec_id,
-    const esp_partition_t*  ota_data_partition)
+    esp_ota_select_entry_t* const two_otadata,
+    const uint32_t                seq,
+    const uint8_t                 sec_id,
+    const esp_partition_t* const  ota_data_partition)
 {
-    if (two_otadata == NULL || sec_id > 1)
+    if ((NULL == two_otadata) || (sec_id > 1))
     {
         LOG_ERR("Invalid argument, two_otadata=%p, sec_id=%" PRIu8, two_otadata, sec_id);
         return ESP_ERR_INVALID_ARG;
@@ -427,7 +427,7 @@ rewrite_ota_seq(
         ota_data_partition->address + sec_id * SPI_FLASH_SEC_SIZE);
 
     esp_err_t ret = esp_partition_erase_range(ota_data_partition, sec_id * SPI_FLASH_SEC_SIZE, SPI_FLASH_SEC_SIZE);
-    if (ret != ESP_OK)
+    if (ESP_OK != ret)
     {
         LOG_ERR("Failed to erase otadata[%" PRIu8 "], err=%" PRId32, sec_id, ret);
         return ret;
@@ -437,7 +437,7 @@ rewrite_ota_seq(
         SPI_FLASH_SEC_SIZE * sec_id,
         &two_otadata[sec_id],
         sizeof(esp_ota_select_entry_t));
-    if (ret != ESP_OK)
+    if (ESP_OK != ret)
     {
         LOG_ERR("Failed to write otadata[%" PRIu8 "], err=%" PRId32, sec_id, ret);
     }
@@ -517,16 +517,20 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
     // while making it map to the requested OTA slot.
 
     const esp_partition_t* p_running_partition = esp_ota_get_running_partition();
-    const int32_t          running_partition_ota_slot
+
+    const int32_t running_partition_ota_slot
         = is_ota_partition(p_running_partition)
               ? (int32_t)(p_running_partition->subtype - ESP_PARTITION_SUBTYPE_APP_OTA_MIN)
               : -1;
 
-    int32_t       active_otadata               = bootloader_common_get_active_otadata(otadata);
-    const int32_t bootloader_selected_ota_slot = (-1 != active_otadata) ? esp_ota_calc_slot_from_seq(
-                                                     otadata[active_otadata].ota_seq,
-                                                     ota_app_count)
-                                                                        : -1;
+    int32_t active_otadata = bootloader_common_get_active_otadata(otadata);
+
+    int32_t bootloader_selected_ota_slot = -1;
+    if (-1 != active_otadata)
+    {
+        bootloader_selected_ota_slot = esp_ota_calc_slot_from_seq(otadata[active_otadata].ota_seq, ota_app_count);
+    }
+
     if ((active_otadata != -1) && (running_partition_ota_slot >= 0)
         && (bootloader_selected_ota_slot != running_partition_ota_slot))
     {
@@ -552,15 +556,15 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
             LOG_WARN("No valid otadata entry maps to running OTA slot %" PRIi32, running_partition_ota_slot);
         }
     }
-    if (active_otadata != -1)
+    if (-1 != active_otadata)
     {
-        uint32_t seq = otadata[active_otadata].ota_seq;
-        uint32_t i   = 0;
-        while (seq > (SUB_TYPE_ID(subtype) + 1) % ota_app_count + i * ota_app_count)
+        const uint32_t seq = otadata[active_otadata].ota_seq;
+        uint32_t       i   = 0;
+        while (seq > (((SUB_TYPE_ID(subtype) + 1) % ota_app_count) + (i * ota_app_count)))
         {
             i++;
         }
-        int next_otadata                = (~active_otadata) & 1; // if 0 -> will be next 1. and if 1 -> will be next 0.
+        const int32_t next_otadata      = (~active_otadata) & 1; // if 0 -> will be next 1. and if 1 -> will be next 0.
         otadata[next_otadata].ota_state = set_new_state_otadata();
         return rewrite_ota_seq(
             otadata,
@@ -568,17 +572,14 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
             next_otadata,
             otadata_partition);
     }
-    else
-    {
-        /* Both OTA slots are invalid, probably because unformatted... */
-        int32_t next_otadata            = 0;
-        otadata[next_otadata].ota_state = set_new_state_otadata();
-        LOG_WARN(
-            "Both otadata entries are invalid, writing otadata[%" PRIi32 "] with ota_seq=%" PRIu32,
-            next_otadata,
-            (uint32_t)(SUB_TYPE_ID(subtype) + 1));
-        return rewrite_ota_seq(otadata, SUB_TYPE_ID(subtype) + 1, next_otadata, otadata_partition);
-    }
+    /* Both OTA slots are invalid, probably because unformatted... */
+    const int32_t next_otadata      = 0;
+    otadata[next_otadata].ota_state = set_new_state_otadata();
+    LOG_WARN(
+        "Both otadata entries are invalid, writing otadata[%" PRIi32 "] with ota_seq=%" PRIu32,
+        next_otadata,
+        (uint32_t)(SUB_TYPE_ID(subtype) + 1));
+    return rewrite_ota_seq(otadata, SUB_TYPE_ID(subtype) + 1, next_otadata, otadata_partition);
 }
 
 esp_err_t

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -46,7 +46,7 @@
 
 #define ESP_OTA_NUM_OTA_SLOTS (2U)
 
-#define SUB_TYPE_ID(i) (i & 0x0F)
+#define SUB_TYPE_ID(i) ((i)&0x0F)
 
 typedef struct ota_ops_entry_t
 {
@@ -97,7 +97,7 @@ read_otadata(esp_ota_select_entry_t* two_otadata)
 
     if (otadata_partition == NULL)
     {
-        ESP_LOGE(TAG, "not found otadata");
+        ESP_LOGE(TAG, "otadata partition not found");
         return NULL;
     }
 
@@ -112,15 +112,19 @@ read_otadata(esp_ota_select_entry_t* two_otadata)
         &ota_data_map);
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "mmap otadata filed. Err=0x%8x", err);
+        ESP_LOGE(TAG, "mmap otadata failed. Err=0x%8x", err);
         return NULL;
     }
-    else
+    if (NULL == result)
     {
-        memcpy(&two_otadata[0], result, sizeof(esp_ota_select_entry_t));
-        memcpy(&two_otadata[1], result + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+        ESP_LOGE(TAG, "mmap otadata returned NULL pointer");
         spi_flash_munmap(ota_data_map);
+        return NULL;
     }
+    const uint8_t* const p_otadata = (const uint8_t*)result;
+    memcpy(&two_otadata[0], p_otadata, sizeof(esp_ota_select_entry_t));
+    memcpy(&two_otadata[1], p_otadata + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+    spi_flash_munmap(ota_data_map);
     return otadata_partition;
 }
 
@@ -586,6 +590,17 @@ esp_err_t
 esp_ota_set_boot_partition_patched(const esp_partition_t* partition)
 {
     if (partition == NULL)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Only FACTORY or OTA app partitions are valid boot targets. Reject other APP subtypes
+     * (e.g. TEST or unrelated APP subtypes) to avoid corrupting otadata. */
+    if (partition->type != ESP_PARTITION_TYPE_APP)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if ((partition->subtype != ESP_PARTITION_SUBTYPE_APP_FACTORY) && (!is_ota_partition(partition)))
     {
         return ESP_ERR_INVALID_ARG;
     }

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -103,7 +103,7 @@ read_otadata(esp_ota_select_entry_t* two_otadata)
 
     spi_flash_mmap_handle_t ota_data_map;
     const void*             result = NULL;
-    esp_err_t               err    = esp_partition_mmap(
+    const esp_err_t         err    = esp_partition_mmap(
         otadata_partition,
         0,
         otadata_partition->size,
@@ -112,7 +112,7 @@ read_otadata(esp_ota_select_entry_t* two_otadata)
         &ota_data_map);
     if (err != ESP_OK)
     {
-        ESP_LOGE(TAG, "mmap otadata failed. Err=0x%8x", err);
+        ESP_LOGE(TAG, "mmap otadata failed. Err=%" PRId32, err);
         return NULL;
     }
     if (NULL == result)

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -46,6 +46,8 @@
 
 #define ESP_OTA_NUM_OTA_SLOTS (2U)
 
+#define SUB_TYPE_ID(i) (i & 0x0F)
+
 typedef struct ota_ops_entry_t
 {
     uint32_t               handle;
@@ -66,12 +68,85 @@ static uint32_t IRAM_ATTR s_ota_ops_last_handle = 0;
 const static char TAG[] = "esp_ota_ops";
 
 /* Return true if this is an OTA app partition */
-bool
-esp_ota_is_ota_partition(const esp_partition_t* p)
+static bool
+is_ota_partition(const esp_partition_t* p)
 {
     return (
         (NULL != p) && (ESP_PARTITION_TYPE_APP == p->type) && (p->subtype >= ESP_PARTITION_SUBTYPE_APP_OTA_0)
         && (p->subtype < ESP_PARTITION_SUBTYPE_APP_OTA_MAX));
+}
+
+bool
+esp_ota_is_ota_partition(const esp_partition_t* p)
+{
+    return is_ota_partition(p);
+}
+
+// Read otadata partition and fill array from two otadata structures.
+// Also return pointer to otadata info partition.
+static const esp_partition_t*
+read_otadata(esp_ota_select_entry_t* two_otadata)
+{
+    const esp_partition_t* otadata_partition = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA,
+        ESP_PARTITION_SUBTYPE_DATA_OTA,
+        NULL);
+
+    if (otadata_partition == NULL)
+    {
+        ESP_LOGE(TAG, "not found otadata");
+        return NULL;
+    }
+
+    spi_flash_mmap_handle_t ota_data_map;
+    const void*             result = NULL;
+    esp_err_t               err    = esp_partition_mmap(
+        otadata_partition,
+        0,
+        otadata_partition->size,
+        SPI_FLASH_MMAP_DATA,
+        &result,
+        &ota_data_map);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "mmap otadata filed. Err=0x%8x", err);
+        return NULL;
+    }
+    else
+    {
+        memcpy(&two_otadata[0], result, sizeof(esp_ota_select_entry_t));
+        memcpy(&two_otadata[1], result + SPI_FLASH_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+        spi_flash_munmap(ota_data_map);
+    }
+    return otadata_partition;
+}
+
+static esp_err_t
+image_validate(const esp_partition_t* partition, esp_image_load_mode_t load_mode)
+{
+    esp_image_metadata_t      data;
+    const esp_partition_pos_t part_pos = {
+        .offset = partition->address,
+        .size   = partition->size,
+    };
+
+    if (esp_image_verify(load_mode, &part_pos, &data) != ESP_OK)
+    {
+        return ESP_ERR_OTA_VALIDATE_FAILED;
+    }
+
+    return ESP_OK;
+}
+
+static esp_ota_img_states_t
+set_new_state_otadata(void)
+{
+#ifdef CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+    ESP_LOGD(TAG, "Monitoring the first boot of the app is enabled.");
+    return ESP_OTA_IMG_NEW;
+#else
+    return ESP_OTA_IMG_UNDEFINED;
+#endif
 }
 
 esp_err_t
@@ -93,7 +168,7 @@ esp_ota_begin_patched(
         return ESP_ERR_NOT_FOUND;
     }
 
-    if (!esp_ota_is_ota_partition(p_partition_verified))
+    if (!is_ota_partition(p_partition_verified))
     {
         return ESP_ERR_INVALID_ARG;
     }
@@ -106,7 +181,7 @@ esp_ota_begin_patched(
 
 #ifdef CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
     esp_ota_img_states_t ota_state_running_part = ESP_OTA_IMG_UNDEFINED;
-    if ((ESP_OK == esp_ota_get_state_partition(p_running_partition, &ota_state_running_part))
+    if ((ESP_OK == esp_ota_get_state_partition_patched(p_running_partition, &ota_state_running_part))
         && (ESP_OTA_IMG_PENDING_VERIFY == ota_state_running_part))
     {
         LOG_ERR("Running app has not confirmed state (ESP_OTA_IMG_PENDING_VERIFY)");
@@ -321,6 +396,35 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
     return ret;
 }
 
+static esp_err_t
+rewrite_ota_seq(
+    esp_ota_select_entry_t* two_otadata,
+    uint32_t                seq,
+    uint8_t                 sec_id,
+    const esp_partition_t*  ota_data_partition)
+{
+    if (two_otadata == NULL || sec_id > 1)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    two_otadata[sec_id].ota_seq = seq;
+    two_otadata[sec_id].crc     = bootloader_common_ota_select_crc(&two_otadata[sec_id]);
+    esp_err_t ret = esp_partition_erase_range(ota_data_partition, sec_id * SPI_FLASH_SEC_SIZE, SPI_FLASH_SEC_SIZE);
+    if (ret != ESP_OK)
+    {
+        return ret;
+    }
+    else
+    {
+        return esp_partition_write(
+            ota_data_partition,
+            SPI_FLASH_SEC_SIZE * sec_id,
+            &two_otadata[sec_id],
+            sizeof(esp_ota_select_entry_t));
+    }
+}
+
 static uint8_t
 get_ota_partition_count(void)
 {
@@ -333,6 +437,128 @@ get_ota_partition_count(void)
         ota_app_count++;
     }
     return ota_app_count;
+}
+
+static esp_err_t
+esp_rewrite_ota_data(esp_partition_subtype_t subtype)
+{
+    esp_ota_select_entry_t otadata[2];
+    const esp_partition_t* otadata_partition = read_otadata(otadata);
+    if (otadata_partition == NULL)
+    {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    int ota_app_count = get_ota_partition_count();
+    if (SUB_TYPE_ID(subtype) >= ota_app_count)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // esp32_idf use two sector for store information about which partition is running
+    // it defined the two sector as ota data partition,two structure esp_ota_select_entry_t is saved in the two sector
+    // named data in first sector as otadata[0], second sector data as otadata[1]
+    // e.g.
+    // if otadata[0].ota_seq == otadata[1].ota_seq == 0xFFFFFFFF,means ota info partition is in init status
+    // so it will boot factory application(if there is),if there's no factory application,it will boot ota[0]
+    // application if otadata[0].ota_seq != 0 and otadata[1].ota_seq != 0,it will choose a max seq ,and get value of
+    // max_seq%max_ota_app_number and boot a subtype (mask 0x0F) value is (max_seq - 1)%max_ota_app_number,so if want
+    // switch to run ota[x],can use next formulas. for example, if otadata[0].ota_seq = 4, otadata[1].ota_seq = 5, and
+    // there are 8 ota application, current running is (5-1)%8 = 4,running ota[4],so if we want to switch to run ota[7],
+    // we should add otadata[0].ota_seq (is 4) to 4 ,(8-1)%8=7,then it will boot ota[7]
+    // if      A=(B - C)%D
+    // then    B=(A + C)%D + D*n ,n= (0,1,2...)
+    // so current ota app sub type id is x , dest bin subtype is y,total ota app count is n
+    // seq will add (x + n*1 + 1 - seq)%n
+
+    int active_otadata = bootloader_common_get_active_otadata(otadata);
+    if (active_otadata != -1)
+    {
+        uint32_t seq = otadata[active_otadata].ota_seq;
+        uint32_t i   = 0;
+        while (seq > (SUB_TYPE_ID(subtype) + 1) % ota_app_count + i * ota_app_count)
+        {
+            i++;
+        }
+        int next_otadata                = (~active_otadata) & 1; // if 0 -> will be next 1. and if 1 -> will be next 0.
+        otadata[next_otadata].ota_state = set_new_state_otadata();
+        return rewrite_ota_seq(
+            otadata,
+            (SUB_TYPE_ID(subtype) + 1) % ota_app_count + i * ota_app_count,
+            next_otadata,
+            otadata_partition);
+    }
+    else
+    {
+        /* Both OTA slots are invalid, probably because unformatted... */
+        int next_otadata                = 0;
+        otadata[next_otadata].ota_state = set_new_state_otadata();
+        return rewrite_ota_seq(otadata, SUB_TYPE_ID(subtype) + 1, next_otadata, otadata_partition);
+    }
+}
+
+esp_err_t
+esp_ota_set_boot_partition_patched(const esp_partition_t* partition)
+{
+    if (partition == NULL)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (image_validate(partition, ESP_IMAGE_VERIFY) != ESP_OK)
+    {
+        return ESP_ERR_OTA_VALIDATE_FAILED;
+    }
+
+    // if set boot partition to factory bin ,just format ota info partition
+    if (partition->type == ESP_PARTITION_TYPE_APP)
+    {
+        if (partition->subtype == ESP_PARTITION_SUBTYPE_APP_FACTORY)
+        {
+            const esp_partition_t* find_partition = esp_partition_find_first(
+                ESP_PARTITION_TYPE_DATA,
+                ESP_PARTITION_SUBTYPE_DATA_OTA,
+                NULL);
+            if (find_partition != NULL)
+            {
+                return esp_partition_erase_range(find_partition, 0, find_partition->size);
+            }
+            else
+            {
+                return ESP_ERR_NOT_FOUND;
+            }
+        }
+        else
+        {
+#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+            esp_app_desc_t partition_app_desc;
+            esp_err_t      err = esp_ota_get_partition_description(partition, &partition_app_desc);
+            if (err != ESP_OK)
+            {
+                return err;
+            }
+
+            if (esp_efuse_check_secure_version(partition_app_desc.secure_version) == false)
+            {
+                ESP_LOGE(
+                    TAG,
+                    "This a new partition can not be booted due to a secure version is lower than stored in efuse. "
+                    "Partition will be erased.");
+                esp_err_t err = esp_partition_erase_range(partition, 0, partition->size);
+                if (err != ESP_OK)
+                {
+                    return err;
+                }
+                return ESP_ERR_OTA_SMALL_SEC_VER;
+            }
+#endif
+            return esp_rewrite_ota_data(partition->subtype);
+        }
+    }
+    else
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
 }
 
 static const esp_partition_t*
@@ -399,7 +625,7 @@ esp_ota_get_state_partition_patched(const esp_partition_t* const p_partition, es
         return ESP_ERR_INVALID_ARG;
     }
 
-    if (!esp_ota_is_ota_partition(p_partition))
+    if (!is_ota_partition(p_partition))
     {
         return ESP_ERR_NOT_SUPPORTED;
     }

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -456,7 +456,7 @@ get_ota_partition_count(void)
            != NULL)
     {
         const uint32_t max_ota_app_count = ESP_PARTITION_SUBTYPE_APP_OTA_MAX - ESP_PARTITION_SUBTYPE_APP_OTA_MIN;
-        assert(ota_app_count < max_ota_app_count && "must erase the partition before writing to it");
+        assert(ota_app_count < max_ota_app_count && "too many OTA app partitions: OTA subtype range overflow");
         ota_app_count++;
     }
     return ota_app_count;
@@ -489,7 +489,7 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
 {
     esp_ota_select_entry_t otadata[2];
     const esp_partition_t* otadata_partition = read_otadata(otadata);
-    if (otadata_partition == NULL)
+    if (NULL == otadata_partition)
     {
         return ESP_ERR_NOT_FOUND;
     }
@@ -520,7 +520,7 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
     // Keep the new sequence number higher than the current active sequence number,
     // while making it map to the requested OTA slot.
 
-    const esp_partition_t* p_running_partition = esp_ota_get_running_partition();
+    const esp_partition_t* const p_running_partition = esp_ota_get_running_partition();
 
     const int32_t running_partition_ota_slot
         = is_ota_partition(p_running_partition)
@@ -535,7 +535,7 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
         bootloader_selected_ota_slot = esp_ota_calc_slot_from_seq(otadata[active_otadata].ota_seq, ota_app_count);
     }
 
-    if ((active_otadata != -1) && (running_partition_ota_slot >= 0)
+    if ((-1 != active_otadata) && (running_partition_ota_slot >= 0)
         && (bootloader_selected_ota_slot != running_partition_ota_slot))
     {
         // The highest-sequence otadata entry can point to a damaged image. In this case
@@ -589,18 +589,18 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
 esp_err_t
 esp_ota_set_boot_partition_patched(const esp_partition_t* partition)
 {
-    if (partition == NULL)
+    if (NULL == partition)
     {
         return ESP_ERR_INVALID_ARG;
     }
 
     /* Only FACTORY or OTA app partitions are valid boot targets. Reject other APP subtypes
      * (e.g. TEST or unrelated APP subtypes) to avoid corrupting otadata. */
-    if (partition->type != ESP_PARTITION_TYPE_APP)
+    if (ESP_PARTITION_TYPE_APP != partition->type)
     {
         return ESP_ERR_INVALID_ARG;
     }
-    if ((partition->subtype != ESP_PARTITION_SUBTYPE_APP_FACTORY) && (!is_ota_partition(partition)))
+    if ((ESP_PARTITION_SUBTYPE_APP_FACTORY != partition->subtype) && (!is_ota_partition(partition)))
     {
         return ESP_ERR_INVALID_ARG;
     }
@@ -610,55 +610,43 @@ esp_ota_set_boot_partition_patched(const esp_partition_t* partition)
         return ESP_ERR_OTA_VALIDATE_FAILED;
     }
 
-    // if set boot partition to factory bin ,just format ota info partition
-    if (partition->type == ESP_PARTITION_TYPE_APP)
+    // if set boot partition to factory bin, just format ota info partition
+    if (partition->subtype == ESP_PARTITION_SUBTYPE_APP_FACTORY)
     {
-        if (partition->subtype == ESP_PARTITION_SUBTYPE_APP_FACTORY)
+        const esp_partition_t* find_partition = esp_partition_find_first(
+            ESP_PARTITION_TYPE_DATA,
+            ESP_PARTITION_SUBTYPE_DATA_OTA,
+            NULL);
+        if (NULL == find_partition)
         {
-            const esp_partition_t* find_partition = esp_partition_find_first(
-                ESP_PARTITION_TYPE_DATA,
-                ESP_PARTITION_SUBTYPE_DATA_OTA,
-                NULL);
-            if (find_partition != NULL)
-            {
-                return esp_partition_erase_range(find_partition, 0, find_partition->size);
-            }
-            else
-            {
-                return ESP_ERR_NOT_FOUND;
-            }
+            return ESP_ERR_NOT_FOUND;
         }
-        else
-        {
-#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
-            esp_app_desc_t partition_app_desc;
-            esp_err_t      err = esp_ota_get_partition_description(partition, &partition_app_desc);
-            if (err != ESP_OK)
-            {
-                return err;
-            }
+        return esp_partition_erase_range(find_partition, 0, find_partition->size);
+    }
 
-            if (esp_efuse_check_secure_version(partition_app_desc.secure_version) == false)
-            {
-                ESP_LOGE(
-                    TAG,
-                    "This a new partition can not be booted due to a secure version is lower than stored in efuse. "
-                    "Partition will be erased.");
-                esp_err_t err = esp_partition_erase_range(partition, 0, partition->size);
-                if (err != ESP_OK)
-                {
-                    return err;
-                }
-                return ESP_ERR_OTA_SMALL_SEC_VER;
-            }
-#endif
-            return esp_rewrite_ota_data(partition->subtype);
-        }
-    }
-    else
+#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+    esp_app_desc_t partition_app_desc = { 0 };
+    esp_err_t      err                = esp_ota_get_partition_description(partition, &partition_app_desc);
+    if (ESP_OK != err)
     {
-        return ESP_ERR_INVALID_ARG;
+        return err;
     }
+
+    if (!esp_efuse_check_secure_version(partition_app_desc.secure_version))
+    {
+        ESP_LOGE(
+            TAG,
+            "This a new partition can not be booted due to a secure version is lower than stored in efuse. "
+            "Partition will be erased.");
+        esp_err_t err = esp_partition_erase_range(partition, 0, partition->size);
+        if (ESP_OK != err)
+        {
+            return err;
+        }
+        return ESP_ERR_OTA_SMALL_SEC_VER;
+    }
+#endif
+    return esp_rewrite_ota_data(partition->subtype);
 }
 
 static const esp_partition_t*
@@ -669,7 +657,7 @@ read_two_ota_data(esp_ota_select_entry_t* const p_two_ota_data)
         ESP_PARTITION_SUBTYPE_DATA_OTA,
         NULL);
 
-    if (p_ota_data_partition == NULL)
+    if (NULL == p_ota_data_partition)
     {
         LOG_ERR("Partition with OTA data not found");
         return NULL;

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -567,13 +567,25 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
     {
         const uint32_t seq  = otadata[active_otadata].ota_seq;
         const uint32_t base = (SUB_TYPE_ID(subtype) + 1) % ota_app_count;
-        // Find the smallest i such that (base + i * ota_app_count) >= seq.
-        // Equivalent to the previous loop, but O(1) instead of O(seq / ota_app_count),
-        // which matters because ota_seq grows monotonically across OTA updates.
-        uint32_t i = 0;
-        if (seq > base)
+        // Find the smallest i such that (base + i * ota_app_count) > seq, i.e. produce a
+        // new ota_seq that is strictly greater than the currently active one. This is
+        // required so the bootloader's "highest ota_seq wins" rule unambiguously selects
+        // the newly written entry; if new_seq could equal seq, both otadata entries would
+        // share the same sequence number and the tiebreaker would be undefined.
+        //
+        // Done in O(1) instead of the original IDF O(seq / ota_app_count) loop, which
+        // matters because ota_seq grows monotonically across OTA updates.
+        uint32_t i;
+        if (seq < base)
         {
-            i = (seq - base + ota_app_count - 1) / ota_app_count;
+            i = 0; // base alone is already > seq
+        }
+        else
+        {
+            // Ceiling of (seq - base + 1) / ota_app_count, written so it also yields a
+            // strictly greater value when (seq - base) is an exact multiple of ota_app_count
+            // (including seq == base).
+            i = (seq - base + ota_app_count) / ota_app_count;
         }
         const int32_t next_otadata      = (~active_otadata) & 1; // if 0 -> will be next 1. and if 1 -> will be next 0.
         otadata[next_otadata].ota_state = set_new_state_otadata();

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -67,6 +67,9 @@ static uint32_t IRAM_ATTR s_ota_ops_last_handle = 0;
 
 const static char TAG[] = "esp_ota_ops";
 
+static int32_t
+esp_ota_calc_slot_from_seq(const uint32_t ota_seq, const uint8_t ota_app_count);
+
 /* Return true if this is an OTA app partition */
 static bool
 is_ota_partition(const esp_partition_t* p)
@@ -405,24 +408,40 @@ rewrite_ota_seq(
 {
     if (two_otadata == NULL || sec_id > 1)
     {
+        LOG_ERR("Invalid argument, two_otadata=%p, sec_id=%" PRIu8, two_otadata, sec_id);
         return ESP_ERR_INVALID_ARG;
     }
-
     two_otadata[sec_id].ota_seq = seq;
     two_otadata[sec_id].crc     = bootloader_common_ota_select_crc(&two_otadata[sec_id]);
+    LOG_INFO(
+        "Writing otadata[%" PRIu8 "]: ota_seq=%" PRIu32 ", ota_state=%" PRIu32 ", crc=0x%08" PRIx32,
+        sec_id,
+        two_otadata[sec_id].ota_seq,
+        two_otadata[sec_id].ota_state,
+        two_otadata[sec_id].crc);
+    LOG_DUMP_INFO(
+        (const uint8_t*)&two_otadata[sec_id],
+        sizeof(esp_ota_select_entry_t),
+        "otadata[%" PRIu8 "] to write at flash address 0x%08" PRIx32,
+        sec_id,
+        ota_data_partition->address + sec_id * SPI_FLASH_SEC_SIZE);
+
     esp_err_t ret = esp_partition_erase_range(ota_data_partition, sec_id * SPI_FLASH_SEC_SIZE, SPI_FLASH_SEC_SIZE);
     if (ret != ESP_OK)
     {
+        LOG_ERR("Failed to erase otadata[%" PRIu8 "], err=%" PRId32, sec_id, ret);
         return ret;
     }
-    else
+    ret = esp_partition_write(
+        ota_data_partition,
+        SPI_FLASH_SEC_SIZE * sec_id,
+        &two_otadata[sec_id],
+        sizeof(esp_ota_select_entry_t));
+    if (ret != ESP_OK)
     {
-        return esp_partition_write(
-            ota_data_partition,
-            SPI_FLASH_SEC_SIZE * sec_id,
-            &two_otadata[sec_id],
-            sizeof(esp_ota_select_entry_t));
+        LOG_ERR("Failed to write otadata[%" PRIu8 "], err=%" PRId32, sec_id, ret);
     }
+    return ret;
 }
 
 static uint8_t
@@ -437,6 +456,28 @@ get_ota_partition_count(void)
         ota_app_count++;
     }
     return ota_app_count;
+}
+
+static int32_t
+find_otadata_idx_for_ota_slot(
+    const esp_ota_select_entry_t* const otadata,
+    const int32_t                       ota_slot,
+    const uint8_t                       ota_app_count)
+{
+    if (ota_slot < 0)
+    {
+        return -1;
+    }
+
+    for (uint32_t i = 0; i < ESP_OTA_NUM_OTA_SLOTS; ++i)
+    {
+        if ((ota_slot == esp_ota_calc_slot_from_seq(otadata[i].ota_seq, ota_app_count))
+            && (otadata[i].crc == bootloader_common_ota_select_crc(&otadata[i])))
+        {
+            return (int32_t)i;
+        }
+    }
+    return -1;
 }
 
 static esp_err_t
@@ -471,7 +512,46 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
     // so current ota app sub type id is x , dest bin subtype is y,total ota app count is n
     // seq will add (x + n*1 + 1 - seq)%n
 
-    int active_otadata = bootloader_common_get_active_otadata(otadata);
+    // The bootloader maps ota_seq to an OTA slot as (ota_seq - 1) % ota_app_count.
+    // Keep the new sequence number higher than the current active sequence number,
+    // while making it map to the requested OTA slot.
+
+    const esp_partition_t* p_running_partition = esp_ota_get_running_partition();
+    const int32_t          running_partition_ota_slot
+        = is_ota_partition(p_running_partition)
+              ? (int32_t)(p_running_partition->subtype - ESP_PARTITION_SUBTYPE_APP_OTA_MIN)
+              : -1;
+
+    int32_t       active_otadata               = bootloader_common_get_active_otadata(otadata);
+    const int32_t bootloader_selected_ota_slot = (-1 != active_otadata) ? esp_ota_calc_slot_from_seq(
+                                                     otadata[active_otadata].ota_seq,
+                                                     ota_app_count)
+                                                                        : -1;
+    if ((active_otadata != -1) && (running_partition_ota_slot >= 0)
+        && (bootloader_selected_ota_slot != running_partition_ota_slot))
+    {
+        // The highest-sequence otadata entry can point to a damaged image. In this case
+        // the bootloader skips it and falls back to another bootable partition, so preserve
+        // the otadata entry that actually describes the running image.
+        LOG_WARN(
+            "Bootloader selected OTA slot %" PRIi32 " using otadata[%" PRIi32 "], but running OTA slot is %" PRIi32,
+            bootloader_selected_ota_slot,
+            active_otadata,
+            running_partition_ota_slot);
+        const int32_t running_otadata = find_otadata_idx_for_ota_slot(
+            otadata,
+            running_partition_ota_slot,
+            ota_app_count);
+        if (-1 != running_otadata)
+        {
+            active_otadata = running_otadata;
+            LOG_INFO("Preserving running partition state from otadata[%" PRIi32 "]", active_otadata);
+        }
+        else
+        {
+            LOG_WARN("No valid otadata entry maps to running OTA slot %" PRIi32, running_partition_ota_slot);
+        }
+    }
     if (active_otadata != -1)
     {
         uint32_t seq = otadata[active_otadata].ota_seq;
@@ -491,8 +571,12 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
     else
     {
         /* Both OTA slots are invalid, probably because unformatted... */
-        int next_otadata                = 0;
+        int32_t next_otadata            = 0;
         otadata[next_otadata].ota_state = set_new_state_otadata();
+        LOG_WARN(
+            "Both otadata entries are invalid, writing otadata[%" PRIi32 "] with ota_seq=%" PRIu32,
+            next_otadata,
+            (uint32_t)(SUB_TYPE_ID(subtype) + 1));
         return rewrite_ota_seq(otadata, SUB_TYPE_ID(subtype) + 1, next_otadata, otadata_partition);
     }
 }
@@ -684,6 +768,11 @@ esp_ota_get_state_partition_patched(const esp_partition_t* const p_partition, es
                     actual_crc);
                 continue;
             }
+            LOG_INFO(
+                "### Found OTA slot %" PRIi32 " at idx %" PRIi32 ", ota_state=%" PRIu32,
+                req_ota_slot,
+                i,
+                ota_data[i].ota_state);
             return ESP_OK;
         }
     }

--- a/main/esp_ota_ops_patched.c
+++ b/main/esp_ota_ops_patched.c
@@ -475,8 +475,11 @@ find_otadata_idx_for_ota_slot(
 
     for (uint32_t i = 0; i < ESP_OTA_NUM_OTA_SLOTS; ++i)
     {
+        // Use the same validity rules as the bootloader: an entry is usable only if
+        // its CRC matches AND its ota_state is not INVALID/ABORTED. Otherwise we may
+        // "preserve" an entry the bootloader will never consider active.
         if ((ota_slot == esp_ota_calc_slot_from_seq(otadata[i].ota_seq, ota_app_count))
-            && (otadata[i].crc == bootloader_common_ota_select_crc(&otadata[i])))
+            && bootloader_common_ota_select_valid(&otadata[i]))
         {
             return (int32_t)i;
         }
@@ -562,19 +565,19 @@ esp_rewrite_ota_data(esp_partition_subtype_t subtype)
     }
     if (-1 != active_otadata)
     {
-        const uint32_t seq = otadata[active_otadata].ota_seq;
-        uint32_t       i   = 0;
-        while (seq > (((SUB_TYPE_ID(subtype) + 1) % ota_app_count) + (i * ota_app_count)))
+        const uint32_t seq  = otadata[active_otadata].ota_seq;
+        const uint32_t base = (SUB_TYPE_ID(subtype) + 1) % ota_app_count;
+        // Find the smallest i such that (base + i * ota_app_count) >= seq.
+        // Equivalent to the previous loop, but O(1) instead of O(seq / ota_app_count),
+        // which matters because ota_seq grows monotonically across OTA updates.
+        uint32_t i = 0;
+        if (seq > base)
         {
-            i++;
+            i = (seq - base + ota_app_count - 1) / ota_app_count;
         }
         const int32_t next_otadata      = (~active_otadata) & 1; // if 0 -> will be next 1. and if 1 -> will be next 0.
         otadata[next_otadata].ota_state = set_new_state_otadata();
-        return rewrite_ota_seq(
-            otadata,
-            (SUB_TYPE_ID(subtype) + 1) % ota_app_count + i * ota_app_count,
-            next_otadata,
-            otadata_partition);
+        return rewrite_ota_seq(otadata, base + i * ota_app_count, next_otadata, otadata_partition);
     }
     /* Both OTA slots are invalid, probably because unformatted... */
     const int32_t next_otadata      = 0;

--- a/main/esp_ota_ops_patched.h
+++ b/main/esp_ota_ops_patched.h
@@ -93,6 +93,9 @@ esp_ota_end_patched(const esp_ota_handle_t handle, esp_ota_sha256_digest_t* cons
 esp_err_t
 esp_ota_get_state_partition_patched(const esp_partition_t* const p_partition, esp_ota_img_states_t* const p_ota_state);
 
+esp_err_t
+esp_ota_set_boot_partition_patched(const esp_partition_t* partition);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -1533,7 +1533,7 @@ fw_update_do_actions(fw_update_error_message_info_t* const p_error_message_info)
     }
 
     LOG_INFO("esp_ota_set_boot_partition");
-    const esp_err_t err = esp_ota_set_boot_partition(g_ruuvi_flash_info.p_next_update_partition);
+    const esp_err_t err = esp_ota_set_boot_partition_patched(g_ruuvi_flash_info.p_next_update_partition);
     if (ESP_OK != err)
     {
         LOG_ERR_ESP(err, "%s failed", "esp_ota_set_boot_partition");

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -1652,7 +1652,7 @@ fw_update_task(void)
         const esp_err_t err = esp_ota_set_boot_partition_patched(g_ruuvi_flash_info.p_next_update_partition);
         if (ESP_OK != err)
         {
-            LOG_ERR_ESP(err, "%s failed", "esp_ota_set_boot_partition");
+            LOG_ERR_ESP(err, "%s failed", "esp_ota_set_boot_partition_patched");
             if (NULL == error_message_info.p_message)
             {
                 error_message_info.p_message = "Failed to switch boot partition";

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -1532,18 +1532,6 @@ fw_update_do_actions(fw_update_error_message_info_t* const p_error_message_info)
         return false;
     }
 
-    LOG_INFO("esp_ota_set_boot_partition");
-    const esp_err_t err = esp_ota_set_boot_partition_patched(g_ruuvi_flash_info.p_next_update_partition);
-    if (ESP_OK != err)
-    {
-        LOG_ERR_ESP(err, "%s failed", "esp_ota_set_boot_partition");
-        if (NULL == p_error_message_info->p_message)
-        {
-            p_error_message_info->p_message = "Failed to switch boot partition";
-        }
-        return false;
-    }
-
     g_ruuvi_flash_info.p_boot_partition = g_ruuvi_flash_info.p_next_update_partition;
     g_ruuvi_flash_info.is_ota0_active   = !g_ruuvi_flash_info.is_ota0_active;
 
@@ -1567,7 +1555,6 @@ fw_update_do_actions(fw_update_error_message_info_t* const p_error_message_info)
         fw_update_set_extra_info_for_status_json_update_failed_nrf52("Failed to update nRF52 firmware");
         return false;
     }
-    fw_update_set_extra_info_for_status_json_update_successful();
     return true;
 }
 
@@ -1648,7 +1635,7 @@ fw_update_task(void)
     const bool flag_wait_relaying_completed = true;
     gw_status_suspend_http_relaying(flag_wait_relaying_completed);
 
-    const bool flag_fw_update_successful = fw_update_do_actions(&error_message_info);
+    bool flag_fw_update_successful = fw_update_do_actions(&error_message_info);
 
     if (!flag_fw_update_successful)
     {
@@ -1658,6 +1645,21 @@ fw_update_task(void)
         g_update_progress_stage = FW_UPDATE_STAGE_4;
         fw_update_invalidate_all_next_partitions();
         fw_update_set_extra_info_for_status_json_update_failed(error_message_info.p_message);
+    }
+    else
+    {
+        LOG_INFO("Switch boot partition");
+        const esp_err_t err = esp_ota_set_boot_partition_patched(g_ruuvi_flash_info.p_next_update_partition);
+        if (ESP_OK != err)
+        {
+            LOG_ERR_ESP(err, "%s failed", "esp_ota_set_boot_partition");
+            if (NULL == error_message_info.p_message)
+            {
+                error_message_info.p_message = "Failed to switch boot partition";
+            }
+            flag_fw_update_successful = false;
+            fw_update_set_extra_info_for_status_json_update_failed(error_message_info.p_message);
+        }
     }
 
     const char* const p_reboot_reason_msg = fw_update_get_reboot_reason_msg(
@@ -1670,6 +1672,7 @@ fw_update_task(void)
     }
     else
     {
+        fw_update_set_extra_info_for_status_json_update_successful();
         switch (fw_updating_reason_get())
         {
             case FW_UPDATE_REASON_AUTO:

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -1532,9 +1532,6 @@ fw_update_do_actions(fw_update_error_message_info_t* const p_error_message_info)
         return false;
     }
 
-    g_ruuvi_flash_info.p_boot_partition = g_ruuvi_flash_info.p_next_update_partition;
-    g_ruuvi_flash_info.is_ota0_active   = !g_ruuvi_flash_info.is_ota0_active;
-
     fw_update_set_stage_nrf52_updating();
 
     LOG_INFO("nrf52fw_update_fw_if_necessary");
@@ -1672,6 +1669,9 @@ fw_update_task(void)
     }
     else
     {
+        g_ruuvi_flash_info.p_boot_partition = g_ruuvi_flash_info.p_next_update_partition;
+        g_ruuvi_flash_info.is_ota0_active   = !g_ruuvi_flash_info.is_ota0_active;
+
         fw_update_set_extra_info_for_status_json_update_successful();
         switch (fw_updating_reason_get())
         {

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -656,6 +656,13 @@ fw_update_get_current_fatfs_nrf52_partition_name(void)
     return p_flash_info->is_ota0_active ? GW_NRF_PARTITION : GW_NRF_PARTITION_2;
 }
 
+static const char*
+fw_update_get_inactive_fatfs_nrf52_partition_name(void)
+{
+    const ruuvi_flash_info_t* const p_flash_info = &g_ruuvi_flash_info;
+    return !p_flash_info->is_ota0_active ? GW_NRF_PARTITION : GW_NRF_PARTITION_2;
+}
+
 const char*
 fw_update_get_current_fatfs_gwui_partition_name(void)
 {
@@ -1536,7 +1543,7 @@ fw_update_do_actions(fw_update_error_message_info_t* const p_error_message_info)
 
     LOG_INFO("nrf52fw_update_fw_if_necessary");
     if (!nrf52fw_update_fw_if_necessary(
-            fw_update_get_current_fatfs_nrf52_partition_name(),
+            fw_update_get_inactive_fatfs_nrf52_partition_name(),
             &fw_update_nrf52fw_cb_progress,
             NULL,
             &fw_update_nrf52fw_cb_before_updating,

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -1662,6 +1662,12 @@ fw_update_task(void)
                 error_message_info.p_message = "Failed to switch boot partition";
             }
             flag_fw_update_successful = false;
+            // Mirror the cleanup done in the fw_update_do_actions() failure branch above:
+            // the next partition has been flashed but the boot switch failed, so invalidate
+            // it to avoid booting into a partition that the bootloader was never told to use,
+            // and reflect the failed finalization in the progress stage.
+            g_update_progress_stage = FW_UPDATE_STAGE_4;
+            fw_update_invalidate_all_next_partitions();
             fw_update_set_extra_info_for_status_json_update_failed(error_message_info.p_message);
         }
     }


### PR DESCRIPTION
## Fix otadata corruption after bootloader fallback from a failed firmware update (Issue #1280)

### Problem

After a failed firmware update, the bootloader may select an OTA partition from `otadata` (based on the highest valid `ota_seq`), fail to boot it because the image is invalid, and then fall back to another valid OTA partition. In this state, `esp_ota_set_boot_partition()` still chooses which `otadata` sector to overwrite based on `bootloader_common_get_active_otadata()` — i.e. the highest valid `ota_seq` — not the partition that is actually running.

**Example scenario:**

- `otadata[0]`: `ota_seq = 3`, state `PENDING_VERIFY`/`ABORTED`, maps to `ota_0`
- `otadata[1]`: `ota_seq = 2`, state `VALID`, maps to `ota_1`
- `ota_0` image is damaged
- Bootloader tries `ota_0`, fails, then boots valid `ota_1`

When a new update is started from `ota_1`, `esp_ota_set_boot_partition()` treats `otadata[0]` as active and overwrites `otadata[1]`. As a result, both `otadata` records point to `ota_0`, while the currently running `ota_1` no longer has an `otadata` record. The application then cannot determine the state of the running partition and reports it as `UNDEFINED`.

### Root cause

`esp_rewrite_ota_data()` derives the otadata entry to preserve from `bootloader_common_get_active_otadata()`. This function identifies the bootloader-selected entry (highest valid `ota_seq`), but not necessarily the entry for the partition that successfully booted after fallback.

### Fix

1. **Patch `esp_ota_set_boot_partition`** — copy the original ESP-IDF implementation into `esp_ota_ops_patched.c` so it can be modified safely.

2. **Detect bootloader fallback and preserve the correct otadata entry** — in `esp_rewrite_ota_data()`, compare the running partition's OTA slot with the bootloader-selected slot. If they differ (i.e. the bootloader fell back), find and preserve the otadata entry that corresponds to the actually running partition via a new helper `find_otadata_idx_for_ota_slot()`.

3. **Defer boot partition switch until after nRF52 update** — move `esp_ota_set_boot_partition_patched()` from `fw_update_do_actions()` to `fw_update_task()`, so the new ESP32 image is only selected after the paired nRF52 firmware update completes successfully.

4. **Handle boot partition switch failure** — if `esp_ota_set_boot_partition_patched()` fails, mark the firmware update as failed and report the failure in the status JSON.

### Changes

- **`main/esp_ota_ops_patched.c`**
  - Added `esp_ota_set_boot_partition_patched()` (based on upstream `esp_ota_set_boot_partition`)
  - Added `find_otadata_idx_for_ota_slot()` to locate the otadata entry for a given OTA slot
  - Modified `esp_rewrite_ota_data()` to detect bootloader fallback and preserve the running partition's otadata entry
  - Added diagnostic hex-dump logs for otadata entries in `rewrite_ota_seq()`
  - Added diagnostic log in `esp_ota_get_state_partition_patched()` when an OTA slot is not found
  - Refactored for const-correctness, Yoda conditions, and code clarity

- **`main/esp_ota_ops_patched.h`**
  - Added declaration for `esp_ota_set_boot_partition_patched()`

- **`main/fw_update.c`**
  - Switched from `esp_ota_set_boot_partition()` to `esp_ota_set_boot_partition_patched()`
  - Moved boot partition switch from `fw_update_do_actions()` to `fw_update_task()`, after `nrf52fw_update_fw_if_necessary()` succeeds
  - Added failure handling: set `flag_fw_update_successful = false` and call `fw_update_set_extra_info_for_status_json_update_failed()` when boot partition switch fails
  - Moved `fw_update_set_extra_info_for_status_json_update_successful()` to after boot partition switch succeeds
