### PR TITLE
fix(fatfs): #1294 harden `vfs_fat_*_mount` failure cleanup against leaks and crashes

### DIFF
--- a/components/fatfs/vfs/vfs_fat_spiflash.c
+++ b/components/fatfs/vfs/vfs_fat_spiflash.c
@@ -90,7 +90,7 @@ esp_err_t esp_vfs_fat_spiflash_mount(const char* base_path,
     }
     diskio_registered = true;
 
-    FATFS *fs;
+    FATFS *fs = NULL;
     result = esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs);
     if (result == ESP_ERR_INVALID_STATE) {
         // it's okay, already registered with VFS
@@ -158,6 +158,8 @@ fail:
     }
     if (diskio_registered) {
         ff_diskio_clear_pdrv_wl(*wl_handle);
+    }
+    if (pdrv != 0xFF) {
         ff_diskio_unregister(pdrv);
     }
     if (wl_mounted) {
@@ -217,7 +219,7 @@ esp_err_t esp_vfs_fat_rawflash_mount(const char* base_path,
     }
     diskio_registered = true;
 
-    FATFS *fs;
+    FATFS *fs = NULL;
     result = esp_vfs_fat_register(base_path, drv, mount_config->max_files, &fs);
     if (result == ESP_ERR_INVALID_STATE) {
         // it's okay, already registered with VFS
@@ -247,7 +249,7 @@ fail:
     if (vfs_registered) {
         esp_vfs_fat_unregister_path(base_path);
     }
-    if (diskio_registered) {
+    if (diskio_registered || (pdrv != 0xFF)) {
         ff_diskio_unregister(pdrv);
     }
     return result;


### PR DESCRIPTION
### Summary

This PR contains two small follow-up fixes to the Ruuvi overlay of
`components/fatfs/vfs/vfs_fat_spiflash.c` (issue #1294). Both address
latent defects on the `fail:` cleanup paths of
`esp_vfs_fat_spiflash_mount()` and `esp_vfs_fat_rawflash_mount()` that
could leak FatFs volume slots or, in pathological cases, dereference
uninitialized memory.

### Motivation

The earlier #1294 work made the `fail:` paths call
`f_mount(NULL, ...)` and `wl_unmount()` in the correct order so that
retrying a mount after a wear-levelled failure no longer asserts in
`vQueueDelete(NULL)`. While re-reading that code two further issues
were spotted:

1. `FATFS *fs;` was declared without an initializer and immediately
   passed by address to `esp_vfs_fat_register()`. If registration
   fails before writing through the out-pointer, `fs` is
   indeterminate. Any subsequent read — even a defensive one — is
   undefined behaviour. The compiler happens to emit safe code today,
   but the construct is fragile and trips static analyzers.

2. The `fail:` paths only called `ff_diskio_unregister(pdrv)` when
   `diskio_registered` was true. But `diskio_registered` is only set
   *after* `ff_diskio_register_{wl,raw}_partition()` succeeds, whereas
   the pdrv slot itself is reserved earlier by `ff_diskio_get_drive()`.
   If the register step failed, the pdrv slot stayed allocated forever,
   eventually exhausting `FF_VOLUMES` after enough failed mount
   attempts.

### Changes

`components/fatfs/vfs/vfs_fat_spiflash.c`:

- Initialize `FATFS *fs = NULL;` in both `esp_vfs_fat_spiflash_mount()`
  and `esp_vfs_fat_rawflash_mount()` before passing `&fs` to
  `esp_vfs_fat_register()`.
- Split the `pdrv` release out of the `diskio_registered` branch in
  the `spiflash` cleanup: `ff_diskio_clear_pdrv_wl(*wl_handle)` still
  runs only when the wl partition driver was actually attached, but
  `ff_diskio_unregister(pdrv)` now runs whenever `pdrv != 0xFF`.
- Apply the same `diskio_registered || (pdrv != 0xFF)` guard in the
  `rawflash` cleanup so the pdrv slot is always freed once it has been
  reserved.

No behavioural change on the success path; only the `fail:` cleanup is
affected.

### Risk / compatibility

- The overlay file is the only file touched; no public API changes.
- `ff_diskio_unregister()` is safe to call on a pdrv that was reserved
  by `ff_diskio_get_drive()` but not bound to a partition driver — it
  simply clears the slot.
- The success path is unchanged, so existing mount/unmount sequences
  behave identically.

### Testing

- Firmware builds cleanly against ESP-IDF v4.2.2.
- Repeated forced-failure mounts (induced by exhausting wear-levelling
  initialization) no longer leak FatFs volume slots; the device can
  retry indefinitely without hitting `ESP_ERR_NO_MEM` from
  `ff_diskio_get_drive()`.
