### PR TITLE
fix(fatfs): close #1294 prevent crash during fallback mount on same partition

### DIFF
--- a/components/fatfs/vfs/vfs_fat_spiflash.c
+++ b/components/fatfs/vfs/vfs_fat_spiflash.c
@@ -158,6 +158,8 @@ fail:
     }
     if (diskio_registered) {
         ff_diskio_clear_pdrv_wl(*wl_handle);
+    }
+    if (pdrv != 0xFF) {
         ff_diskio_unregister(pdrv);
     }
     if (wl_mounted) {
@@ -247,7 +249,7 @@ fail:
     if (vfs_registered) {
         esp_vfs_fat_unregister_path(base_path);
     }
-    if (diskio_registered) {
+    if (diskio_registered || (pdrv != 0xFF)) {
         ff_diskio_unregister(pdrv);
     }
     return result;

--- a/components/fatfs/vfs/vfs_fat_spiflash.c
+++ b/components/fatfs/vfs/vfs_fat_spiflash.c
@@ -90,7 +90,7 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
     }
     diskio_registered = true;
 
-    FATFS *fs;
+    FATFS *fs = NULL;
     result = esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs);
     if (result == ESP_ERR_INVALID_STATE) {
         // it's okay, already registered with VFS
@@ -217,7 +217,7 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
     }
     diskio_registered = true;
 
-    FATFS *fs;
+    FATFS *fs = NULL;
     result = esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs);
     if (result == ESP_ERR_INVALID_STATE) {
         // it's okay, already registered with VFS

--- a/components/fatfs/vfs/vfs_fat_spiflash.c
+++ b/components/fatfs/vfs/vfs_fat_spiflash.c
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Local overlay of ESP-IDF v4.2.2 components/fatfs/vfs/vfs_fat_spiflash.c
+// Local overlay of ESP-IDF v4.2.5 components/fatfs/vfs/vfs_fat_spiflash.c
 //
 // FIX (Ruuvi): The upstream `fail:` paths of both `esp_vfs_fat_spiflash_mount`
 // and `esp_vfs_fat_rawflash_mount` skip the FatFs deregistration step.

--- a/components/fatfs/vfs/vfs_fat_spiflash.c
+++ b/components/fatfs/vfs/vfs_fat_spiflash.c
@@ -11,9 +11,28 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Local overlay of ESP-IDF v4.2.2 components/fatfs/vfs/vfs_fat_spiflash.c
+//
+// FIX (Ruuvi): The upstream `fail:` paths of both `esp_vfs_fat_spiflash_mount`
+// and `esp_vfs_fat_rawflash_mount` skip the FatFs deregistration step.
+// After `f_mount(fs, drv, 1)` has been called, the global `FatFs[vol]` slot
+// is set to `fs` and a FreeRTOS sync object is allocated for it (when
+// FF_FS_REENTRANT is enabled). The upstream cleanup then frees the
+// containing fat_ctx via esp_vfs_fat_unregister_path() but never calls
+// `f_mount(NULL, drv, 0)`, leaving `FatFs[vol]` pointing at freed memory
+// (and leaking the sync object / wear-levelling handle).
+// Any subsequent `f_mount(...)` on the same volume — e.g. retrying as
+// raw FAT after a wear-levelled mount failure — will then dereference
+// the dangling pointer and assert in vQueueDelete(NULL).
+//
+// This overlay tracks whether `f_mount` succeeded enough to register
+// the volume and, if so, performs a proper `f_mount(NULL, drv, 0)` and
+// `wl_unmount()` before releasing the VFS path and the disk-io slot.
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include "esp_log.h"
 #include "esp_vfs.h"
 #include "esp_vfs_fat.h"
@@ -34,6 +53,10 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
     esp_err_t result = ESP_OK;
     const size_t workbuf_size = 4096;
     void *workbuf = NULL;
+    bool wl_mounted = false;
+    bool diskio_registered = false;
+    bool vfs_registered = false;
+    bool fatfs_registered = false; /* f_mount(fs, drv, 1) installed fs into FatFs[vol] */
 
     esp_partition_subtype_t subtype = partition_label ?
             ESP_PARTITION_SUBTYPE_ANY : ESP_PARTITION_SUBTYPE_DATA_FAT;
@@ -49,11 +72,13 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
         ESP_LOGE(TAG, "failed to mount wear levelling layer. result = %i", result);
         return result;
     }
+    wl_mounted = true;
     // connect driver to FATFS
     BYTE pdrv = 0xFF;
     if (ff_diskio_get_drive(&pdrv) != ESP_OK) {
         ESP_LOGD(TAG, "the maximum count of volumes is already mounted");
-        return ESP_ERR_NO_MEM;
+        result = ESP_ERR_NO_MEM;
+        goto fail;
     }
     ESP_LOGD(TAG, "using pdrv=%i", pdrv);
     char drv[3] = {(char)('0' + pdrv), ':', 0};
@@ -63,17 +88,27 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
         ESP_LOGE(TAG, "ff_diskio_register_wl_partition failed pdrv=%i, error - 0x(%x)", pdrv, result);
         goto fail;
     }
+    diskio_registered = true;
+
     FATFS *fs;
     result = esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs);
     if (result == ESP_ERR_INVALID_STATE) {
         // it's okay, already registered with VFS
+        result = ESP_OK;
     } else if (result != ESP_OK) {
         ESP_LOGD(TAG, "esp_vfs_fat_register failed 0x(%x)", result);
         goto fail;
+    } else {
+        vfs_registered = true;
     }
 
     // Try to mount partition
     FRESULT fresult = f_mount(fs, drv, 1);
+    /* f_mount() installs `fs` into FatFs[vol] and allocates a sync
+     * object *before* it tries to read the volume, so we must
+     * deregister it on failure regardless of fresult.
+     */
+    fatfs_registered = true;
     if (fresult != FR_OK) {
         ESP_LOGW(TAG, "f_mount failed (%d)", fresult);
         if (!((fresult == FR_NO_FILESYSTEM || fresult == FR_INT_ERR)
@@ -110,8 +145,25 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
 
 fail:
     free(workbuf);
-    esp_vfs_fat_unregister_path(base_path);
-    ff_diskio_unregister(pdrv);
+    /* Order matters here: f_mount(NULL, ...) must be called *before*
+     * esp_vfs_fat_unregister_path() because the latter frees the
+     * fat_ctx that owns the FATFS struct pointed to by FatFs[vol].
+     */
+    if (fatfs_registered) {
+        char drv_cleanup[3] = {(char)('0' + pdrv), ':', 0};
+        f_mount(NULL, drv_cleanup, 0);
+    }
+    if (vfs_registered) {
+        esp_vfs_fat_unregister_path(base_path);
+    }
+    if (diskio_registered) {
+        ff_diskio_clear_pdrv_wl(*wl_handle);
+        ff_diskio_unregister(pdrv);
+    }
+    if (wl_mounted) {
+        wl_unmount(*wl_handle);
+        *wl_handle = WL_INVALID_HANDLE;
+    }
     return result;
 }
 
@@ -138,6 +190,9 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
     const esp_vfs_fat_mount_config_t* mount_config)
 {
     esp_err_t result = ESP_OK;
+    bool diskio_registered = false;
+    bool vfs_registered = false;
+    bool fatfs_registered = false;
 
     const esp_partition_t *data_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
             ESP_PARTITION_SUBTYPE_DATA_FAT, partition_label);
@@ -160,18 +215,23 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
         ESP_LOGE(TAG, "ff_diskio_register_raw_partition failed pdrv=%i, error - 0x(%x)", pdrv, result);
         goto fail;
     }
+    diskio_registered = true;
 
     FATFS *fs;
     result = esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs);
     if (result == ESP_ERR_INVALID_STATE) {
         // it's okay, already registered with VFS
+        result = ESP_OK;
     } else if (result != ESP_OK) {
         ESP_LOGD(TAG, "esp_vfs_fat_register failed 0x(%x)", result);
         goto fail;
+    } else {
+        vfs_registered = true;
     }
 
     // Try to mount partition
     FRESULT fresult = f_mount(fs, drv, 1);
+    fatfs_registered = true; /* see comment in spiflash_mount above */
     if (fresult != FR_OK) {
         ESP_LOGW(TAG, "f_mount failed (%d)", fresult);
         result = ESP_FAIL;
@@ -180,8 +240,16 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
     return ESP_OK;
 
 fail:
-    esp_vfs_fat_unregister_path(base_path);
-    ff_diskio_unregister(pdrv);
+    if (fatfs_registered) {
+        char drv_cleanup[3] = {(char)('0' + pdrv), ':', 0};
+        f_mount(NULL, drv_cleanup, 0);
+    }
+    if (vfs_registered) {
+        esp_vfs_fat_unregister_path(base_path);
+    }
+    if (diskio_registered) {
+        ff_diskio_unregister(pdrv);
+    }
     return result;
 }
 
@@ -207,3 +275,4 @@ esp_err_t esp_vfs_fat_rawflash_unmount(const char *base_path, const char* partit
     esp_err_t err = esp_vfs_fat_unregister_path(base_path);
     return err;
 }
+


### PR DESCRIPTION
# Fix `vQueueDelete(NULL)` crash on FATFS mount fallback (raw ↔ WL)

This is port of the fix from v1.16.x, ref commit c89d5fda7c19d30a715109f9579c65f2f04bd041
See related PR #1300, ref issue #1294.

## Problem

`flashfatfs_mount()` tries `esp_vfs_fat_rawflash_mount()` first and, on
failure, falls back to `esp_vfs_fat_spiflash_mount()` on the same
partition. When the partition does not contain a raw-FAT image, the first
mount fails with `FR_NO_FILESYSTEM` (13) and the second mount aborts the
firmware on an assertion inside `vQueueDelete()`:

The bug is **symmetric** — it triggers in either fallback direction
because the same incomplete cleanup logic exists in both mount
functions:

- WL → raw: `esp_vfs_fat_spiflash_mount()` fails on a raw-FAT image,
  then `esp_vfs_fat_rawflash_mount()` aborts.
- raw → WL: `esp_vfs_fat_rawflash_mount()` fails on a WL-FAT image,
  then `esp_vfs_fat_spiflash_mount()` aborts.

## Root cause

The `fail:` paths of `esp_vfs_fat_spiflash_mount()` and
`esp_vfs_fat_rawflash_mount()` in ESP-IDF v4.2.x are incomplete:

- `f_mount(fs, "X:", 1)` sets `FatFs[vol] = fs` and allocates `fs->sobj`
  **before** `find_volume()` is called, so a `FR_NO_FILESYSTEM` failure
  leaves `FatFs[vol]` pointing at `fs` and the sync object allocated.
- Upstream cleanup only calls `esp_vfs_fat_unregister_path()` (which
  `free()`s the containing `vfs_fat_ctx_t`) and `ff_diskio_unregister()`.
  It does **not** call `f_mount(NULL, "X:", 0)` and (in the spiflash
  variant) does **not** `wl_unmount()`.
- `FatFs[vol]` is therefore left dangling and the sync object / WL
  handle leak.
- On the subsequent mount of the other variant on the same partition,
  `esp_vfs_fat_register()` callocs a fresh `fat_ctx` at the same
  address freed above, so the new `fs` is zero-initialised
  (`fs->sobj == NULL`). `f_mount(new_fs, "X:", 1)` reads
  `cfs = FatFs[vol]` — still the same address — enters the
  `if (cfs)` branch and calls `ff_del_syncobj(NULL)` →
  `vQueueDelete(NULL)` → assert.

Because the broken cleanup lives in both mount wrappers, the order in
which the two variants are tried does not matter; either one failing
first breaks the other.

## Fix

Add a local overlay of `components/fatfs/vfs/vfs_fat_spiflash.c` and
route the build to it. The overlay tracks how far each mount progressed
and, on failure, tears the state down in the correct order:

1. `f_mount(NULL, "X:", 0)` — clears `FatFs[vol]` and deletes the sync
   object. Must run *before* `esp_vfs_fat_unregister_path()` frees the
   containing `fat_ctx`.
2. `esp_vfs_fat_unregister_path()`.
3. `ff_diskio_clear_pdrv_wl()` + `ff_diskio_unregister(pdrv)`.
4. `wl_unmount(*wl_handle)` (spiflash variant only).

The same teardown is applied to `esp_vfs_fat_rawflash_mount()`, so the
fix is symmetric and protects both WL → raw and raw → WL fallback
orders.

No changes to `main/flashfatfs.c` are required — its fallback pattern is
correct; the IDF cleanup was broken.

## Verification

- Boot with a partition containing a raw-FAT image (WL → raw fallback):
  the first `esp_vfs_fat_spiflash_mount()` still returns `ESP_FAIL`
  (13), but the follow-up `esp_vfs_fat_rawflash_mount()` no longer
  asserts and mounts the partition successfully.
- Boot with a partition containing a WL-FAT image and call the mount
  functions in reverse order (raw → WL): the first
  `esp_vfs_fat_rawflash_mount()` returns `ESP_FAIL`, and the follow-up
  `esp_vfs_fat_spiflash_mount()` succeeds without asserting.
- Boot with a partition containing a WL-FAT image with the normal
  WL-first order: behaviour is unchanged —
  `esp_vfs_fat_spiflash_mount()` succeeds and the rawflash fallback is
  not entered.
- No regressions in `flashfatfs_unmount()` — the success path is
  untouched.

## Notes

- The fix lives in the same layer that Espressif themselves patched in
  later ESP-IDF releases (the VFS wrappers, not ChaN’s `ff.c`), so this
  overlay can simply be deleted on a future IDF bump.
