### PR TITLE
feat(nrf52fw): #1303 support mounting fatfs_nrf52 partition as raw read-only FAT

### DIFF
--- a/main/flashfatfs.c
+++ b/main/flashfatfs.c
@@ -31,19 +31,27 @@ struct flash_fat_fs_t
 {
     char*       mount_point;
     wl_handle_t wl_handle;
+    char*       partition_label;
+    bool        flag_use_raw_flash;
 };
 
 const flash_fat_fs_t*
-flashfatfs_mount(const char* mount_point, const char* partition_label, const flash_fat_fs_num_files_t max_files)
+flashfatfs_mount(
+    const char*                    mount_point,
+    const char*                    partition_label,
+    const flash_fat_fs_num_files_t max_files,
+    const bool                     flag_use_raw_fatfs)
 {
     const char* mount_point_prefix = "";
 #if RUUVI_TESTS_NRF52FW || RUUVI_TESTS_FLASHFATFS
     mount_point_prefix = (mount_point[0] == '/') ? "." : "";
 #endif
-    size_t mount_point_buf_size = strlen(mount_point_prefix) + strlen(mount_point) + 1;
+    size_t mount_point_buf_size     = strlen(mount_point_prefix) + strlen(mount_point) + 1;
+    size_t partition_label_buf_size = strlen(partition_label) + 1;
 
     LOG_INFO("Mount partition '%s' to the mount point %s", partition_label, mount_point);
-    flash_fat_fs_t* p_obj = os_calloc(1, sizeof(*p_obj) + mount_point_buf_size);
+
+    flash_fat_fs_t* p_obj = os_calloc(1, sizeof(*p_obj) + mount_point_buf_size + partition_label_buf_size);
     if (NULL == p_obj)
     {
         LOG_ERR("Can't allocate memory");
@@ -51,8 +59,35 @@ flashfatfs_mount(const char* mount_point, const char* partition_label, const fla
     }
     p_obj->mount_point = (void*)(p_obj + 1);
     snprintf(p_obj->mount_point, mount_point_buf_size, "%s%s", mount_point_prefix, mount_point);
+    p_obj->partition_label = p_obj->mount_point + mount_point_buf_size;
+    snprintf(p_obj->partition_label, partition_label_buf_size, "%s", partition_label);
+    p_obj->flag_use_raw_flash = false;
 
-    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+    if (flag_use_raw_fatfs)
+    {
+        const esp_vfs_fat_mount_config_t mount_config_fat = {
+            .format_if_mount_failed = false,
+            .max_files              = max_files,
+            .allocation_unit_size   = 512U,
+        };
+
+        LOG_INFO(
+            "Try to mount partition '%s' as FATFS (raw flash) to the mount point %s",
+            partition_label,
+            mount_point);
+        const esp_err_t err = esp_vfs_fat_rawflash_mount(p_obj->mount_point, p_obj->partition_label, &mount_config_fat);
+        if (ESP_OK == err)
+        {
+            p_obj->flag_use_raw_flash = true;
+            LOG_INFO("Partition '%s' mounted successfully to %s as FATFS on raw flash", partition_label, mount_point);
+            return p_obj;
+        }
+        LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_rawflash_mount");
+        LOG_WARN("Try to mount partition as SPI-Flash FATFS");
+    }
+
+    LOG_INFO("Mount partition '%s' as FATFS (SPI-Flash) to the mount point %s", partition_label, mount_point);
+    const esp_vfs_fat_sdmmc_mount_config_t mount_config = {
         .format_if_mount_failed = false,
         .max_files              = max_files,
         .allocation_unit_size   = 512U,
@@ -64,7 +99,7 @@ flashfatfs_mount(const char* mount_point, const char* partition_label, const fla
         os_free(p_obj);
         return NULL;
     }
-    LOG_INFO("Partition '%s' mounted successfully to %s", partition_label, mount_point);
+    LOG_INFO("Partition '%s' mounted successfully to %s as FATFS on SPI-Flash", partition_label, mount_point);
     return p_obj;
 }
 
@@ -73,12 +108,27 @@ flashfatfs_unmount(const flash_fat_fs_t** pp_ffs)
 {
     const flash_fat_fs_t* p_ffs = *pp_ffs;
     LOG_INFO("Unmount %s", p_ffs->mount_point);
-    const esp_err_t err = esp_vfs_fat_spiflash_unmount(p_ffs->mount_point, p_ffs->wl_handle);
+    esp_err_t err = ESP_FAIL;
+    if (p_ffs->flag_use_raw_flash)
+    {
+        err = esp_vfs_fat_rawflash_unmount(p_ffs->mount_point, p_ffs->partition_label);
+        if (ESP_OK != err)
+        {
+            LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_rawflash_unmount");
+        }
+    }
+    else
+    {
+        err = esp_vfs_fat_spiflash_unmount(p_ffs->mount_point, p_ffs->wl_handle);
+        if (ESP_OK != err)
+        {
+            LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_spiflash_unmount");
+        }
+    }
     os_free(p_ffs);
     *pp_ffs = NULL;
     if (ESP_OK != err)
     {
-        LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_spiflash_unmount");
         return false;
     }
     return true;

--- a/main/flashfatfs.h
+++ b/main/flashfatfs.h
@@ -33,7 +33,11 @@ typedef struct flash_fat_fs_t flash_fat_fs_t;
 typedef int flash_fat_fs_num_files_t;
 
 const flash_fat_fs_t*
-flashfatfs_mount(const char* mount_point, const char* partition_label, const flash_fat_fs_num_files_t max_files);
+flashfatfs_mount(
+    const char*                    mount_point,
+    const char*                    partition_label,
+    const flash_fat_fs_num_files_t max_files,
+    const bool                     flag_use_raw_fatfs);
 
 bool
 flashfatfs_unmount(const flash_fat_fs_t** pp_ffs);

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -860,6 +860,7 @@ fw_update_do_actions(void)
     LOG_INFO("nrf52fw_update_fw_if_necessary");
     if (!nrf52fw_update_fw_if_necessary(
             fw_update_get_current_fatfs_nrf52_partition_name(),
+            true,
             &update_fw_cb_params,
             NULL,
             false))

--- a/main/http_server_cb.c
+++ b/main/http_server_cb.c
@@ -55,7 +55,7 @@ http_server_cb_init(const char* const p_fatfs_gwui_partition_name)
     const char*                    mount_point   = "/fs_gwui";
     const flash_fat_fs_num_files_t max_num_files = 4U;
 
-    gp_ffs_gwui = flashfatfs_mount(mount_point, p_fatfs_gwui_partition_name, max_num_files);
+    gp_ffs_gwui = flashfatfs_mount(mount_point, p_fatfs_gwui_partition_name, max_num_files, false);
     if (NULL == gp_ffs_gwui)
     {
         LOG_ERR("flashfatfs_mount: failed to mount partition '%s'", GW_GWUI_PARTITION);

--- a/main/nrf52fw.c
+++ b/main/nrf52fw.c
@@ -839,12 +839,17 @@ NRF52FW_STATIC
 bool
 nrf52fw_update_fw_step1(
     const char* const                          p_fatfs_nrf52_partition_name,
+    const bool                                 flag_try_using_raw_fatfs,
     const nrf52fw_update_fw_cb_params_t* const p_cb_params,
     ruuvi_nrf52_fw_ver_t* const                p_nrf52_fw_ver)
 {
     const flash_fat_fs_num_files_t max_num_files = 1;
 
-    const flash_fat_fs_t* p_ffs = flashfatfs_mount("/fs_nrf52", p_fatfs_nrf52_partition_name, max_num_files);
+    const flash_fat_fs_t* p_ffs = flashfatfs_mount(
+        "/fs_nrf52",
+        p_fatfs_nrf52_partition_name,
+        max_num_files,
+        flag_try_using_raw_fatfs);
     if (NULL == p_ffs)
     {
         LOG_ERR("%s failed", "flashfatfs_mount");
@@ -859,6 +864,7 @@ NRF52FW_STATIC
 bool
 nrf52fw_update_fw_step0(
     const char* const                          p_fatfs_nrf52_partition_name,
+    const bool                                 flag_try_using_raw_fatfs,
     const nrf52fw_update_fw_cb_params_t* const p_cb_params,
     ruuvi_nrf52_fw_ver_t* const                p_nrf52_fw_ver,
     const bool                                 flag_run_fw_after_update)
@@ -869,7 +875,11 @@ nrf52fw_update_fw_step0(
         return false;
     }
 
-    bool result = nrf52fw_update_fw_step1(p_fatfs_nrf52_partition_name, p_cb_params, p_nrf52_fw_ver);
+    bool result = nrf52fw_update_fw_step1(
+        p_fatfs_nrf52_partition_name,
+        flag_try_using_raw_fatfs,
+        p_cb_params,
+        p_nrf52_fw_ver);
 
     if (result && flag_run_fw_after_update)
     {
@@ -902,6 +912,7 @@ nrf52fw_hw_reset_nrf52(const bool flag_reset)
 bool
 nrf52fw_update_fw_if_necessary(
     const char* const                          p_fatfs_nrf52_partition_name,
+    const bool                                 flag_try_using_raw_fatfs,
     const nrf52fw_update_fw_cb_params_t* const p_cb_params,
     ruuvi_nrf52_fw_ver_t* const                p_nrf52_fw_ver,
     const bool                                 flag_run_fw_after_update)
@@ -916,6 +927,7 @@ nrf52fw_update_fw_if_necessary(
 
     const bool res = nrf52fw_update_fw_step0(
         p_fatfs_nrf52_partition_name,
+        flag_try_using_raw_fatfs,
         p_cb_params,
         p_nrf52_fw_ver,
         flag_run_fw_after_update);

--- a/main/nrf52fw.h
+++ b/main/nrf52fw.h
@@ -92,6 +92,7 @@ nrf52fw_hw_reset_nrf52(const bool flag_reset);
 bool
 nrf52fw_update_fw_if_necessary(
     const char* const                          p_fatfs_nrf52_partition_name,
+    const bool                                 flag_try_using_raw_fatfs,
     const nrf52fw_update_fw_cb_params_t* const p_cb_params,
     ruuvi_nrf52_fw_ver_t* const                p_nrf52_fw_ver,
     const bool                                 flag_run_fw_after_update);

--- a/main/ruuvi_gateway_main.c
+++ b/main/ruuvi_gateway_main.c
@@ -480,6 +480,7 @@ main_task_init(void)
     };
     if (!nrf52fw_update_fw_if_necessary(
             fw_update_get_current_fatfs_nrf52_partition_name(),
+            false,
             &update_fw_cb_params,
             &nrf52_fw_ver,
             true))

--- a/tests/test_flashfatfs/include/esp_vfs_fat.h
+++ b/tests/test_flashfatfs/include/esp_vfs_fat.h
@@ -195,7 +195,6 @@ esp_vfs_fat_spiflash_mount(
 esp_err_t
 esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle);
 
-#if 0
 /**
  * @brief Convenience function to initialize read-only FAT filesystem and register it in VFS
  *
@@ -219,12 +218,12 @@ esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle);
  *      - ESP_FAIL if partition can not be mounted
  *      - other error codes from SPI flash driver, or FATFS drivers
  */
-esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
-    const char* partition_label,
+esp_err_t
+esp_vfs_fat_rawflash_mount(
+    const char*                       base_path,
+    const char*                       partition_label,
     const esp_vfs_fat_mount_config_t* mount_config);
-#endif
 
-#if 0
 /**
  * @brief Unmount FAT filesystem and release resources acquired using esp_vfs_fat_rawflash_mount
  *
@@ -235,8 +234,8 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_spiflash_mount hasn't been called
  */
- esp_err_t esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label);
-#endif
+esp_err_t
+esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label);
 
 #ifdef __cplusplus
 }

--- a/tests/test_flashfatfs/test_flashfatfs.cpp
+++ b/tests/test_flashfatfs/test_flashfatfs.cpp
@@ -34,11 +34,13 @@ class FlashFatFs_VFS_FAT_MountInfo
 public:
     string                     base_path;
     string                     partition_label;
-    esp_vfs_fat_mount_config_t mount_config = {};
-    bool                       flag_mounted = false;
-    esp_err_t                  mount_err    = ESP_OK;
-    esp_err_t                  unmount_err  = ESP_OK;
-    wl_handle_t                wl_handle    = 0;
+    esp_vfs_fat_mount_config_t mount_config    = {};
+    bool                       flag_mounted    = false;
+    esp_err_t                  mount_err       = ESP_OK;
+    esp_err_t                  unmount_err     = ESP_OK;
+    wl_handle_t                wl_handle       = 0;
+    esp_err_t                  mount_raw_err   = ESP_OK;
+    esp_err_t                  unmount_raw_err = ESP_OK;
 };
 
 class MemAllocTrace
@@ -129,12 +131,14 @@ protected:
         esp_log_wrapper_init();
         g_pTestClass = this;
 
-        this->m_malloc_cnt              = 0;
-        this->m_malloc_fail_on_cnt      = 0;
-        this->m_mount_info.flag_mounted = false;
-        this->m_mount_info.mount_err    = ESP_OK;
-        this->m_mount_info.unmount_err  = ESP_OK;
-        this->m_mount_info.wl_handle    = 0;
+        this->m_malloc_cnt                 = 0;
+        this->m_malloc_fail_on_cnt         = 0;
+        this->m_mount_info.flag_mounted    = false;
+        this->m_mount_info.mount_err       = ESP_OK;
+        this->m_mount_info.unmount_err     = ESP_OK;
+        this->m_mount_info.wl_handle       = 0;
+        this->m_mount_info.mount_raw_err   = ESP_OK;
+        this->m_mount_info.unmount_raw_err = ESP_OK;
     }
 
     void
@@ -241,8 +245,27 @@ esp_vfs_fat_spiflash_mount(
     g_pTestClass->m_mount_info.partition_label = string(partition_label);
     g_pTestClass->m_mount_info.mount_config    = *mount_config;
     *wl_handle                                 = g_pTestClass->m_mount_info.wl_handle;
-    g_pTestClass->m_mount_info.flag_mounted    = true;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
     return g_pTestClass->m_mount_info.mount_err;
+}
+
+esp_err_t
+esp_vfs_fat_rawflash_mount(
+    const char*                       base_path,
+    const char*                       partition_label,
+    const esp_vfs_fat_mount_config_t* mount_config)
+{
+    g_pTestClass->m_mount_info.base_path       = string(base_path);
+    g_pTestClass->m_mount_info.partition_label = string(partition_label);
+    g_pTestClass->m_mount_info.mount_config    = *mount_config;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_raw_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
+    return g_pTestClass->m_mount_info.mount_raw_err;
 }
 
 esp_err_t
@@ -253,6 +276,15 @@ esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle)
     assert(g_pTestClass->m_mount_info.wl_handle == wl_handle);
     g_pTestClass->m_mount_info.flag_mounted = false;
     return g_pTestClass->m_mount_info.unmount_err;
+}
+
+esp_err_t
+esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label)
+{
+    assert(nullptr != g_pTestClass);
+    assert(g_pTestClass->m_mount_info.flag_mounted);
+    g_pTestClass->m_mount_info.flag_mounted = false;
+    return g_pTestClass->m_mount_info.unmount_raw_err;
 }
 
 } // extern "C"
@@ -268,7 +300,7 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_rel_path) // NOLINT
     const int         max_files  = 1;
     this->m_mount_info.wl_handle = wl_handle;
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
 
     ASSERT_NE(nullptr, this->m_p_ffs);
     ASSERT_EQ(string("fs_nrf52"), string(this->m_p_ffs->mount_point));
@@ -284,7 +316,12 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_rel_path) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -296,7 +333,7 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_abs_path) // NOLINT
     const int         max_files  = 1;
     this->m_mount_info.wl_handle = wl_handle;
 
-    this->m_p_ffs = flashfatfs_mount("/fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("/fs_nrf52", GW_NRF_PARTITION, max_files, false);
 
     ASSERT_NE(nullptr, this->m_p_ffs);
     ASSERT_EQ(string("./fs_nrf52"), string(this->m_p_ffs->mount_point));
@@ -312,7 +349,12 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_abs_path) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -324,7 +366,7 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_unmount_failed) // NOLINT
     const int         max_files  = 1;
     this->m_mount_info.wl_handle = wl_handle;
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
 
     ASSERT_NE(nullptr, this->m_p_ffs);
 
@@ -333,7 +375,12 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_unmount_failed) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_unmount failed, err=262 (Unknown error 262)");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -344,7 +391,7 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_failed_no_mem) // NOLINT
 {
     const int max_files        = 1;
     this->m_malloc_fail_on_cnt = 1;
-    this->m_p_ffs              = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files);
+    this->m_p_ffs              = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files, false);
     ASSERT_EQ(nullptr, this->m_p_ffs);
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
@@ -357,10 +404,13 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_failed_on_spiflash_mount) // NOLINT
 {
     const int max_files          = 1;
     this->m_mount_info.mount_err = ESP_ERR_NOT_FOUND;
-    this->m_p_ffs                = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files);
+    this->m_p_ffs                = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files, false);
     ASSERT_EQ(nullptr, this->m_p_ffs);
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=261 (Unknown error 261)");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -385,7 +435,7 @@ TEST_F(TestFlashFatFs, flashfatfs_get_full_path_no_mount_point) // NOLINT
 TEST_F(TestFlashFatFs, flashfatfs_get_full_path_with_mount_point) // NOLINT
 {
     const char* mount_point = "/fs_nrf52";
-    this->m_p_ffs           = flashfatfs_mount(mount_point, GW_NRF_PARTITION, 1);
+    this->m_p_ffs           = flashfatfs_mount(mount_point, GW_NRF_PARTITION, 1, false);
     {
         const char* file_name = "abc";
         str_buf_t   path      = flashfatfs_get_full_path(this->m_p_ffs, file_name);
@@ -432,7 +482,7 @@ TEST_F(TestFlashFatFs, flashfatfs_open_ok) // NOLINT
         fclose(fd);
     }
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     file_descriptor_t fd = flashfatfs_open(this->m_p_ffs, test_file_name);
@@ -452,7 +502,12 @@ TEST_F(TestFlashFatFs, flashfatfs_open_ok) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -466,7 +521,7 @@ TEST_F(TestFlashFatFs, flashfatfs_open_failed) // NOLINT
 
     const char* test_file_name = "test1.txt";
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     file_descriptor_t fd = flashfatfs_open(this->m_p_ffs, test_file_name);
@@ -476,7 +531,12 @@ TEST_F(TestFlashFatFs, flashfatfs_open_failed) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't open: fs_nrf52/test1.txt");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -500,7 +560,7 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_ascii_ok) // NOLINT
         fclose(fd);
     }
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     const bool flag_use_binary_mode = false;
@@ -521,7 +581,12 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_ascii_ok) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -544,7 +609,7 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_binary_ok) // NOLINT
         fclose(fd);
     }
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     const bool flag_use_binary_mode = true;
@@ -565,7 +630,12 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_binary_ok) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -579,7 +649,7 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_failed) // NOLINT
 
     const char* test_file_name = "test1.txt";
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     const bool flag_use_binary_mode = false;
@@ -590,7 +660,12 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_failed) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't open: fs_nrf52/test1.txt");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -614,7 +689,7 @@ TEST_F(TestFlashFatFs, flashfatfs_stat_ok) // NOLINT
         fclose(fd);
     }
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     struct stat st = { 0 };
@@ -625,7 +700,12 @@ TEST_F(TestFlashFatFs, flashfatfs_stat_ok) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -639,7 +719,7 @@ TEST_F(TestFlashFatFs, flashfatfs_stat_failed) // NOLINT
 
     const char* test_file_name = "test1.txt";
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     struct stat st = { 0 };
@@ -649,7 +729,12 @@ TEST_F(TestFlashFatFs, flashfatfs_stat_failed) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -672,7 +757,7 @@ TEST_F(TestFlashFatFs, flashfatfs_get_file_size_ok) // NOLINT
         fclose(fd);
     }
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     size_t size = 0;
@@ -683,7 +768,12 @@ TEST_F(TestFlashFatFs, flashfatfs_get_file_size_ok) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -697,7 +787,7 @@ TEST_F(TestFlashFatFs, flashfatfs_get_file_size_failed) // NOLINT
 
     const char* test_file_name = "test1.txt";
 
-    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     size_t size = 0;
@@ -707,7 +797,272 @@ TEST_F(TestFlashFatFs, flashfatfs_get_file_size_failed) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_ok_rel_path) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, true);
+
+    ASSERT_NE(nullptr, this->m_p_ffs);
+    ASSERT_EQ(string("fs_nrf52"), string(this->m_p_ffs->mount_point));
+    ASSERT_TRUE(this->m_mount_info.flag_mounted);
+    ASSERT_EQ("fs_nrf52", this->m_mount_info.base_path);
+    ASSERT_EQ(GW_NRF_PARTITION, this->m_mount_info.partition_label);
+    ASSERT_FALSE(this->m_mount_info.mount_config.format_if_mount_failed);
+    ASSERT_EQ(max_files, this->m_mount_info.mount_config.max_files);
+    ASSERT_EQ(512U, this->m_mount_info.mount_config.allocation_unit_size);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on raw flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_ok_abs_path) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("/fs_nrf52", GW_NRF_PARTITION, max_files, true);
+
+    ASSERT_NE(nullptr, this->m_p_ffs);
+    ASSERT_EQ(string("./fs_nrf52"), string(this->m_p_ffs->mount_point));
+    ASSERT_TRUE(this->m_mount_info.flag_mounted);
+    ASSERT_EQ("./fs_nrf52", this->m_mount_info.base_path);
+    ASSERT_EQ(GW_NRF_PARTITION, this->m_mount_info.partition_label);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on raw flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount ./fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_fallback_to_spiflash_ok) // NOLINT
+{
+    const wl_handle_t wl_handle      = 25;
+    const int         max_files      = 1;
+    this->m_mount_info.wl_handle     = wl_handle;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, true);
+
+    ASSERT_NE(nullptr, this->m_p_ffs);
+    ASSERT_EQ(wl_handle, this->m_p_ffs->wl_handle);
+    ASSERT_TRUE(this->m_mount_info.flag_mounted);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_WARN, "Try to mount partition as SPI-Flash FATFS");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_fallback_to_spiflash_failed) // NOLINT
+{
+    const int max_files              = 1;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+    this->m_mount_info.mount_err     = ESP_ERR_NOT_FOUND;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, true);
+    ASSERT_EQ(nullptr, this->m_p_ffs);
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_WARN, "Try to mount partition as SPI-Flash FATFS");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=261 (Unknown error 261)");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_ok_unmount_failed) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, true);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+
+    this->m_mount_info.unmount_raw_err = ESP_ERR_NOT_SUPPORTED;
+    ASSERT_FALSE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on raw flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_unmount failed, err=262 (Unknown error 262)");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_failed_no_mem) // NOLINT
+{
+    const int max_files        = 1;
+    this->m_malloc_fail_on_cnt = 1;
+
+    this->m_p_ffs = flashfatfs_mount("/fs_nrf52", GW_NRF_PARTITION, max_files, true);
+    ASSERT_EQ(nullptr, this->m_p_ffs);
+    ASSERT_FALSE(this->m_mount_info.flag_mounted);
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't allocate memory");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_open_failed_no_mem) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+
+    this->m_malloc_fail_on_cnt = this->m_malloc_cnt + 1;
+    file_descriptor_t fd       = flashfatfs_open(this->m_p_ffs, "test1.txt");
+    ASSERT_EQ(-1, fd);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't allocate memory");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_fopen_failed_no_mem) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+
+    this->m_malloc_fail_on_cnt = this->m_malloc_cnt + 1;
+    FILE* p_fd                 = flashfatfs_fopen(this->m_p_ffs, "test1.txt", false);
+    ASSERT_EQ(nullptr, p_fd);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't allocate memory");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_stat_failed_no_mem) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+
+    this->m_malloc_fail_on_cnt = this->m_malloc_cnt + 1;
+    struct stat st             = { 0 };
+    ASSERT_FALSE(flashfatfs_stat(this->m_p_ffs, "test1.txt", &st));
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't allocate memory");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_get_file_size_failed_no_mem) // NOLINT
+{
+    const int max_files = 1;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files, false);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+
+    this->m_malloc_fail_on_cnt = this->m_malloc_cnt + 1;
+    size_t size                = 0;
+    ASSERT_FALSE(flashfatfs_get_file_size(this->m_p_ffs, "test1.txt", &size));
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't allocate memory");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());

--- a/tests/test_http_server_cb/test_http_server_cb.cpp
+++ b/tests/test_http_server_cb/test_http_server_cb.cpp
@@ -719,8 +719,13 @@ ethernet_update_ip(void)
 }
 
 const flash_fat_fs_t*
-flashfatfs_mount(const char* mount_point, const char* partition_label, const flash_fat_fs_num_files_t max_files)
+flashfatfs_mount(
+    const char*                    mount_point,
+    const char*                    partition_label,
+    const flash_fat_fs_num_files_t max_files,
+    const bool                     flag_use_raw_fatfs)
 {
+    (void)flag_use_raw_fatfs;
     assert(!g_pTestClass->m_is_fatfs_mounted);
     if (g_pTestClass->m_is_fatfs_mount_fail)
     {

--- a/tests/test_nrf52fw/include/esp_vfs_fat.h
+++ b/tests/test_nrf52fw/include/esp_vfs_fat.h
@@ -195,7 +195,6 @@ esp_vfs_fat_spiflash_mount(
 esp_err_t
 esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle);
 
-#if 0
 /**
  * @brief Convenience function to initialize read-only FAT filesystem and register it in VFS
  *
@@ -219,12 +218,12 @@ esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle);
  *      - ESP_FAIL if partition can not be mounted
  *      - other error codes from SPI flash driver, or FATFS drivers
  */
-esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
-    const char* partition_label,
+esp_err_t
+esp_vfs_fat_rawflash_mount(
+    const char*                       base_path,
+    const char*                       partition_label,
     const esp_vfs_fat_mount_config_t* mount_config);
-#endif
 
-#if 0
 /**
  * @brief Unmount FAT filesystem and release resources acquired using esp_vfs_fat_rawflash_mount
  *
@@ -235,8 +234,8 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_spiflash_mount hasn't been called
  */
- esp_err_t esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label);
-#endif
+esp_err_t
+esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label);
 
 #ifdef __cplusplus
 }

--- a/tests/test_nrf52fw/test_nrf52fw.cpp
+++ b/tests/test_nrf52fw/test_nrf52fw.cpp
@@ -36,11 +36,13 @@ class NRF52Fw_VFS_FAT_MountInfo
 public:
     string                     base_path;
     string                     partition_label;
-    esp_vfs_fat_mount_config_t mount_config = {};
-    bool                       flag_mounted = false;
-    esp_err_t                  mount_err    = ESP_OK;
-    esp_err_t                  unmount_err  = ESP_OK;
-    wl_handle_t                wl_handle    = 0;
+    esp_vfs_fat_mount_config_t mount_config    = {};
+    bool                       flag_mounted    = false;
+    esp_err_t                  mount_err       = ESP_OK;
+    esp_err_t                  unmount_err     = ESP_OK;
+    wl_handle_t                wl_handle       = 0;
+    esp_err_t                  mount_raw_err   = ESP_OK;
+    esp_err_t                  unmount_raw_err = ESP_OK;
 };
 
 class MemAllocTrace
@@ -183,6 +185,8 @@ protected:
         this->m_mount_info.mount_err                            = ESP_OK;
         this->m_mount_info.unmount_err                          = ESP_OK;
         this->m_mount_info.wl_handle                            = 0;
+        this->m_mount_info.mount_raw_err                        = ESP_OK;
+        this->m_mount_info.unmount_raw_err                      = ESP_OK;
         this->m_uicr_fw_ver                                     = 0xFFFFFFFFU;
         this->m_uicr_fw_ver_simulate_write_error                = false;
         this->m_uicr_fw_ver_simulate_read_error                 = false;
@@ -482,7 +486,10 @@ esp_vfs_fat_spiflash_mount(
     g_pTestClass->m_mount_info.partition_label = string(partition_label);
     g_pTestClass->m_mount_info.mount_config    = *mount_config;
     *wl_handle                                 = g_pTestClass->m_mount_info.wl_handle;
-    g_pTestClass->m_mount_info.flag_mounted    = true;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
     return g_pTestClass->m_mount_info.mount_err;
 }
 
@@ -493,6 +500,31 @@ esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle)
     assert(g_pTestClass->m_mount_info.wl_handle == wl_handle);
     g_pTestClass->m_mount_info.flag_mounted = false;
     return g_pTestClass->m_mount_info.unmount_err;
+}
+
+esp_err_t
+esp_vfs_fat_rawflash_mount(
+    const char*                       base_path,
+    const char*                       partition_label,
+    const esp_vfs_fat_mount_config_t* mount_config)
+{
+    g_pTestClass->m_mount_info.base_path       = string(base_path);
+    g_pTestClass->m_mount_info.partition_label = string(partition_label);
+    g_pTestClass->m_mount_info.mount_config    = *mount_config;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_raw_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
+    return g_pTestClass->m_mount_info.mount_raw_err;
+}
+esp_err_t
+esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label)
+{
+    (void)base_path;
+    (void)partition_label;
+    assert(g_pTestClass->m_mount_info.flag_mounted);
+    g_pTestClass->m_mount_info.flag_mounted = false;
+    return g_pTestClass->m_mount_info.unmount_raw_err;
 }
 
 void
@@ -1005,7 +1037,7 @@ TEST_F(TestNRF52Fw, nrf52fw_read_info_txt) // NOLINT
         this->m_fd = nullptr;
     }
     {
-        this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+        this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
         ASSERT_NE(nullptr, this->m_p_ffs);
 
         nrf52fw_info_t info = { 0 };
@@ -1045,7 +1077,7 @@ TEST_F(TestNRF52Fw, nrf52fw_read_info_txt_no_file) // NOLINT
 {
     nrf52fw_info_t info = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_FALSE(nrf52fw_read_info_txt(this->m_p_ffs, this->m_info_txt_name, &info));
@@ -1057,7 +1089,12 @@ TEST_F(TestNRF52Fw, nrf52fw_read_info_txt_no_file) // NOLINT
     ASSERT_EQ(0, info.num_segments);
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/info.txt");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open: info.txt");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -1077,7 +1114,7 @@ TEST_F(TestNRF52Fw, nrf52fw_read_info_txt_bad_line_3) // NOLINT
         fclose(this->m_fd);
         this->m_fd = nullptr;
     }
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
     {
         nrf52fw_info_t info = { 0 };
@@ -1089,7 +1126,12 @@ TEST_F(TestNRF52Fw, nrf52fw_read_info_txt_bad_line_3) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Failed to parse 'info.txt' at line 3");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -1625,7 +1667,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_ok) // NOLINT
     this->m_memSegmentsRead.emplace_back(
         MemSegment(segment_addr, sizeof(segment_buf) / sizeof(segment_buf[0]), segment_buf));
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_TRUE(nrf52fw_write_segment_from_file(
@@ -1645,7 +1687,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_ok) // NOLINT
         ASSERT_EQ(this->m_memSegmentsRead[0].data, this->m_memSegmentsWrite[0].data);
     }
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Writing 0x00001000...");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -1677,7 +1724,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_error_on_writing_segme
     this->m_memSegmentsWrite.emplace_back(
         MemSegment(segment_addr, sizeof(segment_buf) / sizeof(segment_buf[0]), segment_buf));
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_FALSE(nrf52fw_write_segment_from_file(
@@ -1692,7 +1739,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_error_on_writing_segme
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Writing 0x00001000...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52swd_write_mem failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Failed to write segment 0x00001000 from 'segment_1.bin'");
@@ -1716,7 +1768,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_error_no_file) // NOLI
     this->m_memSegmentsRead.emplace_back(
         MemSegment(segment_addr, sizeof(segment_buf) / sizeof(segment_buf[0]), segment_buf));
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_FALSE(nrf52fw_write_segment_from_file(
@@ -1731,7 +1783,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_error_no_file) // NOLI
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/segment_1.bin");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open 'segment_1.bin'");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -1797,7 +1854,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_ok) // NOLINT
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_TRUE(nrf52fw_flash_write_firmware(this->m_p_ffs, &tmp_buf, &fw_info, nullptr, nullptr));
@@ -1818,7 +1875,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_ok) // NOLINT
         ASSERT_EQ(fw_info.fw_ver.version, this->m_uicr_fw_ver);
     }
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 2 segments");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash segment 0: 0x00000000 size=516 from segment_1.bin");
@@ -1914,7 +1976,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_ok_with_version_segment) // NOL
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_TRUE(nrf52fw_flash_write_firmware(this->m_p_ffs, &tmp_buf, &fw_info, nullptr, nullptr));
@@ -1935,7 +1997,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_ok_with_version_segment) // NOL
         ASSERT_EQ(fw_info.fw_ver.version, this->m_uicr_fw_ver);
     }
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 3 segments");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash segment 0: 0x00000000 size=516 from segment_1.bin");
@@ -2013,7 +2080,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_writing_version) // NOLIN
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     {
@@ -2035,7 +2102,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_writing_version) // NOLIN
         ASSERT_EQ(this->m_memSegmentsRead[1].data, this->m_memSegmentsWrite[1].data);
     }
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 2 segments");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash segment 0: 0x00000000 size=516 from segment_1.bin");
@@ -2112,7 +2184,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_writing_segment) // NOLIN
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     {
@@ -2131,7 +2203,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_writing_segment) // NOLIN
         ASSERT_EQ(this->m_memSegmentsRead[0].data, this->m_memSegmentsWrite[1].data);
     }
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 2 segments");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash segment 0: 0x00000000 size=516 from segment_1.bin");
@@ -2206,7 +2283,7 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_erasing) // NOLINT
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     this->m_result_nrf52swd_erase_all = false;
@@ -2218,7 +2295,12 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_erasing) // NOLINT
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52swd_erase_all failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_erase_flash failed");
@@ -2403,7 +2485,7 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_ok) // NOLINT
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_TRUE(nrf52fw_check_firmware(this->m_p_ffs, &tmp_buf, &fw_info));
@@ -2412,7 +2494,12 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_ok) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -2473,7 +2560,7 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_error_bad_crc) // NOLINT
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_FALSE(nrf52fw_check_firmware(this->m_p_ffs, &tmp_buf, &fw_info));
@@ -2482,7 +2569,12 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_error_bad_crc) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Segment: 0x00001000: expected CRC: 0xa433c76e, actual CRC: 0xa433c76d");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -2537,7 +2629,7 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_fail_open_file) // NOLINT
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     ASSERT_FALSE(nrf52fw_check_firmware(this->m_p_ffs, &tmp_buf, &fw_info));
@@ -2546,7 +2638,12 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_fail_open_file) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/segment_2.bin");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open 'segment_2.bin'");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -2609,7 +2706,7 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_fail_calc_segment_crc) // NOLINT
 
     nrf52fw_tmp_buf_t tmp_buf = { 0 };
 
-    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2);
+    this->m_p_ffs = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, 2, false);
     ASSERT_NE(nullptr, this->m_p_ffs);
 
     nrf52fw_simulate_file_read_error(true);
@@ -2619,7 +2716,12 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_fail_calc_segment_crc) // NOLINT
     this->m_p_ffs = nullptr;
 
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_file_read failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_calc_segment_crc failed");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -2704,7 +2806,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_not_needed) // 
         this->m_uicr_fw_ver = 0x01020300;
     }
 
-    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -2714,7 +2816,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_not_needed) // 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware updating is not needed");
@@ -2804,7 +2911,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_not_needed_dont
         this->m_uicr_fw_ver = 0x01020300;
     }
 
-    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, false));
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, false));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -2814,7 +2921,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_not_needed_dont
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware updating is not needed");
@@ -2905,7 +3017,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required) // NO
     this->m_memSegmentsRead.emplace_back(MemSegment(0x00001000, segment2_size / sizeof(uint32_t), segment2_buf.get()));
     this->m_memSegmentsRead.emplace_back(MemSegment(0x00026000, segment3_size / sizeof(uint32_t), segment3_buf.get()));
 
-    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(1, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(3, this->m_memSegmentsWrite.size());
@@ -2915,7 +3027,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required) // NO
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Need to update firmware on nRF52");
@@ -3037,7 +3154,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required_dont_r
     this->m_memSegmentsRead.emplace_back(MemSegment(0x00001000, segment2_size / sizeof(uint32_t), segment2_buf.get()));
     this->m_memSegmentsRead.emplace_back(MemSegment(0x00026000, segment3_size / sizeof(uint32_t), segment3_buf.get()));
 
-    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, false));
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, false));
 
     ASSERT_EQ(1, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(3, this->m_memSegmentsWrite.size());
@@ -3047,7 +3164,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required_dont_r
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Need to update firmware on nRF52");
@@ -3189,7 +3311,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required__with_
               .cb_before_updating  = &cb_before_updating,
               .cb_after_updating   = &cb_after_updating,
     };
-    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, &cb_params, &fw_ver, true));
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, &cb_params, &fw_ver, true));
 
     ASSERT_EQ(697, cb_progress_cnt);
     ASSERT_EQ(1, this->cb_before_updating_cnt);
@@ -3203,7 +3325,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required__with_
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Need to update firmware on nRF52");
@@ -3324,7 +3451,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_init_swd_nrf52sw
     }
 
     this->m_result_nrf52swd_init = false;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
@@ -3421,7 +3548,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_init_swd_nrf52sw
     }
 
     this->m_result_nrf52swd_check_id_code = false;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
@@ -3518,7 +3645,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_init_swd_nrf52sw
     }
 
     this->m_result_nrf52swd_debug_halt = false;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
@@ -3615,7 +3742,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_init_swd_nrf52sw
     }
 
     this->m_result_nrf52swd_debug_reset = false;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
@@ -3714,7 +3841,7 @@ TEST_F(
     }
 
     this->m_result_nrf52swd_debug_enable_reset_vector_catch = false;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
@@ -3810,7 +3937,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__debug_run_failed) // N
     }
 
     this->m_result_nrf52swd_debug_run = false;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -3820,7 +3947,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__debug_run_failed) // N
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware updating is not needed");
@@ -3913,7 +4045,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_mount_failed) //
     }
 
     this->m_mount_info.mount_err = ESP_ERR_NOT_FOUND;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -3923,6 +4055,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_mount_failed) //
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "flashfatfs_mount failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
@@ -4012,7 +4147,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_mount_failed_no_
     }
 
     this->m_malloc_fail_on_cnt = 1;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -4111,7 +4246,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_step2_no_mem) //
     }
 
     this->m_malloc_fail_on_cnt = 2;
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -4121,7 +4256,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_step2_no_mem) //
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "os_calloc failed");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
@@ -4201,7 +4341,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_info_txt) /
         this->m_memSegmentsRead.emplace_back(MemSegment(0x10001080, 1, &version));
     }
 
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -4211,7 +4351,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_info_txt) /
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/info.txt");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open: info.txt");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_read_info_txt failed");
@@ -4301,7 +4446,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_version) //
         this->m_uicr_fw_ver_simulate_read_error = true;
     }
 
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -4311,7 +4456,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_version) //
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_read_current_fw_ver failed");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -4400,7 +4550,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_check_firmware) 
         this->m_uicr_fw_ver = 0x01020000;
     }
 
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
     ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
@@ -4410,7 +4560,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_check_firmware) 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Need to update firmware on nRF52");
@@ -4506,7 +4661,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_write_firmware) 
         this->m_memSegmentsWrite.emplace_back(MemSegment(0x00000000, 1, &stub));
     }
 
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, nullptr, nullptr, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, nullptr, nullptr, true));
 
     ASSERT_EQ(1, this->m_memSegmentsWrite.size());
     ASSERT_EQ(1, this->m_cnt_nrf52swd_erase_all);
@@ -4516,7 +4671,12 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_write_firmware) 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Need to update firmware on nRF52");
@@ -4618,7 +4778,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required__with_
         .cb_before_updating  = nullptr,
         .cb_after_updating   = nullptr,
     };
-    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, &cb_params, &fw_ver, true));
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, &cb_params, &fw_ver, true));
 
     ASSERT_EQ(0, this->cb_before_updating_cnt);
     ASSERT_EQ(0, this->cb_after_updating_cnt);
@@ -4712,7 +4872,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_check_firmware__
           .cb_before_updating  = &cb_before_updating,
           .cb_after_updating   = &cb_after_updating,
     };
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, &cb_params, &fw_ver, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, &cb_params, &fw_ver, true));
 
     ASSERT_EQ(1, this->cb_before_updating_cnt);
     ASSERT_EQ(1, this->cb_after_updating_cnt);
@@ -4810,7 +4970,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_write_firmware__
           .cb_before_updating  = &cb_before_updating,
           .cb_after_updating   = &cb_after_updating,
     };
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, &cb_params, &fw_ver, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, &cb_params, &fw_ver, true));
 
     ASSERT_EQ(1, this->cb_before_updating_cnt);
     ASSERT_EQ(1, this->cb_after_updating_cnt);
@@ -4912,7 +5072,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_current_fw_
         .cb_before_updating  = &cb_before_updating,
         .cb_after_updating   = &cb_after_updating,
     };
-    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, &cb_params, &fw_ver, true));
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, false, &cb_params, &fw_ver, true));
 
     ASSERT_EQ(1, this->cb_before_updating_cnt);
     ASSERT_EQ(1, this->cb_after_updating_cnt);
@@ -4961,4 +5121,281 @@ TEST_F(TestNRF52Fw, nrf52fw_software_reset_failed_nrf52swd_debug_run_failed) // 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52swd_debug_run failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
+}
+/*** Tests for raw-FAT path (new flag_try_using_raw_fatfs parameter) ***********************************/
+TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__with_raw_fatfs__update_not_needed) // NOLINT
+{
+    const char*  segment1_path = "segment_1.bin";
+    const char*  segment2_path = "segment_2.bin";
+    const char*  segment3_path = "segment_3.bin";
+    const size_t segment1_size = 2816;
+    const size_t segment2_size = 151016;
+    const size_t segment3_size = 24448;
+    uint32_t     segment1_crc  = 0;
+    uint32_t     segment2_crc  = 0;
+    uint32_t     segment3_crc  = 0;
+    {
+        std::unique_ptr<uint32_t[]> segment1_buf(new uint32_t[segment1_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment1_size / sizeof(uint32_t); ++i)
+        {
+            segment1_buf[i] = 0xAA000000 + i;
+        }
+        segment1_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment1_buf.get()), segment1_size);
+        {
+            this->m_fd = this->open_file(segment1_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment1_buf.get(), 1, segment1_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    {
+        std::unique_ptr<uint32_t[]> segment2_buf(new uint32_t[segment2_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment2_size / sizeof(uint32_t); ++i)
+        {
+            segment2_buf[i] = 0xBB000000 + i;
+        }
+        segment2_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment2_buf.get()), segment2_size);
+        {
+            this->m_fd = this->open_file(segment2_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment2_buf.get(), 1, segment2_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    {
+        std::unique_ptr<uint32_t[]> segment3_buf(new uint32_t[segment3_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment3_size / sizeof(uint32_t); ++i)
+        {
+            segment3_buf[i] = 0xCC000000 + i;
+        }
+        segment3_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment3_buf.get()), segment3_size);
+        {
+            this->m_fd = this->open_file(segment3_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment3_buf.get(), 1, segment3_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    {
+        this->m_fd = this->open_file("info.txt", "w");
+        ASSERT_NE(nullptr, this->m_fd);
+        fprintf(this->m_fd, "# v1.2.3\n");
+        fprintf(this->m_fd, "0x00000000 %u %s 0x%08x\n", (unsigned)segment1_size, segment1_path, segment1_crc);
+        fprintf(this->m_fd, "0x00001000 %u %s 0x%08x\n", (unsigned)segment2_size, segment2_path, segment2_crc);
+        fprintf(this->m_fd, "0x00026000 %u %s 0x%08x\n", (unsigned)segment3_size, segment3_path, segment3_crc);
+        fclose(this->m_fd);
+        this->m_fd = nullptr;
+    }
+    {
+        this->m_uicr_fw_ver = 0x01020300;
+    }
+    // flag_try_using_raw_fatfs = true; raw mount succeeds (mount_raw_err == ESP_OK by default).
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, true, nullptr, nullptr, true));
+    ASSERT_EQ(0, this->m_memSegmentsWrite.size());
+    ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 manual reset mode: ON");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on raw flash");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware updating is not needed");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 manual reset mode: OFF");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__with_raw_fatfs__fallback_to_spiflash_ok) // NOLINT
+{
+    const char*  segment1_path = "segment_1.bin";
+    const char*  segment2_path = "segment_2.bin";
+    const char*  segment3_path = "segment_3.bin";
+    const size_t segment1_size = 2816;
+    const size_t segment2_size = 151016;
+    const size_t segment3_size = 24448;
+    uint32_t     segment1_crc  = 0;
+    uint32_t     segment2_crc  = 0;
+    uint32_t     segment3_crc  = 0;
+    {
+        std::unique_ptr<uint32_t[]> segment1_buf(new uint32_t[segment1_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment1_size / sizeof(uint32_t); ++i)
+        {
+            segment1_buf[i] = 0xAA000000 + i;
+        }
+        segment1_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment1_buf.get()), segment1_size);
+        {
+            this->m_fd = this->open_file(segment1_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment1_buf.get(), 1, segment1_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    {
+        std::unique_ptr<uint32_t[]> segment2_buf(new uint32_t[segment2_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment2_size / sizeof(uint32_t); ++i)
+        {
+            segment2_buf[i] = 0xBB000000 + i;
+        }
+        segment2_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment2_buf.get()), segment2_size);
+        {
+            this->m_fd = this->open_file(segment2_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment2_buf.get(), 1, segment2_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    {
+        std::unique_ptr<uint32_t[]> segment3_buf(new uint32_t[segment3_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment3_size / sizeof(uint32_t); ++i)
+        {
+            segment3_buf[i] = 0xCC000000 + i;
+        }
+        segment3_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment3_buf.get()), segment3_size);
+        {
+            this->m_fd = this->open_file(segment3_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment3_buf.get(), 1, segment3_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    {
+        this->m_fd = this->open_file("info.txt", "w");
+        ASSERT_NE(nullptr, this->m_fd);
+        fprintf(this->m_fd, "# v1.2.3\n");
+        fprintf(this->m_fd, "0x00000000 %u %s 0x%08x\n", (unsigned)segment1_size, segment1_path, segment1_crc);
+        fprintf(this->m_fd, "0x00001000 %u %s 0x%08x\n", (unsigned)segment2_size, segment2_path, segment2_crc);
+        fprintf(this->m_fd, "0x00026000 %u %s 0x%08x\n", (unsigned)segment3_size, segment3_path, segment3_crc);
+        fclose(this->m_fd);
+        this->m_fd = nullptr;
+    }
+    {
+        this->m_uicr_fw_ver = 0x01020300;
+    }
+    // flag_try_using_raw_fatfs = true; raw mount fails, spiflash fallback succeeds.
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+    ASSERT_TRUE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, true, nullptr, nullptr, true));
+    ASSERT_EQ(0, this->m_memSegmentsWrite.size());
+    ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 manual reset mode: ON");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_WARN, "Try to mount partition as SPI-Flash FATFS");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52 as FATFS on SPI-Flash");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Firmware on FatFS: v1.2.3");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware updating is not needed");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 manual reset mode: OFF");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__with_raw_fatfs__both_raw_and_spiflash_fail) // NOLINT
+{
+    // flag_try_using_raw_fatfs = true; raw mount fails AND fallback spiflash mount also fails.
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+    this->m_mount_info.mount_err     = ESP_ERR_NOT_FOUND;
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, true, nullptr, nullptr, true));
+    ASSERT_EQ(0, this->m_memSegmentsWrite.size());
+    ASSERT_EQ(0, this->m_cnt_nrf52swd_erase_all);
+    ASSERT_FALSE(this->m_mount_info.flag_mounted);
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 manual reset mode: ON");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_WARN, "Try to mount partition as SPI-Flash FATFS");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "flashfatfs_mount failed");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
+    TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 manual reset mode: OFF");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__with_raw_fatfs__unmount_raw_failed) // NOLINT
+{
+    const char*  segment1_path = "segment_1.bin";
+    const size_t segment1_size = 2816;
+    uint32_t     segment1_crc  = 0;
+    {
+        std::unique_ptr<uint32_t[]> segment1_buf(new uint32_t[segment1_size / sizeof(uint32_t)]);
+        for (int i = 0; i < segment1_size / sizeof(uint32_t); ++i)
+        {
+            segment1_buf[i] = 0xAA000000 + i;
+        }
+        segment1_crc = crc32_le(0, reinterpret_cast<const uint8_t*>(segment1_buf.get()), segment1_size);
+        {
+            this->m_fd = this->open_file(segment1_path, "wb");
+            ASSERT_NE(nullptr, this->m_fd);
+            fwrite(segment1_buf.get(), 1, segment1_size, this->m_fd);
+            fclose(this->m_fd);
+            this->m_fd = nullptr;
+        }
+    }
+    // info.txt references a segment file that does not exist on disk so that check_firmware
+    // fails -> nrf52fw_update_fw_step1 returns false, and the raw-flash unmount path is then
+    // exercised on the way back out.
+    {
+        this->m_fd = this->open_file("info.txt", "w");
+        ASSERT_NE(nullptr, this->m_fd);
+        fprintf(this->m_fd, "# v1.2.3\n");
+        fprintf(this->m_fd, "0x00000000 %u %s 0x%08x\n", (unsigned)segment1_size, "missing.bin", segment1_crc);
+        fclose(this->m_fd);
+        this->m_fd = nullptr;
+    }
+    this->m_mount_info.unmount_raw_err = ESP_ERR_NOT_SUPPORTED;
+    ASSERT_FALSE(nrf52fw_update_fw_if_necessary(GW_NRF_PARTITION, true, nullptr, nullptr, true));
+    ASSERT_FALSE(this->m_mount_info.flag_mounted);
+    // Drain all logs and just verify the raw-flash unmount error is emitted.
+    bool found_raw_unmount_err = false;
+    while (!esp_log_wrapper_is_empty())
+    {
+        const LogRecord log_record = esp_log_wrapper_pop();
+        if ((string("FlashFatFS") == log_record.tag)
+            && (string("esp_vfs_fat_rawflash_unmount failed, err=262 (ESP_ERR_NOT_SUPPORTED)")
+                == log_record.parsed.msg))
+        {
+            found_raw_unmount_err = true;
+        }
+    }
+    ASSERT_TRUE(found_raw_unmount_err);
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
 }


### PR DESCRIPTION
## Summary

Transitional v1.16.x change that adds raw read-only FAT mount support for the
`fatfs_nrf52` partition so that the device can flash the nRF52 co-processor
from the new raw-FAT image bundled with the upcoming v1.17.x firmware.

v1.17.x ships both the `fatfs_nrf52` and `fatfs_gwui` partitions as raw FAT
(no wear-leveling). v1.16.x is the only firmware that **mounts** the freshly
downloaded `fatfs_nrf52` image during OTA — it does so to flash the nRF52
co-processor before the device reboots into v1.17.x. Without this change,
mounting fails and the nRF52 cannot be updated.

`fatfs_gwui` is not affected: v1.16.x never mounts the newly downloaded UI
partition during OTA — v1.17.x mounts it natively as raw FAT after reboot.

## Behavior

- `flashfatfs_mount()` takes a new `bool flag_use_raw_fatfs` argument.
  - `true` → try `esp_vfs_fat_rawflash_mount()` first; on failure log a
    warning and fall back to `esp_vfs_fat_spiflash_mount()` (wear-leveled
    FAT). The fallback preserves compatibility with bundles that still ship
    the legacy wear-leveled image.
  - `false` → wear-leveled FAT only (current behavior).
- `flashfatfs_unmount()` calls the matching unmount routine.
- `nrf52fw_update_fw_if_necessary()` takes a new `bool flag_try_using_raw_fatfs`
  argument and propagates it through `step0` / `step1` to `flashfatfs_mount()`.

## Call sites

- `main_task_init()` (boot): `flag_try_using_raw_fatfs = false` — the image
  currently installed on the device is still wear-leveled FAT.
- `fw_update_do_actions()` (post-OTA): `flag_try_using_raw_fatfs = true` —
  the freshly downloaded image is expected to be raw FAT; falls back to
  wear-leveled FAT on failure.
- `http_server_cb_init()` (Web UI): unchanged behavior — wear-leveled FAT
  only.

## Tests

- `test_flashfatfs`: enabled `esp_vfs_fat_rawflash_mount` /
  `esp_vfs_fat_rawflash_unmount` stubs; updated existing tests for the new
  log output and the new `flag_use_raw_fatfs` parameter; added 9 new tests
  covering raw-FAT success, raw→spiflash fallback, raw unmount error, and
  malloc-failure branches. `main/flashfatfs.c` reaches **100 % line / 100 %
  function coverage**.
- `test_nrf52fw`: added stubs for the new raw-FAT ESP-IDF helpers; updated
  the existing 106 tests for the new function signatures and log output;
  added 4 new tests exercising the new `flag_try_using_raw_fatfs` parameter
  end-to-end (raw success, raw→spiflash fallback success, both fail, raw
  unmount error).
- `test_http_server_cb`: updated `flashfatfs_mount` mock signature.

## Upgrade scenario

1. Device running current v1.16.x — both partitions are wear-leveled FAT.
2. User installs this intermediate v1.16.x — no functional change, since
   no raw-FAT image is present yet.
3. User triggers OTA to v1.17.x: new raw-FAT `fatfs_nrf52` is mounted by
   v1.16.x via this change and the nRF52 is flashed; new raw-FAT
   `fatfs_gwui` is just written as bytes and is mounted only after reboot
   by v1.17.x.
4. Device reboots into v1.17.x → native raw-FAT support takes over.

## Out of scope

- Removal of wear-leveled FAT support (planned for v1.17.x).
- Build pipeline changes that produce the raw-FAT images (tracked
  separately).

## Affected files

- `main/flashfatfs.{c,h}`
- `main/nrf52fw.{c,h}`
- `main/fw_update.c`
- `main/http_server_cb.c`
- `main/ruuvi_gateway_main.c`
- `tests/test_flashfatfs/`
- `tests/test_nrf52fw/`
- `tests/test_http_server_cb/`