### PR TITLE
Fix #1172: Memory leak on the failure path of fw_update_ota_partition

### DIFF
--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -1116,7 +1116,10 @@ fw_update_ota(const char* const p_url, fw_update_error_message_info_t* const p_e
     if (!fw_update_ota_partition(p_partition, out_handle, p_url))
     {
         LOG_ERR("Failed to download firmware image");
-        p_error_message_info->p_message = "Firmware image download ended with an error";
+        p_error_message_info->p_message        = "Firmware image download ended with an error";
+        esp_ota_sha256_digest_t pub_key_digest = { 0 };
+        // esp_ota_end_patched removes the OTA ops entry even if validation fails.
+        (void)esp_ota_end_patched(out_handle, &pub_key_digest);
         return false;
     }
 


### PR DESCRIPTION
# Fix #1172: Memory leak on the failure path of fw_update_ota_partition
Related issue: #1163 

## Problem

In `fw_update_ota()`, after `esp_ota_begin_patched()` successfully allocates an
`ota_ops_entry_t` and inserts it into the global OTA ops linked list, a
subsequent failure in `fw_update_ota_partition()` (firmware download/write error)
causes an early return **without** calling `esp_ota_end_patched()` to
finalize and free the OTA handle.

This leaks the `ota_ops_entry_t` allocation and leaves a stale entry in the
global list. Over repeated failed update attempts (e.g. unstable network), this
can exhaust memory.

## Root Cause

`esp_ota_begin_patched()` allocates and list-inserts the OTA ops entry.
`esp_ota_end_patched()` is the only function that removes and frees it.
The failure path after a failed `fw_update_ota_partition()` call was missing the
`esp_ota_end_patched()` cleanup — it logged the error, set the error message,
and returned `false` immediately.

## Fix

Call `esp_ota_end_patched(out_handle, &pub_key_digest)` on the failure path
before returning. The return value is intentionally ignored (cast to `void`)
because this is a cleanup/abort path — `esp_ota_end_patched()` will report
validation errors (incomplete image), but it **unconditionally** removes the
entry from the global list and frees its memory regardless of the return code.

### Changed file

- **`main/fw_update.c`** — added 3 lines: declare a dummy `pub_key_digest`,
  call `esp_ota_end_patched()` to release the OTA handle on the download
  failure path.

## Verification

- Firmware builds successfully with `idf.py build`.
- Code reviewed against `esp_ota_end_patched()` implementation
  (`main/esp_ota_ops_patched.c`): confirmed that `LIST_REMOVE()` + `os_free()`
  execute unconditionally after the handle is found, regardless of
  validation/write errors.
