### PR TITLE
Fix #1284: ci: Firmware built in GitHub Actions embeds a commit hash instead of the "git describe tag"

### DIFF
--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
+          fetch-tags: true
           submodules: recursive
 
       - name: Set up Python 3.8

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
+          fetch-tags: true
           submodules: recursive
 
       - name: Set up Python 3.8


### PR DESCRIPTION
## Summary

The `Build Firmware (dev)` and `Build Firmware (prod)` GitHub Actions
workflows produced firmware whose embedded `esp_app_desc.version` was just
the short commit hash (e.g. `58af0ca`) instead of the expected
tag-relative version produced by local builds
(e.g. `v1.17.1-48-g58af0ca8`).

This PR configures `actions/checkout` in both firmware workflows to fetch
the full git history and all tags, so `git describe --always --tags --dirty`
(used by the root `CMakeLists.txt` to populate `PROJECT_VER`) can resolve
the nearest reachable tag and compute the commit distance, matching the
behavior of local builds.

## Motivation

The embedded firmware version is surfaced in:

- the Web UI "About" page,
- HTTP/MQTT status payloads,
- OTA metadata (`esp_app_desc.version`),
- release artifacts and their filenames.

Showing only a 7-character commit hash makes it impossible to tell which
release a CI-built firmware is based on without manually mapping the hash
to a tag. It also breaks any downstream tooling that parses the
`vX.Y.Z-<n>-g<hash>` format.

## Root cause

`actions/checkout@v6` defaults to a shallow, tag-less checkout:

```text
fetch-depth: 1
fetch-tags: false
```

The build then runs:

```cmake
execute_process(
        COMMAND bash -c "git describe --always --tags --dirty"
        OUTPUT_VARIABLE PROJECT_VER
        OUTPUT_STRIP_TRAILING_WHITESPACE)
```

With no tags fetched and no ancestor commits available, `git describe
--tags` finds no reachable tag and, because of `--always`, falls back to
the abbreviated commit hash.

Full analysis, log excerpts and a local reproduction are documented in
[`docs/issues/ci-firmware-version-uses-commit-hash-instead-of-git-tag.md`](../docs/issues/ci-firmware-version-uses-commit-hash-instead-of-git-tag.md).

## Changes

- `.github/workflows/build-fw-dev.yml`: add `fetch-depth: 0` and
  `fetch-tags: true` to the `Check out code` step.
- `.github/workflows/build-fw-prod.yml`: same change.
- `docs/issues/ci-firmware-version-uses-commit-hash-instead-of-git-tag.md`:
  new file describing the bug, root cause and fix.

Diff applied to both firmware workflows:

```diff
       - name: Check out code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
+          fetch-tags: true
           submodules: recursive
```

### Why both options

- `fetch-depth: 0` brings in the full commit history so `git describe`
  can walk back to the most recent reachable tag and compute the
  commit-count `<n>`.
- `fetch-tags: true` makes the intent explicit and remains correct even
  if the default behavior of `actions/checkout` regarding tags changes
  in a future major version.

## Scope / non-goals

- Only the two firmware build workflows are changed. The
  `SonarCloud Analysis` workflow already uses `fetch-depth: 0`, and the
  other workflows (clang-format, JSON schemas, Google tests, mbedTLS,
  nvs_flash) do not depend on the firmware version string.
- No source code, `CMakeLists.txt`, `sdkconfig` or build flag is changed.
  The fix is purely a CI configuration change.

## How to verify

1. Trigger `Build Firmware (dev)` for any commit that is not directly
   on a tag.
2. In the `Run build` step look for these lines:

    ```text
    Project version: v1.17.1-<n>-g<hash>
    -- App "ruuvi_gateway_esp" version: v1.17.1-<n>-g<hash>
    ```

    Before the fix they read just the short hash, e.g. `58af0ca`.

3. Flash the resulting `ruuvi_gateway_esp.bin` (or read it back with
   `esptool.py`) and confirm `esp_app_desc.version` matches the
   `git describe` output shown in the build log and in the Web UI's
   "About" page.

### Local reproduction of the original failure (no CI required)

```bash
git clone --depth=1 --no-tags https://github.com/ruuvi/ruuvi.gateway_esp.c shallow
cd shallow
git describe --always --tags --dirty   # -> short commit hash (buggy)
git fetch --prune --unshallow --tags
git describe --always --tags --dirty   # -> vX.Y.Z-<n>-g<hash> (fixed)
```

## Risk and rollback

- Risk: minimal. The change only increases the amount of git data
  fetched during CI. Build time grows by a few seconds for the
  additional history and tags.
- Rollback: revert the two-line addition in each workflow file.

