### PR TITLE
chore(bootloader_support): #1309 vendor patched bootloader_support from ESP-IDF v4.2.2

### DIFF
--- a/components/bootloader_support/CMakeLists.txt
+++ b/components/bootloader_support/CMakeLists.txt
@@ -1,0 +1,112 @@
+set(srcs
+    "src/bootloader_clock.c"
+    "src/bootloader_common.c"
+    "src/bootloader_flash.c"
+    "src/bootloader_mem.c"
+    "src/bootloader_random.c"
+    "src/bootloader_random_${IDF_TARGET}.c"
+    "src/bootloader_utility.c"
+    "src/esp_image_format.c"
+    "src/flash_encrypt.c"
+    "src/flash_partitions.c"
+    "src/flash_qio_mode.c"
+    "src/bootloader_flash_config_${IDF_TARGET}.c"
+    "src/bootloader_efuse_${IDF_TARGET}.c"
+    )
+
+set(include_dirs "include" "include_bootloader")
+if(BOOTLOADER_BUILD)
+    set(priv_requires micro-ecc spi_flash efuse)
+    list(APPEND srcs
+    "src/bootloader_init.c"
+    "src/${IDF_TARGET}/bootloader_sha.c"
+    "src/${IDF_TARGET}/flash_encrypt.c"
+    "src/${IDF_TARGET}/bootloader_${IDF_TARGET}.c"
+    )
+else()
+    list(APPEND srcs
+        "src/idf/bootloader_sha.c")
+    set(priv_requires spi_flash mbedtls efuse)
+endif()
+
+if(CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME OR CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME)
+    if(BOOTLOADER_BUILD)
+        list(APPEND srcs
+        "src/${IDF_TARGET}/secure_boot_signatures.c")
+    else()
+        list(APPEND srcs
+            "src/idf/secure_boot_signatures.c")
+    endif()
+endif()
+
+if(CONFIG_SECURE_BOOT AND BOOTLOADER_BUILD)
+    list(APPEND srcs
+        "src/${IDF_TARGET}/secure_boot.c")
+endif()
+
+set(requires soc) #unfortunately the header directly uses SOC registers
+
+idf_component_register(SRCS "${srcs}"
+                    INCLUDE_DIRS "${include_dirs}"
+                    PRIV_INCLUDE_DIRS "${priv_include_dirs}"
+                    REQUIRES "${requires}"
+                    PRIV_REQUIRES "${priv_requires}")
+
+if(CONFIG_SECURE_SIGNED_APPS AND (CONFIG_SECURE_BOOT_V1_ENABLED OR CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME))
+    if(BOOTLOADER_BUILD)
+        # Whether CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES or not, we need verification key to embed
+        # in the library.
+        if(CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES)
+            # We generate the key from the signing key. The signing key is passed from the main project.
+            get_filename_component(secure_boot_signing_key
+                "${SECURE_BOOT_SIGNING_KEY}"
+                ABSOLUTE BASE_DIR "${project_dir}")
+            get_filename_component(secure_boot_verification_key
+                "signature_verification_key.bin"
+                ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+            add_custom_command(OUTPUT "${secure_boot_verification_key}"
+                COMMAND ${ESPSECUREPY}
+                extract_public_key --keyfile "${secure_boot_signing_key}"
+                "${secure_boot_verification_key}"
+                DEPENDS ${secure_boot_signing_key}
+                VERBATIM)
+        else()
+            # We expect to 'inherit' the verification key passed from main project.
+            get_filename_component(secure_boot_verification_key
+                ${SECURE_BOOT_VERIFICATION_KEY}
+                ABSOLUTE BASE_DIR "${project_dir}")
+        endif()
+    else()  # normal app build
+        idf_build_get_property(project_dir PROJECT_DIR)
+
+        if(CONFIG_SECURE_BOOT_VERIFICATION_KEY)
+            # verification-only build supplies verification key
+            set(secure_boot_verification_key ${CONFIG_SECURE_BOOT_VERIFICATION_KEY})
+            get_filename_component(secure_boot_verification_key
+                ${secure_boot_verification_key}
+                ABSOLUTE BASE_DIR "${project_dir}")
+        else()
+            # sign at build time, extracts key from signing key
+            set(secure_boot_verification_key "${CMAKE_BINARY_DIR}/signature_verification_key.bin")
+            get_filename_component(secure_boot_signing_key
+                ${CONFIG_SECURE_BOOT_SIGNING_KEY}
+                ABSOLUTE BASE_DIR "${project_dir}")
+
+            add_custom_command(OUTPUT "${secure_boot_verification_key}"
+                COMMAND ${ESPSECUREPY}
+                extract_public_key --keyfile "${secure_boot_signing_key}"
+                "${secure_boot_verification_key}"
+                WORKING_DIRECTORY ${project_dir}
+                DEPENDS ${secure_boot_signing_key}
+                VERBATIM)
+        endif()
+    endif()
+
+    # Embed the verification key in the binary (app & bootloader)
+    #
+    target_add_binary_data(${COMPONENT_LIB} "${secure_boot_verification_key}" "BINARY"
+        RENAME_TO signature_verification_key_bin)
+    set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+        "${secure_boot_verification_key}")
+endif()

--- a/components/bootloader_support/Makefile.projbuild
+++ b/components/bootloader_support/Makefile.projbuild
@@ -1,0 +1,7 @@
+$(SECURE_BOOT_SIGNING_KEY):
+	@echo "Need to generate secure boot signing key."
+	@echo "One way is to run this command:"
+	@echo "$(ESPSECUREPY) generate_signing_key $@"
+	@echo "Keep key file safe after generating."
+	@echo "(See secure boot documentation for risks & alternatives.)"
+	@exit 1

--- a/components/bootloader_support/README.rst
+++ b/components/bootloader_support/README.rst
@@ -1,0 +1,9 @@
+Bootloader Support Component
+============================
+
+Overview
+--------
+
+"Bootloader support" contains APIs which are used by the bootloader but are also needed for the main app.
+
+Code in this component needs to be aware of being executed in a bootloader environment (no RTOS available, BOOTLOADER_BUILD macro set) or in an esp-idf app environment (RTOS running, need locking support.)

--- a/components/bootloader_support/component.mk
+++ b/components/bootloader_support/component.mk
@@ -1,0 +1,72 @@
+COMPONENT_ADD_INCLUDEDIRS := include
+
+ifdef IS_BOOTLOADER_BUILD
+# share "include_bootloader" headers with bootloader main component
+COMPONENT_ADD_INCLUDEDIRS += include_bootloader
+else
+COMPONENT_PRIV_INCLUDEDIRS := include_bootloader
+endif
+
+COMPONENT_SRCDIRS := src
+
+ifndef IS_BOOTLOADER_BUILD
+COMPONENT_SRCDIRS += src/idf  # idf sub-directory contains platform agnostic IDF versions
+else
+COMPONENT_SRCDIRS += src/$(IDF_TARGET)  # one sub-dir per chip
+endif
+
+ifndef IS_BOOTLOADER_BUILD
+COMPONENT_OBJEXCLUDE := src/bootloader_init.o
+endif
+
+COMPONENT_OBJEXCLUDE += src/bootloader_flash_config_esp32s2.o \
+			src/bootloader_efuse_esp32s2.o \
+			src/bootloader_random_esp32s2.o
+
+ifndef CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
+ifndef CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME
+COMPONENT_OBJEXCLUDE += src/$(IDF_TARGET)/secure_boot_signatures.o \
+			src/idf/secure_boot_signatures.o
+endif
+endif
+
+ifndef CONFIG_SECURE_BOOT
+COMPONENT_OBJEXCLUDE += src/$(IDF_TARGET)/secure_boot.o
+endif
+
+#
+# Secure boot signing key support
+#
+ifdef CONFIG_SECURE_SIGNED_APPS
+
+ifdef CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
+# this path is created relative to the component build directory
+SECURE_BOOT_VERIFICATION_KEY := $(abspath signature_verification_key.bin)
+
+ifdef CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES
+# verification key derived from signing key.
+$(SECURE_BOOT_VERIFICATION_KEY): $(SECURE_BOOT_SIGNING_KEY) $(SDKCONFIG_MAKEFILE)
+	$(ESPSECUREPY) extract_public_key --keyfile $< $@
+else
+# find the configured public key file
+ORIG_SECURE_BOOT_VERIFICATION_KEY := $(call resolvepath,$(call dequote,$(CONFIG_SECURE_BOOT_VERIFICATION_KEY)),$(PROJECT_PATH))
+
+$(ORIG_SECURE_BOOT_VERIFICATION_KEY):
+	@echo "Secure boot verification public key '$@' missing."
+	@echo "This can be extracted from the private signing key, see"
+	@echo "docs/security/secure-boot-v1.rst for details."
+	exit 1
+
+# copy it into the build dir, so the secure boot verification key has
+# a predictable file name
+$(SECURE_BOOT_VERIFICATION_KEY): $(ORIG_SECURE_BOOT_VERIFICATION_KEY) $(SDKCONFIG_MAKEFILE)
+	$(summary) CP $< $@
+	cp $< $@
+endif #CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES
+
+COMPONENT_EXTRA_CLEAN += $(SECURE_BOOT_VERIFICATION_KEY)
+
+COMPONENT_EMBED_FILES := $(SECURE_BOOT_VERIFICATION_KEY)
+
+endif #CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
+endif #CONFIG_SECURE_SIGNED_APPS

--- a/components/bootloader_support/include/bootloader_clock.h
+++ b/components/bootloader_support/include/bootloader_clock.h
@@ -1,0 +1,34 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Configure clocks for early boot
+ *
+ * Called by bootloader, or by the app if the bootloader version is old (pre v2.1).
+ */
+void bootloader_clock_configure(void);
+
+/** @brief Return the rated maximum frequency of this chip
+ */
+int bootloader_clock_get_rated_freq_mhz(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/components/bootloader_support/include/bootloader_common.h
+++ b/components/bootloader_support/include/bootloader_common.h
@@ -1,0 +1,258 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "esp_flash_partitions.h"
+#include "esp_image_format.h"
+#include "esp_app_format.h"
+// RESET_REASON is declared in rom/rtc.h
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/rtc.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/rtc.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Type of hold a GPIO in low state
+typedef enum {
+    GPIO_LONG_HOLD  = 1,    /*!< The long hold GPIO */
+    GPIO_SHORT_HOLD = -1,   /*!< The short hold GPIO */
+    GPIO_NOT_HOLD   = 0     /*!< If the GPIO input is not low */
+} esp_comm_gpio_hold_t;
+
+typedef enum {
+    ESP_IMAGE_BOOTLOADER,
+    ESP_IMAGE_APPLICATION
+} esp_image_type;
+
+/**
+ * @brief Calculate crc for the OTA data select.
+ *
+ * @param[in] s The OTA data select.
+ * @return    Returns crc value.
+ */
+uint32_t bootloader_common_ota_select_crc(const esp_ota_select_entry_t *s);
+
+/**
+ * @brief Verifies the validity of the OTA data select
+ *
+ * @param[in] s The OTA data select.
+ * @return    Returns true on valid, false otherwise.
+ */
+bool bootloader_common_ota_select_valid(const esp_ota_select_entry_t *s);
+
+/**
+ * @brief Returns true if OTADATA is not marked as bootable partition.
+ *
+ * @param[in] s The OTA data select.
+ * @return    Returns true if OTADATA invalid, false otherwise.
+ */
+bool bootloader_common_ota_select_invalid(const esp_ota_select_entry_t *s);
+
+/**
+ * @brief Check if the GPIO input is a long hold or a short hold.
+ *
+ * Number of the GPIO input will be configured as an input with internal pull-up enabled.
+ * If the GPIO input is held low continuously for delay_sec period then it is a long hold.
+ * If the GPIO input is held low for less period then it is a short hold.
+ *
+ * @param[in] num_pin Number of the GPIO input.
+ * @param[in] delay_sec Input must be driven low for at least this long, continuously.
+ * @return esp_comm_gpio_hold_t Defines type of hold a GPIO in low state.
+ */
+esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, uint32_t delay_sec);
+
+/**
+ * @brief Erase the partition data that is specified in the transferred list.
+ *
+ * @param[in] list_erase String containing a list of cleared partitions. Like this "nvs, phy". The string must be null-terminal.
+ * @param[in] ota_data_erase If true then the OTA data partition will be cleared (if there is it in partition table).
+ * @return    Returns true on success, false otherwise.
+ */
+bool bootloader_common_erase_part_type_data(const char *list_erase, bool ota_data_erase);
+
+/**
+ * @brief Determines if the list contains the label
+ *
+ * @param[in] list  A string of names delimited by commas or spaces. Like this "nvs, phy, data". The string must be null-terminated.
+ * @param[in] label The substring that will be searched in the list.
+ * @return    Returns true if the list contains the label, false otherwise.
+ */
+bool bootloader_common_label_search(const char *list, char *label);
+
+/**
+ * @brief Configure default SPI pin modes and drive strengths
+ *
+ * @param drv GPIO drive level (determined by clock frequency)
+ */
+void bootloader_configure_spi_pins(int drv);
+
+/**
+ * @brief Calculates a sha-256 for a given partition or returns a appended digest.
+ *
+ * This function can be used to return the SHA-256 digest of application, bootloader and data partitions.
+ * For apps with SHA-256 appended to the app image, the result is the appended SHA-256 value for the app image content.
+ * The hash is verified before returning, if app content is invalid then the function returns ESP_ERR_IMAGE_INVALID.
+ * For apps without SHA-256 appended to the image, the result is the SHA-256 of all bytes in the app image.
+ * For other partition types, the result is the SHA-256 of the entire partition.
+ *
+ * @param[in]  address      Address of partition.
+ * @param[in]  size         Size of partition.
+ * @param[in]  type         Type of partition. For applications the type is 0, otherwise type is data.
+ * @param[out] out_sha_256  Returned SHA-256 digest for a given partition.
+ *
+ * @return
+ *          - ESP_OK: In case of successful operation.
+ *          - ESP_ERR_INVALID_ARG: The size was 0 or the sha_256 was NULL.
+ *          - ESP_ERR_NO_MEM: Cannot allocate memory for sha256 operation.
+ *          - ESP_ERR_IMAGE_INVALID: App partition doesn't contain a valid app image.
+ *          - ESP_FAIL: An allocation error occurred.
+ */
+esp_err_t bootloader_common_get_sha256_of_partition(uint32_t address, uint32_t size, int type, uint8_t *out_sha_256);
+
+/**
+ * @brief Returns the number of active otadata.
+ *
+ * @param[in] two_otadata Pointer on array from two otadata structures.
+ *
+ * @return The number of active otadata (0 or 1).
+ *        - -1: If it does not have active otadata.
+ */
+int bootloader_common_get_active_otadata(esp_ota_select_entry_t *two_otadata);
+
+/**
+ * @brief Returns the number of active otadata.
+ *
+ * @param[in] two_otadata       Pointer on array from two otadata structures.
+ * @param[in] valid_two_otadata Pointer on array from two bools. True means select.
+ * @param[in] max               True - will select the maximum ota_seq number, otherwise the minimum.
+ *
+ * @return The number of active otadata (0 or 1).
+ *        - -1: If it does not have active otadata.
+ */
+int bootloader_common_select_otadata(const esp_ota_select_entry_t *two_otadata, bool *valid_two_otadata, bool max);
+
+/**
+ * @brief Returns esp_app_desc structure for app partition. This structure includes app version.
+ *
+ * Returns a description for the requested app partition.
+ * @param[in] partition      App partition description.
+ * @param[out] app_desc      Structure of info about app.
+ * @return
+ *  - ESP_OK:                Successful.
+ *  - ESP_ERR_INVALID_ARG:   The arguments passed are not valid.
+ *  - ESP_ERR_NOT_FOUND:     app_desc structure is not found. Magic word is incorrect.
+ *  - ESP_FAIL:              mapping is fail.
+ */
+esp_err_t bootloader_common_get_partition_description(const esp_partition_pos_t *partition, esp_app_desc_t *app_desc);
+
+/**
+ * @brief Get chip revision
+ *
+ * @return Chip revision number
+ */
+uint8_t bootloader_common_get_chip_revision(void);
+
+/**
+ * @brief Query reset reason
+ *
+ * @param cpu_no CPU number
+ * @return reset reason enumeration
+ */
+RESET_REASON bootloader_common_get_reset_reason(int cpu_no);
+
+/**
+ * @brief Check if the image (bootloader and application) has valid chip ID and revision
+ *
+ * @param[in] img_hdr: image header
+ * @param[in] type: image type, bootloader or application
+ * @return
+ *      - ESP_OK: image and chip are matched well
+ *      - ESP_FAIL: image doesn't match to the chip
+ */
+esp_err_t bootloader_common_check_chip_validity(const esp_image_header_t* img_hdr, esp_image_type type);
+
+/**
+ * @brief Configure VDDSDIO, call this API to rise VDDSDIO to 1.9V when VDDSDIO regulator is enabled as 1.8V mode.
+ */
+void bootloader_common_vddsdio_configure(void);
+
+#if defined( CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP ) || defined( CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC )
+/**
+ * @brief Returns partition from rtc_retain_mem
+ *
+ * Uses to get the partition of application which was worked before to go to the deep sleep.
+ * This partition was stored in rtc_retain_mem.
+ * Note: This function operates the RTC FAST memory which available only for PRO_CPU.
+ *       Make sure that this function is used only PRO_CPU.
+ *
+ * @return partition: If rtc_retain_mem is valid.
+ *        - NULL: If it is not valid.
+ */
+esp_partition_pos_t* bootloader_common_get_rtc_retain_mem_partition(void);
+
+/**
+ * @brief Update the partition and reboot_counter in rtc_retain_mem.
+ *
+ * This function saves the partition of application for fast booting from the deep sleep.
+ * An algorithm uses this partition to avoid reading the otadata and does not validate an image.
+ * Note: This function operates the RTC FAST memory which available only for PRO_CPU.
+ *       Make sure that this function is used only PRO_CPU.
+ *
+ * @param[in] partition      App partition description. Can be NULL, in this case rtc_retain_mem.partition is not updated.
+ * @param[in] reboot_counter If true then update reboot_counter.
+ *
+ */
+void bootloader_common_update_rtc_retain_mem(esp_partition_pos_t* partition, bool reboot_counter);
+
+/**
+ * @brief Reset entire rtc_retain_mem.
+ *
+ * Note: This function operates the RTC FAST memory which available only for PRO_CPU.
+ *       Make sure that this function is used only PRO_CPU.
+ */
+void bootloader_common_reset_rtc_retain_mem(void);
+
+/**
+ * @brief Returns reboot_counter from rtc_retain_mem
+ *
+ * The reboot_counter counts the number of reboots. Reset only when power is off.
+ * The very first launch of the application will be from 1.
+ * Overflow is not possible, it will stop at the value UINT16_MAX.
+ * Note: This function operates the RTC FAST memory which available only for PRO_CPU.
+ *       Make sure that this function is used only PRO_CPU.
+ *
+ * @return reboot_counter: 1..65535
+ *         - 0: If rtc_retain_mem is not valid.
+ */
+uint16_t bootloader_common_get_rtc_retain_mem_reboot_counter(void);
+
+/**
+ * @brief Returns rtc_retain_mem
+ *
+ * Note: This function operates the RTC FAST memory which available only for PRO_CPU.
+ *       Make sure that this function is used only PRO_CPU.
+ *
+ * @return rtc_retain_mem
+ */
+rtc_retain_mem_t* bootloader_common_get_rtc_retain_mem(void);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/bootloader_flash_config.h
+++ b/components/bootloader_support/include/bootloader_flash_config.h
@@ -1,0 +1,96 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "sdkconfig.h"
+#include "esp_image_format.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Update the flash id in g_rom_flashchip(global esp_rom_spiflash_chip_t structure).
+ *
+ * @return None
+ */
+void bootloader_flash_update_id(void);
+
+/**
+ * @brief Update the flash size in g_rom_flashchip (global esp_rom_spiflash_chip_t structure).
+ *
+ * @param size The size to store, in bytes.
+ * @return None
+ */
+void bootloader_flash_update_size(uint32_t size);
+
+/**
+ * @brief Set the flash CS setup and hold time.
+ *
+ * @note CS setup time is recomemded to be 1.5T, and CS hold time is recommended to be 2.5T.
+ *       cs_setup = 1, cs_setup_time = 0; cs_hold = 1, cs_hold_time = 1.
+ *
+ * @return None
+ */
+void bootloader_flash_cs_timing_config(void);
+
+/**
+ * @brief Configure SPI flash clock.
+ *
+ * @note This function only set clock frequency for SPI0.
+ *
+ * @param pfhdr Pointer to App image header, from where to fetch flash settings.
+ *
+ * @return None
+ */
+void bootloader_flash_clock_config(const esp_image_header_t* pfhdr);
+
+/**
+ * @brief Configure SPI flash gpio, include the IO matrix and drive strength configuration.
+ *
+ * @param pfhdr Pointer to App image header, from where to fetch flash settings.
+ *
+ * @return None
+ */
+void bootloader_flash_gpio_config(const esp_image_header_t* pfhdr);
+
+/**
+ * @brief Configure SPI flash read dummy based on different mode and frequency.
+ *
+ * @param pfhdr Pointer to App image header, from where to fetch flash settings.
+ *
+ * @return None
+ */
+void bootloader_flash_dummy_config(const esp_image_header_t* pfhdr);
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+/**
+ * @brief Return the pin number used for custom SPI flash and/or SPIRAM WP pin
+ *
+ * Can be determined by eFuse values in most cases, or overriden in configuration
+ *
+ * This value is only meaningful if the other SPI flash pins are overriden via eFuse.
+ *
+ * This value is only meaningful if flash is set to QIO or QOUT mode, or if
+ * SPIRAM is enabled.
+ *
+ * @return Pin number to use, or -1 if the default should be kept
+ */
+int bootloader_flash_get_wp_pin(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/bootloader_mem.h
+++ b/components/bootloader_support/include/bootloader_mem.h
@@ -1,0 +1,24 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void bootloader_init_mem(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/bootloader_random.h
+++ b/components/bootloader_support/include/bootloader_random.h
@@ -1,0 +1,57 @@
+// Copyright 2010-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable early entropy source for RNG
+ *
+ * Uses the SAR ADC to feed entropy into the HWRNG. The ADC is put
+ * into a test mode that reads the 1.1V internal reference source and
+ * feeds the LSB of data into the HWRNG.
+ *
+ * Can also be used from app code early during operation, if entropy
+ * is required before WiFi stack is initialised. Call this function
+ * from app code only if WiFi/BT are not yet enabled and I2S and SAR
+ * ADC are not in use.
+ *
+ * Call bootloader_random_disable() when done.
+ */
+void bootloader_random_enable(void);
+
+/**
+ * @brief Disable early entropy source for RNG
+ *
+ * Disables SAR ADC source and resets the I2S hardware.
+ *
+ */
+void bootloader_random_disable(void);
+
+/**
+ * @brief Fill buffer with 'length' random bytes
+ *
+ * @param buffer Pointer to buffer
+ * @param length This many bytes of random data will be copied to buffer
+ */
+void bootloader_fill_random(void *buffer, size_t length);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/bootloader_util.h
+++ b/components/bootloader_support/include/bootloader_util.h
@@ -1,0 +1,43 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Check if half-open intervals overlap
+ *
+ * @param start1  interval 1 start
+ * @param end1    interval 1 end
+ * @param start2  interval 2 start
+ * @param end2    interval 2 end
+ * @return true iff [start1; end1) overlaps [start2; end2)
+ */
+static inline bool bootloader_util_regions_overlap(
+        const intptr_t start1, const intptr_t end1,
+        const intptr_t start2, const intptr_t end2)
+{
+    assert(end1>start1);
+    assert(end2>start2);
+    return (end1 > start2 && end2 > start1);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/esp_app_format.h
+++ b/components/bootloader_support/include/esp_app_format.h
@@ -1,0 +1,139 @@
+// Copyright 2015-2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ESP chip ID
+ *
+ */
+typedef enum {
+    ESP_CHIP_ID_ESP32 = 0x0000,  /*!< chip ID: ESP32 */
+    ESP_CHIP_ID_ESP32S2 = 0x0002,  /*!< chip ID: ESP32S2 */
+    ESP_CHIP_ID_INVALID = 0xFFFF /*!< Invalid chip ID (we defined it to make sure the esp_chip_id_t is 2 bytes size) */
+} __attribute__((packed)) esp_chip_id_t;
+
+#ifndef __cplusplus
+/** @cond */
+_Static_assert(sizeof(esp_chip_id_t) == 2, "esp_chip_id_t should be 16 bit");
+/** @endcond */
+#endif
+
+/**
+ * @brief SPI flash mode, used in esp_image_header_t
+ */
+typedef enum {
+    ESP_IMAGE_SPI_MODE_QIO,         /*!< SPI mode QIO */
+    ESP_IMAGE_SPI_MODE_QOUT,        /*!< SPI mode QOUT */
+    ESP_IMAGE_SPI_MODE_DIO,         /*!< SPI mode DIO */
+    ESP_IMAGE_SPI_MODE_DOUT,        /*!< SPI mode DOUT */
+    ESP_IMAGE_SPI_MODE_FAST_READ,   /*!< SPI mode FAST_READ */
+    ESP_IMAGE_SPI_MODE_SLOW_READ    /*!< SPI mode SLOW_READ */
+} esp_image_spi_mode_t;
+
+/**
+ * @brief SPI flash clock frequency
+ */
+typedef enum {
+    ESP_IMAGE_SPI_SPEED_40M,        /*!< SPI clock frequency 40 MHz */
+    ESP_IMAGE_SPI_SPEED_26M,        /*!< SPI clock frequency 26 MHz */
+    ESP_IMAGE_SPI_SPEED_20M,        /*!< SPI clock frequency 20 MHz */
+    ESP_IMAGE_SPI_SPEED_80M = 0xF   /*!< SPI clock frequency 80 MHz */
+} esp_image_spi_freq_t;
+
+/**
+ * @brief Supported SPI flash sizes
+ */
+typedef enum {
+    ESP_IMAGE_FLASH_SIZE_1MB = 0,   /*!< SPI flash size 1 MB */
+    ESP_IMAGE_FLASH_SIZE_2MB,       /*!< SPI flash size 2 MB */
+    ESP_IMAGE_FLASH_SIZE_4MB,       /*!< SPI flash size 4 MB */
+    ESP_IMAGE_FLASH_SIZE_8MB,       /*!< SPI flash size 8 MB */
+    ESP_IMAGE_FLASH_SIZE_16MB,      /*!< SPI flash size 16 MB */
+    ESP_IMAGE_FLASH_SIZE_MAX        /*!< SPI flash size MAX */
+} esp_image_flash_size_t;
+
+#define ESP_IMAGE_HEADER_MAGIC 0xE9 /*!< The magic word for the esp_image_header_t structure. */
+
+/**
+ * @brief Main header of binary image
+ */
+typedef struct {
+    uint8_t magic;              /*!< Magic word ESP_IMAGE_HEADER_MAGIC */
+    uint8_t segment_count;      /*!< Count of memory segments */
+    uint8_t spi_mode;           /*!< flash read mode (esp_image_spi_mode_t as uint8_t) */
+    uint8_t spi_speed: 4;       /*!< flash frequency (esp_image_spi_freq_t as uint8_t) */
+    uint8_t spi_size: 4;        /*!< flash chip size (esp_image_flash_size_t as uint8_t) */
+    uint32_t entry_addr;        /*!< Entry address */
+    uint8_t wp_pin;            /*!< WP pin when SPI pins set via efuse (read by ROM bootloader,
+                                * the IDF bootloader uses software to configure the WP
+                                * pin and sets this field to 0xEE=disabled) */
+    uint8_t spi_pin_drv[3];     /*!< Drive settings for the SPI flash pins (read by ROM bootloader) */
+    esp_chip_id_t chip_id;      /*!< Chip identification number */
+    uint8_t min_chip_rev;       /*!< Minimum chip revision supported by image */
+    uint8_t reserved[8];       /*!< Reserved bytes in additional header space, currently unused */
+    uint8_t hash_appended;      /*!< If 1, a SHA256 digest "simple hash" (of the entire image) is appended after the checksum.
+                                 * Included in image length. This digest
+                                 * is separate to secure boot and only used for detecting corruption.
+                                 * For secure boot signed images, the signature
+                                 * is appended after this (and the simple hash is included in the signed data). */
+} __attribute__((packed))  esp_image_header_t;
+
+#ifndef __cplusplus
+/** @cond */
+_Static_assert(sizeof(esp_image_header_t) == 24, "binary image header should be 24 bytes");
+/** @endcond */
+#endif
+
+
+/**
+ * @brief Header of binary image segment
+ */
+typedef struct {
+    uint32_t load_addr;     /*!< Address of segment */
+    uint32_t data_len;      /*!< Length of data */
+} esp_image_segment_header_t;
+
+#define ESP_IMAGE_MAX_SEGMENTS 16           /*!< Max count of segments in the image. */
+
+#define ESP_APP_DESC_MAGIC_WORD 0xABCD5432  /*!< The magic word for the esp_app_desc structure that is in DROM. */
+
+/**
+ * @brief Description about application.
+ */
+typedef struct {
+    uint32_t magic_word;        /*!< Magic word ESP_APP_DESC_MAGIC_WORD */
+    uint32_t secure_version;    /*!< Secure version */
+    uint32_t reserv1[2];        /*!< reserv1 */
+    char version[32];           /*!< Application version */
+    char project_name[32];      /*!< Project name */
+    char time[16];              /*!< Compile time */
+    char date[16];              /*!< Compile date*/
+    char idf_ver[32];           /*!< Version IDF */
+    uint8_t app_elf_sha256[32]; /*!< sha256 of elf file */
+    uint32_t reserv2[20];       /*!< reserv2 */
+} esp_app_desc_t;
+
+#ifndef __cplusplus
+/** @cond */
+_Static_assert(sizeof(esp_app_desc_t) == 256, "esp_app_desc_t should be 256 bytes");
+/** @endcond */
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/esp_flash_data_types.h
+++ b/components/bootloader_support/include/esp_flash_data_types.h
@@ -1,0 +1,2 @@
+#warning esp_flash_data_types.h has been merged into esp_flash_partitions.h, please include esp_flash_partitions.h instead
+#include "esp_flash_partitions.h"

--- a/components/bootloader_support/include/esp_flash_encrypt.h
+++ b/components/bootloader_support/include/esp_flash_encrypt.h
@@ -1,0 +1,164 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <stdbool.h>
+#include "esp_attr.h"
+#include "esp_err.h"
+#ifndef BOOTLOADER_BUILD
+#include "esp_spi_flash.h"
+#endif
+#include "soc/efuse_periph.h"
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* @brief Flash encryption mode based on efuse values
+*/
+typedef enum {
+    ESP_FLASH_ENC_MODE_DISABLED,          // flash encryption is not enabled (flash crypt cnt=0)
+    ESP_FLASH_ENC_MODE_DEVELOPMENT,       // flash encryption is enabled but for Development (reflash over UART allowed)
+    ESP_FLASH_ENC_MODE_RELEASE            // flash encryption is enabled for Release (reflash over UART disabled)
+} esp_flash_enc_mode_t;
+
+/**
+ * @file esp_partition.h
+ * @brief Support functions for flash encryption features
+ *
+ * Can be compiled as part of app or bootloader code.
+ */
+
+/** @brief Is flash encryption currently enabled in hardware?
+ *
+ * Flash encryption is enabled if the FLASH_CRYPT_CNT efuse has an odd number of bits set.
+ *
+ * @return true if flash encryption is enabled.
+ */
+static inline /** @cond */ IRAM_ATTR /** @endcond */ bool esp_flash_encryption_enabled(void)
+{
+    uint32_t flash_crypt_cnt;
+#if CONFIG_IDF_TARGET_ESP32
+    flash_crypt_cnt = REG_GET_FIELD(EFUSE_BLK0_RDATA0_REG, EFUSE_RD_FLASH_CRYPT_CNT);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    flash_crypt_cnt = REG_GET_FIELD(EFUSE_RD_REPEAT_DATA1_REG, EFUSE_SPI_BOOT_CRYPT_CNT);
+#endif
+    /* __builtin_parity is in flash, so we calculate parity inline */
+    bool enabled = false;
+    while (flash_crypt_cnt) {
+        if (flash_crypt_cnt & 1) {
+            enabled = !enabled;
+        }
+        flash_crypt_cnt >>= 1;
+    }
+    return enabled;
+}
+
+/* @brief Update on-device flash encryption
+ *
+ * Intended to be called as part of the bootloader process if flash
+ * encryption is enabled in device menuconfig.
+ *
+ * If FLASH_CRYPT_CNT efuse parity is 1 (ie odd number of bits set),
+ * then return ESP_OK immediately (indicating flash encryption is enabled
+ * and functional).
+ *
+ * If FLASH_CRYPT_CNT efuse parity is 0 (ie even number of bits set),
+ * assume the flash has just been written with plaintext that needs encrypting.
+ *
+ * The following regions of flash are encrypted in place:
+ *
+ * - The bootloader image, if a valid plaintext image is found.[*]
+ * - The partition table, if a valid plaintext table is found.
+ * - Any app partition that contains a valid plaintext app image.
+ * - Any other partitions with the "encrypt" flag set. [**]
+ *
+ * After the re-encryption process completes, a '1' bit is added to the
+ * FLASH_CRYPT_CNT value (setting the parity to 1) and the EFUSE is re-burned.
+ *
+ * [*] If reflashing bootloader with secure boot enabled, pre-encrypt
+ * the bootloader before writing it to flash or secure boot will fail.
+ *
+ * [**] For this reason, if serial re-flashing a previous flashed
+ * device with secure boot enabled and using FLASH_CRYPT_CNT to
+ * trigger re-encryption, you must simultaneously re-flash plaintext
+ * content to all partitions with the "encrypt" flag set or this
+ * data will be corrupted (encrypted twice).
+ *
+ * @note The post-condition of this function is that all
+ * partitions that should be encrypted are encrypted.
+ *
+ * @note Take care not to power off the device while this function
+ * is running, or the partition currently being encrypted will be lost.
+ *
+ * @note RTC_WDT will reset while encryption operations will be performed (if RTC_WDT is configured).
+ *
+ * @return ESP_OK if all operations succeeded, ESP_ERR_INVALID_STATE
+ * if a fatal error occured during encryption of all partitions.
+ */
+esp_err_t esp_flash_encrypt_check_and_update(void);
+
+
+/** @brief Encrypt-in-place a block of flash sectors
+ *
+ * @note This function resets RTC_WDT between operations with sectors.
+ * @param src_addr Source offset in flash. Should be multiple of 4096 bytes.
+ * @param data_length Length of data to encrypt in bytes. Will be rounded up to next multiple of 4096 bytes.
+ *
+ * @return ESP_OK if all operations succeeded, ESP_ERR_FLASH_OP_FAIL
+ * if SPI flash fails, ESP_ERR_FLASH_OP_TIMEOUT if flash times out.
+ */
+esp_err_t esp_flash_encrypt_region(uint32_t src_addr, size_t data_length);
+
+/** @brief Write protect FLASH_CRYPT_CNT
+ *
+ * Intended to be called as a part of boot process if flash encryption
+ * is enabled but secure boot is not used. This should protect against
+ * serial re-flashing of an unauthorised code in absence of secure boot.
+ *
+ * @note On ESP32 V3 only, write protecting FLASH_CRYPT_CNT will also prevent
+ * disabling UART Download Mode. If both are wanted, call
+ * esp_efuse_disable_rom_download_mode() before calling this function.
+ *
+ */
+void esp_flash_write_protect_crypt_cnt(void);
+
+/** @brief Return the flash encryption mode
+ *
+ * The API is called during boot process but can also be called by
+ * application to check the current flash encryption mode of ESP32
+ *
+ * @return
+ */
+esp_flash_enc_mode_t esp_get_flash_encryption_mode(void);
+
+
+/** @brief Check the flash encryption mode during startup
+ *
+ * @note This function is called automatically during app startup,
+ * it doesn't need to be called from the app.
+ *
+ * Verifies the flash encryption config during startup:
+ *
+ * - Correct any insecure flash encryption settings if hardware
+ *   Secure Boot is enabled.
+ * - Log warnings if the efuse config doesn't match the project
+ *  config in any way
+ */
+void esp_flash_encryption_init_checks(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/esp_flash_partitions.h
+++ b/components/bootloader_support/include/esp_flash_partitions.h
@@ -1,0 +1,116 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "esp_err.h"
+#include "esp_types.h"
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_PARTITION_MAGIC 0x50AA
+#define ESP_PARTITION_MAGIC_MD5 0xEBEB
+
+#define PART_TYPE_APP 0x00
+#define PART_SUBTYPE_FACTORY  0x00
+#define PART_SUBTYPE_OTA_FLAG 0x10
+#define PART_SUBTYPE_OTA_MASK 0x0f
+#define PART_SUBTYPE_TEST     0x20
+
+#define PART_TYPE_DATA 0x01
+#define PART_SUBTYPE_DATA_OTA 0x00
+#define PART_SUBTYPE_DATA_RF  0x01
+#define PART_SUBTYPE_DATA_WIFI 0x02
+#define PART_SUBTYPE_DATA_NVS_KEYS 0x04
+#define PART_SUBTYPE_DATA_EFUSE_EM 0x05
+
+#define PART_TYPE_END 0xff
+#define PART_SUBTYPE_END 0xff
+
+#define PART_FLAG_ENCRYPTED (1<<0)
+
+/* The md5sum value is found this many bytes after the ESP_PARTITION_MAGIC_MD5 offset */
+#define ESP_PARTITION_MD5_OFFSET 16
+
+/* Pre-partition table fixed flash offsets */
+#define ESP_BOOTLOADER_DIGEST_OFFSET 0x0
+#define ESP_BOOTLOADER_OFFSET 0x1000 /* Offset of bootloader image. Has matching value in bootloader KConfig.projbuild file. */
+#define ESP_PARTITION_TABLE_OFFSET CONFIG_PARTITION_TABLE_OFFSET /* Offset of partition table. Backwards-compatible name.*/
+
+#define ESP_PARTITION_TABLE_MAX_LEN 0xC00 /* Maximum length of partition table data */
+#define ESP_PARTITION_TABLE_MAX_ENTRIES (ESP_PARTITION_TABLE_MAX_LEN / sizeof(esp_partition_info_t)) /* Maximum length of partition table data, including terminating entry */
+
+/// OTA_DATA states for checking operability of the app.
+typedef enum {
+    ESP_OTA_IMG_NEW             = 0x0U,         /*!< Monitor the first boot. In bootloader this state is changed to ESP_OTA_IMG_PENDING_VERIFY. */
+    ESP_OTA_IMG_PENDING_VERIFY  = 0x1U,         /*!< First boot for this app was. If while the second boot this state is then it will be changed to ABORTED. */
+    ESP_OTA_IMG_VALID           = 0x2U,         /*!< App was confirmed as workable. App can boot and work without limits. */
+    ESP_OTA_IMG_INVALID         = 0x3U,         /*!< App was confirmed as non-workable. This app will not selected to boot at all. */
+    ESP_OTA_IMG_ABORTED         = 0x4U,         /*!< App could not confirm the workable or non-workable. In bootloader IMG_PENDING_VERIFY state will be changed to IMG_ABORTED. This app will not selected to boot at all. */
+    ESP_OTA_IMG_UNDEFINED       = 0xFFFFFFFFU,  /*!< Undefined. App can boot and work without limits. */
+} esp_ota_img_states_t;
+
+/* OTA selection structure (two copies in the OTA data partition.)
+   Size of 32 bytes is friendly to flash encryption */
+typedef struct {
+    uint32_t ota_seq;
+    uint8_t  seq_label[20];
+    uint32_t ota_state;
+    uint32_t crc; /* CRC32 of ota_seq field only */
+} esp_ota_select_entry_t;
+
+
+typedef struct {
+    uint32_t offset;
+    uint32_t size;
+} esp_partition_pos_t;
+
+/* Structure which describes the layout of partition table entry.
+ * See docs/partition_tables.rst for more information about individual fields.
+ */
+typedef struct {
+    uint16_t magic;
+    uint8_t  type;
+    uint8_t  subtype;
+    esp_partition_pos_t pos;
+    uint8_t  label[16];
+    uint32_t flags;
+} esp_partition_info_t;
+
+/* @brief Verify the partition table
+ *
+ * @param partition_table Pointer to at least ESP_PARTITION_TABLE_MAX_ENTRIES of potential partition table data. (ESP_PARTITION_TABLE_MAX_LEN bytes.)
+ * @param log_errors Log errors if the partition table is invalid.
+ * @param num_partitions If result is ESP_OK, num_partitions is updated with total number of partitions (not including terminating entry).
+ *
+ * @return ESP_OK on success, ESP_ERR_INVALID_STATE if partition table is not valid.
+ */
+esp_err_t esp_partition_table_verify(const esp_partition_info_t *partition_table, bool log_errors, int *num_partitions);
+
+
+/**
+ * Check whether the region on the main flash is safe to write.
+ *
+ * @param addr Start address of the region
+ * @param size Size of the region
+ *
+ * @return true if the region is safe to write, otherwise false.
+ */
+bool esp_partition_main_flash_region_safe(size_t addr, size_t size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -1,0 +1,192 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <stdbool.h>
+#include <esp_err.h>
+#include "esp_flash_partitions.h"
+#include "esp_app_format.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_ERR_IMAGE_BASE       0x2000
+#define ESP_ERR_IMAGE_FLASH_FAIL (ESP_ERR_IMAGE_BASE + 1)
+#define ESP_ERR_IMAGE_INVALID    (ESP_ERR_IMAGE_BASE + 2)
+
+/* Support for app/bootloader image parsing
+   Can be compiled as part of app or bootloader code.
+*/
+
+#define ESP_IMAGE_HASH_LEN 32 /* Length of the appended SHA-256 digest */
+
+/* Structure to hold on-flash image metadata */
+typedef struct {
+  uint32_t start_addr;   /* Start address of image */
+  esp_image_header_t image; /* Header for entire image */
+  esp_image_segment_header_t segments[ESP_IMAGE_MAX_SEGMENTS]; /* Per-segment header data */
+  uint32_t segment_data[ESP_IMAGE_MAX_SEGMENTS]; /* Data offsets for each segment */
+  uint32_t image_len; /* Length of image on flash, in bytes */
+  uint8_t image_digest[32]; /* appended SHA-256 digest */
+} esp_image_metadata_t;
+
+typedef enum {
+    ESP_IMAGE_VERIFY,            /* Verify image contents, not load to memory, load metadata. Print errors. */
+    ESP_IMAGE_VERIFY_SILENT,     /* Verify image contents, not load to memory, load metadata. Don't print errors. */
+#ifdef BOOTLOADER_BUILD
+    ESP_IMAGE_LOAD,              /* Verify image contents, load to memory, load metadata. Print errors. */
+    ESP_IMAGE_LOAD_NO_VALIDATE,  /* Not verify image contents, load to memory, load metadata. Print errors. */
+#endif
+} esp_image_load_mode_t;
+
+typedef struct {
+    esp_partition_pos_t partition;  /*!< Partition of application which worked before goes to the deep sleep. */
+    uint16_t reboot_counter;        /*!< Reboot counter. Reset only when power is off. */
+    uint16_t reserve;               /*!< Reserve */
+#ifdef CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC
+    uint8_t custom[CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC_SIZE]; /*!< Reserve for custom propose */
+#endif
+    uint32_t crc;                   /*!< Check sum crc32 */
+} rtc_retain_mem_t;
+
+#ifdef CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC
+_Static_assert(CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC_SIZE % 4 == 0, "CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC_SIZE must be a multiple of 4 bytes");
+#endif
+
+#if defined(CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP) || defined(CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC)
+_Static_assert(CONFIG_BOOTLOADER_RESERVE_RTC_SIZE % 4 == 0, "CONFIG_BOOTLOADER_RESERVE_RTC_SIZE must be a multiple of 4 bytes");
+#endif
+
+#ifdef CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC
+#define ESP_BOOTLOADER_RESERVE_RTC (CONFIG_BOOTLOADER_RESERVE_RTC_SIZE + CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC_SIZE)
+#elif defined(CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP)
+#define ESP_BOOTLOADER_RESERVE_RTC (CONFIG_BOOTLOADER_RESERVE_RTC_SIZE)
+#endif
+
+#if defined(CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP) || defined(CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC)
+_Static_assert(sizeof(rtc_retain_mem_t) <= ESP_BOOTLOADER_RESERVE_RTC, "Reserved RTC area must exceed size of rtc_retain_mem_t");
+#endif
+
+/**
+ * @brief Verify an app image.
+ *
+ * If encryption is enabled, data will be transparently decrypted.
+ *
+ * @param mode Mode of operation (verify, silent verify, or load).
+ * @param part Partition to load the app from.
+ * @param[inout] data Pointer to the image metadata structure which is be filled in by this function.
+ *                    'start_addr' member should be set (to the start address of the image.)
+ *                    Other fields will all be initialised by this function.
+ *
+ * Image validation checks:
+ * - Magic byte.
+ * - Partition smaller than 16MB.
+ * - All segments & image fit in partition.
+ * - 8 bit image checksum is valid.
+ * - SHA-256 of image is valid (if image has this appended).
+ * - (Signature) if signature verification is enabled.
+ *
+ * @return
+ * - ESP_OK if verify or load was successful
+ * - ESP_ERR_IMAGE_FLASH_FAIL if a SPI flash error occurs
+ * - ESP_ERR_IMAGE_INVALID if the image appears invalid.
+ * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
+ */
+esp_err_t esp_image_verify(esp_image_load_mode_t mode, const esp_partition_pos_t *part, esp_image_metadata_t *data);
+
+/**
+ * @brief Verify and load an app image (available only in space of bootloader).
+ *
+ * If encryption is enabled, data will be transparently decrypted.
+ *
+ * @param part Partition to load the app from.
+ * @param[inout] data Pointer to the image metadata structure which is be filled in by this function.
+ *                    'start_addr' member should be set (to the start address of the image.)
+ *                    Other fields will all be initialised by this function.
+ *
+ * Image validation checks:
+ * - Magic byte.
+ * - Partition smaller than 16MB.
+ * - All segments & image fit in partition.
+ * - 8 bit image checksum is valid.
+ * - SHA-256 of image is valid (if image has this appended).
+ * - (Signature) if signature verification is enabled.
+ *
+ * @return
+ * - ESP_OK if verify or load was successful
+ * - ESP_ERR_IMAGE_FLASH_FAIL if a SPI flash error occurs
+ * - ESP_ERR_IMAGE_INVALID if the image appears invalid.
+ * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
+ */
+esp_err_t bootloader_load_image(const esp_partition_pos_t *part, esp_image_metadata_t *data);
+
+/**
+ * @brief Load an app image without verification (available only in space of bootloader).
+ *
+ * If encryption is enabled, data will be transparently decrypted.
+ *
+ * @param part Partition to load the app from.
+ * @param[inout] data Pointer to the image metadata structure which is be filled in by this function.
+ *                    'start_addr' member should be set (to the start address of the image.)
+ *                    Other fields will all be initialised by this function.
+ *
+ * @return
+ * - ESP_OK if verify or load was successful
+ * - ESP_ERR_IMAGE_FLASH_FAIL if a SPI flash error occurs
+ * - ESP_ERR_IMAGE_INVALID if the image appears invalid.
+ * - ESP_ERR_INVALID_ARG if the partition or data pointers are invalid.
+ */
+esp_err_t bootloader_load_image_no_verify(const esp_partition_pos_t *part, esp_image_metadata_t *data);
+
+/**
+ * @brief Verify the bootloader image.
+ *
+ * @param[out] If result is ESP_OK and this pointer is non-NULL, it
+ * will be set to the length of the bootloader image.
+ *
+ * @return As per esp_image_load_metadata().
+ */
+esp_err_t esp_image_verify_bootloader(uint32_t *length);
+
+/**
+ * @brief Verify the bootloader image.
+ *
+ * @param[out] Metadata for the image. Only valid if result is ESP_OK.
+ *
+ * @return As per esp_image_load_metadata().
+ */
+esp_err_t esp_image_verify_bootloader_data(esp_image_metadata_t *data);
+
+/**
+ * @brief Get the flash size of the image
+ *
+ * @param app_flash_size The value configured in the image header
+ * @return Actual size, in bytes.
+ */
+int esp_image_get_flash_size(esp_image_flash_size_t app_flash_size);
+
+
+typedef struct {
+    uint32_t drom_addr;
+    uint32_t drom_load_addr;
+    uint32_t drom_size;
+    uint32_t irom_addr;
+    uint32_t irom_load_addr;
+    uint32_t irom_size;
+} esp_image_flash_mapping_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include/esp_secure_boot.h
+++ b/components/bootloader_support/include/esp_secure_boot.h
@@ -1,0 +1,216 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <stdbool.h>
+#include <esp_err.h>
+#include "soc/efuse_periph.h"
+#include "esp_image_format.h"
+
+#include "sdkconfig.h"
+#if CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/efuse.h"
+#else
+#include "esp32/rom/secure_boot.h"
+#endif
+
+typedef struct ets_secure_boot_signature ets_secure_boot_signature_t;
+
+#ifdef CONFIG_SECURE_BOOT_V1_ENABLED
+#if !defined(CONFIG_SECURE_SIGNED_ON_BOOT) || !defined(CONFIG_SECURE_SIGNED_ON_UPDATE) || !defined(CONFIG_SECURE_SIGNED_APPS)
+#error "internal sdkconfig error, secure boot should always enable all signature options"
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Support functions for secure boot features.
+
+   Can be compiled as part of app or bootloader code.
+*/
+
+/** @brief Is secure boot currently enabled in hardware?
+ *
+ * This means that the ROM bootloader code will only boot
+ * a verified secure bootloader from now on.
+ *
+ * @return true if secure boot is enabled.
+ */
+static inline bool esp_secure_boot_enabled(void)
+{
+#if CONFIG_IDF_TARGET_ESP32
+    #ifdef CONFIG_SECURE_BOOT_V1_ENABLED
+        return REG_READ(EFUSE_BLK0_RDATA6_REG) & EFUSE_RD_ABS_DONE_0;
+    #elif CONFIG_SECURE_BOOT_V2_ENABLED
+        return ets_use_secure_boot_v2();
+    #endif
+#elif CONFIG_IDF_TARGET_ESP32S2
+    return ets_efuse_secure_boot_enabled();
+#endif
+    return false; /* Secure Boot not enabled in menuconfig */
+}
+
+/** @brief Generate secure digest from bootloader image
+ *
+ * @important This function is intended to be called from bootloader code only.
+ *
+ * This function is only used in the context of the Secure Boot V1 scheme.
+ * 
+ * If secure boot is not yet enabled for bootloader, this will:
+ *     1) generate the secure boot key and burn it on EFUSE
+ *        (without enabling R/W protection)
+ *     2) generate the digest from bootloader and save it
+ *        to flash address 0x0
+ *
+ * If first boot gets interrupted after calling this function
+ * but before esp_secure_boot_permanently_enable() is called, then
+ * the key burned on EFUSE will not be regenerated, unless manually
+ * done using espefuse.py tool
+ *
+ * @return ESP_OK if secure boot digest is generated
+ * successfully or found to be already present
+ */
+esp_err_t esp_secure_boot_generate_digest(void);
+
+/** @brief Enable secure boot V1 if it is not already enabled.
+ *
+ * @important If this function succeeds, secure boot V1 is permanently
+ * enabled on the chip via efuse.
+ *
+ * @important This function is intended to be called from bootloader code only.
+ *
+ * @important In case of Secure Boot V1, this will enable r/w protection 
+ * of secure boot key on EFUSE, therefore it is to be ensured that 
+ * esp_secure_boot_generate_digest() is called before this .If secure boot is not 
+ * yet enabled for bootloader, this will
+ *     1) enable R/W protection of secure boot key on EFUSE
+ *     2) enable secure boot by blowing the EFUSE_RD_ABS_DONE_0 efuse.
+ *
+ * This function does not verify secure boot of the bootloader (the
+ * ROM bootloader does this.)
+ *
+ * Will fail if efuses have been part-burned in a way that indicates
+ * secure boot should not or could not be correctly enabled.
+ *
+ * @return ESP_ERR_INVALID_STATE if efuse state doesn't allow
+ * secure boot to be enabled cleanly. ESP_OK if secure boot
+ * is enabled on this chip from now on.
+ */
+esp_err_t esp_secure_boot_permanently_enable(void);
+
+/** @brief Enables secure boot V2 if it is not already enabled.
+ *
+ * @important If this function succeeds, secure boot V2 is permanently
+ * enabled on the chip via efuse.
+ *
+ * @important This function is intended to be called from bootloader code only.
+ * 
+ * @important In case of Secure Boot V2, this will enable write protection 
+ * of secure boot key on EFUSE in BLK2. .If secure boot is not 
+ * yet enabled for bootloader, this will
+ *     1) enable W protection of secure boot key on EFUSE
+ *     2) enable secure boot by blowing the EFUSE_RD_ABS_DONE_1 efuse.
+ *
+ * This function does not verify secure boot of the bootloader (the
+ * ROM bootloader does this.)
+ *
+ * @param image_data Image metadata of the application to be loaded.
+ * 
+ * Will fail if efuses have been part-burned in a way that indicates
+ * secure boot should not or could not be correctly enabled.
+ *
+ * @return ESP_ERR_INVALID_STATE if efuse state doesn't allow
+ * secure boot to be enabled cleanly. ESP_OK if secure boot
+ * is enabled on this chip from now on.
+ */
+esp_err_t esp_secure_boot_v2_permanently_enable(const esp_image_metadata_t *image_data);
+
+/** @brief Verify the secure boot signature appended to some binary data in flash.
+ *
+ * For ECDSA Scheme (Secure Boot V1) - deterministic ECDSA w/ SHA256 image
+ * For RSA Scheme (Secure Boot V2) - RSA-PSS Verification of the SHA-256 image
+ * 
+ * Public key is compiled into the calling program in the ECDSA Scheme.
+ * See the apt docs/security/secure-boot-v1.rst or docs/security/secure-boot-v2.rst for details.
+ *
+ * @param src_addr Starting offset of the data in flash.
+ * @param length Length of data in bytes. Signature is appended -after- length bytes.
+ *
+ * If flash encryption is enabled, the image will be transparently decrypted while being verified.
+ *
+ * @note This function doesn't have any fault injection resistance so should not be called
+ * during a secure boot itself (but can be called when verifying an update, etc.)
+ *
+ * @return ESP_OK if signature is valid, ESP_ERR_INVALID_STATE if
+ * signature fails, ESP_FAIL for other failures (ie can't read flash).
+ */
+esp_err_t esp_secure_boot_verify_signature(uint32_t src_addr, uint32_t length);
+
+/** @brief Secure boot verification block, on-flash data format. */
+typedef struct {
+    uint32_t version;
+    uint8_t signature[64];
+} esp_secure_boot_sig_block_t;
+
+/** @brief Verify the ECDSA secure boot signature block for Secure Boot V1.
+ *
+ *  Calculates Deterministic ECDSA w/ SHA256 based on the SHA256 hash of the image. ECDSA signature
+ *  verification must be enabled in project configuration to use this function.
+ *
+ * Similar to esp_secure_boot_verify_signature(), but can be used when the digest is precalculated.
+ * @param sig_block Pointer to ECDSA signature block data
+ * @param image_digest Pointer to 32 byte buffer holding SHA-256 hash.
+ * @param verified_digest Pointer to 32 byte buffer that will receive verified digest if verification completes. (Used during bootloader implementation only, result is invalid otherwise.)
+ *
+ */
+esp_err_t esp_secure_boot_verify_ecdsa_signature_block(const esp_secure_boot_sig_block_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest);
+
+
+/** @brief Verify the RSA secure boot signature block for Secure Boot V2.
+ *
+ *  Performs RSA-PSS Verification of the SHA-256 image based on the public key
+ *  in the signature block, compared against the public key digest stored in efuse.
+ *
+ * Similar to esp_secure_boot_verify_signature(), but can be used when the digest is precalculated.
+ * @param sig_block Pointer to RSA signature block data
+ * @param image_digest Pointer to 32 byte buffer holding SHA-256 hash.
+ * @param verified_digest Pointer to 32 byte buffer that will receive verified digest if verification completes. (Used during bootloader implementation only, result is invalid otherwise.)
+ *
+ */
+esp_err_t esp_secure_boot_verify_rsa_signature_block(const ets_secure_boot_signature_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest);
+
+/** @brief Legacy ECDSA verification function
+ *
+ * @note Deprecated, call either esp_secure_boot_verify_ecdsa_signature_block() or esp_secure_boot_verify_rsa_signature_block() instead.
+ *
+ * @param sig_block Pointer to ECDSA signature block data
+ * @param image_digest Pointer to 32 byte buffer holding SHA-256 hash.
+ */
+esp_err_t esp_secure_boot_verify_signature_block(const esp_secure_boot_sig_block_t *sig_block, const uint8_t *image_digest)
+    __attribute__((deprecated("use esp_secure_boot_verify_ecdsa_signature_block instead")));
+
+
+#define FLASH_OFFS_SECURE_BOOT_IV_DIGEST 0
+
+/** @brief Secure boot IV+digest header */
+typedef struct {
+    uint8_t iv[128];
+    uint8_t digest[64];
+} esp_secure_boot_iv_digest_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/include_bootloader/bootloader_config.h
+++ b/components/bootloader_support/include_bootloader/bootloader_config.h
@@ -1,0 +1,54 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef __BOOT_CONFIG_H__
+#define __BOOT_CONFIG_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "esp_flash_partitions.h"
+#include "soc/soc.h"
+
+#define SPI_SEC_SIZE 0x1000
+
+#define SPI_ERROR_LOG "spi flash error"
+
+#define MAX_OTA_SLOTS 16
+
+typedef struct {
+    esp_partition_pos_t ota_info;
+    esp_partition_pos_t factory;
+    esp_partition_pos_t test;
+    esp_partition_pos_t ota[MAX_OTA_SLOTS];
+    uint32_t app_count;
+    uint32_t selected_subtype;
+} bootloader_state_t;
+
+bool flash_encrypt(bootloader_state_t *bs);
+
+/* Indices used by index_to_partition are the OTA index
+   number, or these special constants */
+#define FACTORY_INDEX (-1)
+#define TEST_APP_INDEX (-2)
+#define INVALID_INDEX (-99)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOT_CONFIG_H__ */

--- a/components/bootloader_support/include_bootloader/bootloader_flash.h
+++ b/components/bootloader_support/include_bootloader/bootloader_flash.h
@@ -1,0 +1,139 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef __BOOTLOADER_FLASH_H
+#define __BOOTLOADER_FLASH_H
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <esp_err.h>
+#include <esp_spi_flash.h> /* including in bootloader for error values */
+
+#define FLASH_SECTOR_SIZE 0x1000
+#define FLASH_BLOCK_SIZE 0x10000
+#define MMAP_ALIGNED_MASK 0x0000FFFF
+
+/* Provide a Flash API for bootloader_support code,
+   that can be used from bootloader or app code.
+
+   This header is available to source code in the bootloader &
+   bootloader_support components only.
+*/
+
+/**
+ * @brief Get number of free pages
+ *
+ * @return Number of free pages
+ */
+uint32_t bootloader_mmap_get_free_pages(void);
+
+/**
+ * @brief Map a region of flash to data memory
+ *
+ * @important In bootloader code, only one region can be bootloader_mmaped at once. The previous region must be bootloader_munmapped before another region is mapped.
+ *
+ * @important In app code, these functions are not thread safe.
+ *
+ * Call bootloader_munmap once for each successful call to bootloader_mmap.
+ *
+ * In esp-idf app, this function maps directly to spi_flash_mmap.
+ *
+ * @param offset - Starting flash offset to map to memory.
+ * @param length - Length of data to map.
+ *
+ * @return Pointer to mapped data memory (at src_addr), or NULL
+ * if an allocation error occured.
+ */
+const void *bootloader_mmap(uint32_t src_addr, uint32_t size);
+
+
+/**
+ * @brief Unmap a previously mapped region of flash
+ *
+ * Call bootloader_munmap once for each successful call to bootloader_mmap.
+ */
+void bootloader_munmap(const void *mapping);
+
+/**
+ * @brief  Read data from Flash.
+ *
+ *
+ * @note All of src, dest and size have to be 4-byte aligned.
+ *
+ * @param  src   source address of the data in Flash.
+ * @param  dest  pointer to the destination buffer
+ * @param  size  length of data
+ * @param  allow_decrypt If true and flash encryption is enabled, data on flash
+ *         will be decrypted transparently as part of the read.
+ *
+ * @return ESP_OK on success, ESP_ERR_FLASH_OP_FAIL on SPI failure,
+ * ESP_ERR_FLASH_OP_TIMEOUT on SPI timeout.
+ */
+esp_err_t bootloader_flash_read(size_t src_addr, void *dest, size_t size, bool allow_decrypt);
+
+
+/**
+ * @brief  Write data to Flash.
+ *
+ * @note All of dest_addr, src and size have to be 4-byte aligned. If write_encrypted is set, dest_addr and size must be 32-byte aligned.
+ *
+ * Note: In bootloader, when write_encrypted == true, the src buffer is encrypted in place.
+ *
+ * @param  dest_addr Destination address to write in Flash.
+ * @param  src Pointer to the data to write to flash
+ * @param  size Length of data in bytes.
+ * @param  write_encrypted If true, data will be written encrypted on flash.
+ *
+ * @return ESP_OK on success, ESP_ERR_FLASH_OP_FAIL on SPI failure,
+ * ESP_ERR_FLASH_OP_TIMEOUT on SPI timeout.
+ */
+esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool write_encrypted);
+
+/**
+ * @brief  Erase the Flash sector.
+ *
+ * @param  sector  Sector number, the count starts at sector 0, 4KB per sector.
+ *
+ * @return esp_err_t
+ */
+esp_err_t bootloader_flash_erase_sector(size_t sector);
+
+/**
+ * @brief  Erase the Flash range.
+ *
+ * @param  start_addr start address of flash offset
+ * @param  size       sector aligned size to be erased
+ *
+ * @return esp_err_t
+ */
+esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size);
+
+/* Cache MMU block size */
+#define MMU_BLOCK_SIZE    0x00010000
+
+/* Cache MMU address mask (MMU tables ignore bits which are zero) */
+#define MMU_FLASH_MASK    (~(MMU_BLOCK_SIZE - 1))
+
+/**
+ * @brief Calculate the number of cache pages to map
+ * @param size  size of data to map
+ * @param vaddr  virtual address where data will be mapped
+ * @return number of cache MMU pages required to do the mapping
+ */
+static inline uint32_t bootloader_cache_pages_to_map(uint32_t size, uint32_t vaddr)
+{
+    return (size + (vaddr - (vaddr & MMU_FLASH_MASK)) + MMU_BLOCK_SIZE - 1) / MMU_BLOCK_SIZE;
+}
+
+#endif

--- a/components/bootloader_support/include_bootloader/bootloader_init.h
+++ b/components/bootloader_support/include_bootloader/bootloader_init.h
@@ -1,0 +1,59 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "esp_err.h"
+#include "esp_image_format.h"
+
+/**@{*/
+/**
+ * @brief labels from bootloader linker script: bootloader.ld
+ *
+ */
+extern int _bss_start;
+extern int _bss_end;
+extern int _data_start;
+extern int _data_end;
+/**@}*/
+
+/**
+ * @brief bootloader image header
+ *
+ */
+extern esp_image_header_t bootloader_image_hdr;
+
+/**@{*/
+/**
+ * @brief Common initialization steps that are applied to all targets.
+ *
+ */
+esp_err_t bootloader_read_bootloader_header(void);
+esp_err_t bootloader_check_bootloader_validity(void);
+void bootloader_clear_bss_section(void);
+void bootloader_config_wdt(void);
+void bootloader_enable_random(void);
+void bootloader_print_banner(void);
+/**@}*/
+
+/* @brief Prepares hardware for work.
+ *
+ * Setting up:
+ * - Disable Cache access for both CPUs;
+ * - Initialise cache mmu;
+ * - Setting up pins and mode for SD, SPI, UART, Clocking.
+
+ *  @return ESP_OK   - If the setting is successful.
+ *          ESP_FAIL - If the setting is not successful.
+ */
+esp_err_t bootloader_init(void);

--- a/components/bootloader_support/include_bootloader/bootloader_sha.h
+++ b/components/bootloader_support/include_bootloader/bootloader_sha.h
@@ -1,0 +1,33 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+/* Provide a SHA256 API for bootloader_support code,
+   that can be used from bootloader or app code.
+
+   This header is available to source code in the bootloader & bootloader_support components only.
+   Use mbedTLS APIs or include esp32/sha.h to calculate SHA256 in IDF apps.
+*/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "esp_err.h"
+
+typedef void *bootloader_sha256_handle_t;
+
+bootloader_sha256_handle_t bootloader_sha256_start(void);
+
+void bootloader_sha256_data(bootloader_sha256_handle_t handle, const void *data, size_t data_len);
+
+void bootloader_sha256_finish(bootloader_sha256_handle_t handle, uint8_t *digest);

--- a/components/bootloader_support/include_bootloader/bootloader_utility.h
+++ b/components/bootloader_support/include_bootloader/bootloader_utility.h
@@ -1,0 +1,124 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "bootloader_config.h"
+#include "esp_image_format.h"
+#include "bootloader_config.h"
+
+/**
+ * @brief Load partition table.
+ *
+ * Parse partition table, get useful data such as location of
+ * OTA data partition, factory app partition, and test app partition.
+ *
+ * @param[out] bs Bootloader state structure used to save read data.
+ * @return        Return true if the partition table was succesfully loaded and MD5 checksum is valid.
+ */
+bool bootloader_utility_load_partition_table(bootloader_state_t* bs);
+
+/**
+ * @brief Return the index of the selected boot partition.
+ *
+ * This is the preferred boot partition, as determined by the partition table &
+ * any OTA sequence number found in OTA data.
+ * This partition will only be booted if it contains a valid app image, otherwise load_boot_image() will search
+ * for a valid partition using this selection as the starting point.
+ *
+ * @param[in] bs Bootloader state structure.
+ * @return       Returns the index on success, INVALID_INDEX otherwise.
+ */
+int bootloader_utility_get_selected_boot_partition(const bootloader_state_t *bs);
+
+/**
+ * @brief Load the selected partition and start application.
+ *
+ * Start from partition 'start_index', if not bootable then work backwards to FACTORY_INDEX
+ * (ie try any OTA slots in descending order and then the factory partition).
+ * If still nothing, start from 'start_index + 1' and work up to highest numbered OTA partition.
+ * If still nothing, try TEST_APP_INDEX.
+ * Everything this function calls must be located in the iram_loader_seg segment.
+ *
+ * @param[in] bs Bootloader state structure.
+ * @param[in] start_index The index from which the search for images begins.
+ */
+__attribute__((noreturn)) void bootloader_utility_load_boot_image(const bootloader_state_t *bs, int start_index);
+
+#ifdef CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP
+/**
+ * @brief Load that application which was worked before we go to the deep sleep.
+ *
+ * Checks the reboot reason if it is the deep sleep and has a valid partition in the RTC memory
+ * then try to load the application which was worked before we go to the deep sleep.
+ *
+ */
+void bootloader_utility_load_boot_image_from_deep_sleep(void);
+#endif
+
+/**
+ * @brief Software reset the ESP32
+ *
+ * Bootloader code should call this in the case that it cannot proceed.
+ *
+ * It is not recommended to call this function from an app (if called, the app will abort).
+ */
+__attribute__((noreturn)) void bootloader_reset(void);
+
+/**
+ * @brief Converts an array to a printable string.
+ *
+ * This function is useful for printing SHA-256 digest.
+ * \code{c}
+ * // Example of using. image_hash will be printed
+ * #define HASH_LEN 32 // SHA-256 digest length
+ * ...
+ * char hash_print[HASH_LEN * 2 + 1];
+ * hash_print[HASH_LEN * 2] = 0;
+ * bootloader_sha256_hex_to_str(hash_print, image_hash, HASH_LEN);
+ * ESP_LOGI(TAG, %s", hash_print);
+ * \endcode
+
+ * @param[out] out_str       Output string
+ * @param[in]  in_array_hex  Pointer to input array
+ * @param[in]  len           Length of input array
+ *
+ * @return   ESP_OK: Successful
+ *           ESP_ERR_INVALID_ARG: Error in the passed arguments
+ */
+esp_err_t bootloader_sha256_hex_to_str(char *out_str, const uint8_t *in_array_hex, size_t len);
+
+/**
+ * @brief Debug log contents of a buffer as hexadecimal
+ *
+ * @note Only works if component log level is DEBUG or higher.
+ *
+ * @param buffer Buffer to log
+ * @param length Length of buffer in bytes. Maximum length 128 bytes.
+ * @param label Label to print at beginning of log line.
+ */
+void bootloader_debug_buffer(const void *buffer, size_t length, const char *label);
+
+/** @brief Generates the digest of the data between offset & offset+length.
+ *
+ * This function should be used when the size of the data is larger than 3.2MB.
+ * The MMU capacity is 3.2MB (50 pages - 64KB each). This function generates the SHA-256 
+ * of the data in chunks of 3.2MB, considering the MMU capacity. 
+ * 
+ * @param[in]  flash_offset  Offset of the data in flash.
+ * @param[in]  len           Length of data in bytes.
+ * @param[out] digest        Pointer to buffer where the digest is written, if ESP_OK is returned. 
+ * 
+ * @return ESP_OK if secure boot digest is generated successfully.
+ */
+esp_err_t bootloader_sha256_flash_contents(uint32_t flash_offset, uint32_t len, uint8_t *digest);

--- a/components/bootloader_support/include_bootloader/flash_qio_mode.h
+++ b/components/bootloader_support/include_bootloader/flash_qio_mode.h
@@ -1,0 +1,37 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Enable Quad I/O mode in bootloader (if configured)
+ *
+ * Queries attached SPI flash ID and sends correct SPI flash
+ * commands to enable QIO or QOUT mode, then enables this mode.
+ */
+void bootloader_enable_qio_mode(void);
+
+/**
+ * @brief Read flash ID by sending 0x9F command
+ * @return flash raw ID
+ *     mfg_id = (ID >> 16) & 0xFF;
+       flash_id = ID & 0xffff;
+ */
+uint32_t bootloader_read_flash_id(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/bootloader_support/src/bootloader_clock.c
+++ b/components/bootloader_support/src/bootloader_clock.c
@@ -1,0 +1,91 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+#include "soc/soc.h"
+#include "soc/rtc.h"
+#include "soc/dport_reg.h"
+#include "soc/efuse_periph.h"
+#include "soc/rtc_cntl_reg.h"
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/uart.h"
+#include "esp32/rom/rtc.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/uart.h"
+#include "esp32s2/rom/rtc.h"
+#endif
+
+void bootloader_clock_configure(void)
+{
+    // ROM bootloader may have put a lot of text into UART0 FIFO.
+    // Wait for it to be printed.
+    // This is not needed on power on reset, when ROM bootloader is running at
+    // 40 MHz. But in case of TG WDT reset, CPU may still be running at >80 MHZ,
+    // and will be done with the bootloader much earlier than UART FIFO is empty.
+    uart_tx_wait_idle(0);
+
+    /* Set CPU to 80MHz. Keep other clocks unmodified. */
+    int cpu_freq_mhz = 80;
+    
+#if CONFIG_IDF_TARGET_ESP32
+    /* On ESP32 rev 0, switching to 80/160 MHz if clock was previously set to
+     * 240 MHz may cause the chip to lock up (see section 3.5 of the errata
+     * document). For rev. 0, switch to 240 instead if it has been enabled
+     * previously.
+     */
+    uint32_t chip_ver_reg = REG_READ(EFUSE_BLK0_RDATA3_REG);
+    if ((chip_ver_reg & EFUSE_RD_CHIP_VER_REV1_M) == 0 &&
+            DPORT_REG_GET_FIELD(DPORT_CPU_PER_CONF_REG, DPORT_CPUPERIOD_SEL) == DPORT_CPUPERIOD_SEL_240) {
+        cpu_freq_mhz = 240;
+    }
+#endif
+
+    rtc_clk_config_t clk_cfg = RTC_CLK_CONFIG_DEFAULT();
+#if CONFIG_IDF_TARGET_ESP32
+    clk_cfg.xtal_freq = CONFIG_ESP32_XTAL_FREQ;
+#endif
+    /* ESP32-S2 doesn't have XTAL_FREQ choice, always 40MHz */
+    clk_cfg.cpu_freq_mhz = cpu_freq_mhz;
+    clk_cfg.slow_freq = rtc_clk_slow_freq_get();
+    clk_cfg.fast_freq = rtc_clk_fast_freq_get();
+    rtc_clk_init(clk_cfg);
+    /* As a slight optimization, if 32k XTAL was enabled in sdkconfig, we enable
+     * it here. Usually it needs some time to start up, so we amortize at least
+     * part of the start up time by enabling 32k XTAL early.
+     * App startup code will wait until the oscillator has started up.
+     */
+
+    /* TODO: move the clock option into esp_system, so that this doesn't have
+     * to continue:
+     */
+#if CONFIG_ESP32_RTC_CLK_SRC_EXT_CRYS
+    if (!rtc_clk_32k_enabled()) {
+        rtc_clk_32k_bootstrap(CONFIG_ESP32_RTC_XTAL_BOOTSTRAP_CYCLES);
+    }
+#endif
+#if CONFIG_ESP32S2_RTC_CLK_SRC_EXT_CRYS
+    if (!rtc_clk_32k_enabled()) {
+        rtc_clk_32k_bootstrap(0);
+    }
+#endif
+}
+
+#ifdef BOOTLOADER_BUILD
+
+int esp_clk_apb_freq(void)
+{
+    return rtc_clk_apb_freq_get();
+}
+
+#endif // BOOTLOADER_BUILD

--- a/components/bootloader_support/src/bootloader_common.c
+++ b/components/bootloader_support/src/bootloader_common.c
@@ -1,0 +1,368 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdbool.h>
+#include <assert.h>
+#include "string.h"
+#include "sdkconfig.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/crc.h"
+#include "esp32/rom/gpio.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/spi_flash.h"
+#include "esp32s2/rom/crc.h"
+#include "esp32s2/rom/ets_sys.h"
+#include "esp32s2/rom/gpio.h"
+#endif
+#include "esp_flash_partitions.h"
+#include "bootloader_flash.h"
+#include "bootloader_common.h"
+#include "bootloader_utility.h"
+#include "soc/gpio_periph.h"
+#include "soc/rtc.h"
+#include "soc/efuse_reg.h"
+#include "soc/soc_memory_layout.h"
+#include "esp_image_format.h"
+#include "bootloader_sha.h"
+#include "sys/param.h"
+
+#define ESP_PARTITION_HASH_LEN 32 /* SHA-256 digest length */
+
+static const char* TAG = "boot_comm";
+
+uint32_t bootloader_common_ota_select_crc(const esp_ota_select_entry_t *s)
+{
+    return crc32_le(UINT32_MAX, (uint8_t*)&s->ota_seq, 4);
+}
+
+bool bootloader_common_ota_select_invalid(const esp_ota_select_entry_t *s)
+{
+    return s->ota_seq == UINT32_MAX || s->ota_state == ESP_OTA_IMG_INVALID || s->ota_state == ESP_OTA_IMG_ABORTED;
+}
+
+bool bootloader_common_ota_select_valid(const esp_ota_select_entry_t *s)
+{
+    return bootloader_common_ota_select_invalid(s) == false && s->crc == bootloader_common_ota_select_crc(s);
+}
+
+esp_comm_gpio_hold_t bootloader_common_check_long_hold_gpio(uint32_t num_pin, uint32_t delay_sec)
+{
+    gpio_pad_select_gpio(num_pin);
+    if (GPIO_PIN_MUX_REG[num_pin]) {
+        PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[num_pin]);
+    }
+    gpio_pad_pullup(num_pin);
+    uint32_t tm_start = esp_log_early_timestamp();
+    if (GPIO_INPUT_GET(num_pin) == 1) {
+        return GPIO_NOT_HOLD;
+    }
+    do {
+        if (GPIO_INPUT_GET(num_pin) != 0) {
+            return GPIO_SHORT_HOLD;
+        }
+    } while (delay_sec > ((esp_log_early_timestamp() - tm_start) / 1000L));
+    return GPIO_LONG_HOLD;
+}
+
+// Search for a label in the list. list = "nvs1, nvs2, otadata, nvs"; label = "nvs".
+bool bootloader_common_label_search(const char *list, char *label)
+{
+    if (list == NULL || label == NULL) {
+        return false;
+    }
+    const char *sub_list_start_like_label = strstr(list, label);
+    while (sub_list_start_like_label != NULL) {
+
+        // ["," or " "] + label + ["," or " " or "\0"]
+        // first character before the label found there must be a delimiter ["," or " "].
+        int idx_first = sub_list_start_like_label - list;
+        if (idx_first == 0 || (idx_first != 0 && (list[idx_first - 1] == ',' || list[idx_first - 1] == ' '))) {
+            // next character after the label found there must be a delimiter ["," or " " or "\0"].
+            int len_label = strlen(label);
+            if (sub_list_start_like_label[len_label] == 0   ||
+                sub_list_start_like_label[len_label] == ',' ||
+                sub_list_start_like_label[len_label] == ' ') {
+                return true;
+            }
+        }
+
+        // [start_delim] + label + [end_delim] was not found.
+        // Position is moving to next delimiter if it is not the end of list.
+        int pos_delim = strcspn(sub_list_start_like_label, ", ");
+        if (pos_delim == strlen(sub_list_start_like_label)) {
+            break;
+        }
+        sub_list_start_like_label = strstr(&sub_list_start_like_label[pos_delim], label);
+    }
+    return false;
+}
+
+bool bootloader_common_erase_part_type_data(const char *list_erase, bool ota_data_erase)
+{
+    const esp_partition_info_t *partitions;
+    const char *marker;
+    esp_err_t err;
+    int num_partitions;
+    bool ret = true;
+
+    partitions = bootloader_mmap(ESP_PARTITION_TABLE_OFFSET, ESP_PARTITION_TABLE_MAX_LEN);
+    if (!partitions) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", ESP_PARTITION_TABLE_OFFSET, ESP_PARTITION_TABLE_MAX_LEN);
+        return false;
+    }
+    ESP_LOGD(TAG, "mapped partition table 0x%x at 0x%x", ESP_PARTITION_TABLE_OFFSET, (intptr_t)partitions);
+
+    err = esp_partition_table_verify(partitions, true, &num_partitions);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to verify partition table");
+        ret = false;
+    } else {
+        ESP_LOGI(TAG, "## Label            Usage Offset   Length   Cleaned");
+        for (int i = 0; i < num_partitions; i++) {
+            const esp_partition_info_t *partition = &partitions[i];
+            char label[sizeof(partition->label) + 1] = {0};
+            if (partition->type == PART_TYPE_DATA) {
+                bool fl_ota_data_erase = false;
+                if (ota_data_erase == true && partition->subtype == PART_SUBTYPE_DATA_OTA) {
+                    fl_ota_data_erase = true;
+                }
+                // partition->label is not null-terminated string.
+                strncpy(label, (char *)&partition->label, sizeof(label) - 1);
+                if (fl_ota_data_erase == true || (bootloader_common_label_search(list_erase, label) == true)) {
+                    err = bootloader_flash_erase_range(partition->pos.offset, partition->pos.size);
+                    if (err != ESP_OK) {
+                        ret = false;
+                        marker = "err";
+                    } else {
+                        marker = "yes";
+                    }
+                } else {
+                    marker = "no";
+                }
+
+                ESP_LOGI(TAG, "%2d %-16s data  %08x %08x [%s]", i, partition->label,
+                         partition->pos.offset, partition->pos.size, marker);
+            }
+        }
+    }
+
+    bootloader_munmap(partitions);
+
+    return ret;
+}
+
+esp_err_t bootloader_common_get_sha256_of_partition (uint32_t address, uint32_t size, int type, uint8_t *out_sha_256)
+{
+    if (out_sha_256 == NULL || size == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (type == PART_TYPE_APP) {
+        const esp_partition_pos_t partition_pos = {
+            .offset = address,
+            .size = size,
+        };
+        esp_image_metadata_t data;
+        // Function esp_image_verify() verifies and fills the structure data.
+        // here important to get: image_digest, image_len, hash_appended.
+        if (esp_image_verify(ESP_IMAGE_VERIFY_SILENT, &partition_pos, &data) != ESP_OK) {
+            return ESP_ERR_IMAGE_INVALID;
+        }
+        if (data.image.hash_appended) {
+            memcpy(out_sha_256, data.image_digest, ESP_PARTITION_HASH_LEN);
+            return ESP_OK;
+        }
+        // If image doesn't have a appended hash then hash calculates for entire image.
+        size = data.image_len;
+    }
+    // If image is type by data then hash is calculated for entire image.
+    return bootloader_sha256_flash_contents(address, size, out_sha_256);
+}
+
+int bootloader_common_select_otadata(const esp_ota_select_entry_t *two_otadata, bool *valid_two_otadata, bool max)
+{
+    if (two_otadata == NULL || valid_two_otadata == NULL) {
+        return -1;
+    }
+    int active_otadata = -1;
+    if (valid_two_otadata[0] && valid_two_otadata[1]) {
+        int condition = (max == true) ? MAX(two_otadata[0].ota_seq, two_otadata[1].ota_seq) : MIN(two_otadata[0].ota_seq, two_otadata[1].ota_seq);
+        if (condition == two_otadata[0].ota_seq) {
+            active_otadata = 0;
+        } else {
+            active_otadata = 1;
+        }
+        ESP_LOGD(TAG, "Both OTA copies are valid");
+    } else {
+        for (int i = 0; i < 2; ++i) {
+            if (valid_two_otadata[i]) {
+                active_otadata = i;
+                ESP_LOGD(TAG, "Only otadata[%d] is valid", i);
+                break;
+            }
+        }
+    }
+    return active_otadata;
+}
+
+int bootloader_common_get_active_otadata(esp_ota_select_entry_t *two_otadata)
+{
+    if (two_otadata == NULL) {
+        return -1;
+    }
+    bool valid_two_otadata[2];
+    valid_two_otadata[0] = bootloader_common_ota_select_valid(&two_otadata[0]);
+    valid_two_otadata[1] = bootloader_common_ota_select_valid(&two_otadata[1]);
+    return bootloader_common_select_otadata(two_otadata, valid_two_otadata, true);
+}
+
+esp_err_t bootloader_common_get_partition_description(const esp_partition_pos_t *partition, esp_app_desc_t *app_desc)
+{
+    if (partition == NULL || app_desc == NULL || partition->offset == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const uint32_t app_desc_offset = sizeof(esp_image_header_t) + sizeof(esp_image_segment_header_t);
+    const uint32_t mmap_size = app_desc_offset + sizeof(esp_app_desc_t);
+    const uint8_t *image = bootloader_mmap(partition->offset, mmap_size);
+    if (image == NULL) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", partition->offset, mmap_size);
+        return ESP_FAIL;
+    }
+
+    memcpy(app_desc, image + app_desc_offset, sizeof(esp_app_desc_t));
+    bootloader_munmap(image);
+
+    if (app_desc->magic_word != ESP_APP_DESC_MAGIC_WORD) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    return ESP_OK;
+}
+
+void bootloader_common_vddsdio_configure(void)
+{
+#if CONFIG_BOOTLOADER_VDDSDIO_BOOST_1_9V
+    rtc_vddsdio_config_t cfg = rtc_vddsdio_get_config();
+    if (cfg.enable == 1 && cfg.tieh == RTC_VDDSDIO_TIEH_1_8V) {    // VDDSDIO regulator is enabled @ 1.8V
+        cfg.drefh = 3;
+        cfg.drefm = 3;
+        cfg.drefl = 3;
+        cfg.force = 1;
+        rtc_vddsdio_set_config(cfg);
+        ets_delay_us(10); // wait for regulator to become stable
+    }
+#endif // CONFIG_BOOTLOADER_VDDSDIO_BOOST
+}
+
+
+esp_err_t bootloader_common_check_chip_validity(const esp_image_header_t* img_hdr, esp_image_type type)
+{
+    esp_err_t err = ESP_OK;
+    esp_chip_id_t chip_id = CONFIG_IDF_FIRMWARE_CHIP_ID;
+    if (chip_id != img_hdr->chip_id) {
+        ESP_LOGE(TAG, "mismatch chip ID, expected %d, found %d", chip_id, img_hdr->chip_id);
+        err = ESP_FAIL;
+    }
+    uint8_t revision = bootloader_common_get_chip_revision();
+    if (revision < img_hdr->min_chip_rev) {
+        ESP_LOGE(TAG, "can't run on lower chip revision, expected %d, found %d", revision, img_hdr->min_chip_rev);
+        err = ESP_FAIL;
+    } else if (revision != img_hdr->min_chip_rev) {
+#ifdef BOOTLOADER_BUILD
+        ESP_LOGI(TAG, "chip revision: %d, min. %s chip revision: %d", revision, type == ESP_IMAGE_BOOTLOADER ? "bootloader" : "application", img_hdr->min_chip_rev);
+#endif
+    }
+    return err;
+}
+
+RESET_REASON bootloader_common_get_reset_reason(int cpu_no)
+{
+    return rtc_get_reset_reason(cpu_no);
+}
+
+#if defined( CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP ) || defined( CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC )
+
+#define RTC_RETAIN_MEM_ADDR (SOC_RTC_DRAM_HIGH - sizeof(rtc_retain_mem_t))
+
+rtc_retain_mem_t *const rtc_retain_mem = (rtc_retain_mem_t *)RTC_RETAIN_MEM_ADDR;
+
+#if !IS_BOOTLOADER_BUILD
+/* The app needs to be told this memory is reserved, important if configured to use RTC memory as heap.
+
+   Note that keeping this macro here only works when other symbols in this file are referenced by the app, as
+   this feature is otherwise 100% part of the bootloader. However this seems to happen in all apps.
+ */
+SOC_RESERVE_MEMORY_REGION(RTC_RETAIN_MEM_ADDR, RTC_RETAIN_MEM_ADDR + sizeof(rtc_retain_mem_t), rtc_retain_mem);
+#endif
+
+static bool check_rtc_retain_mem(void)
+{
+    return crc32_le(UINT32_MAX, (uint8_t*)rtc_retain_mem, sizeof(rtc_retain_mem_t) - sizeof(rtc_retain_mem->crc)) == rtc_retain_mem->crc && rtc_retain_mem->crc != UINT32_MAX;
+}
+
+static void update_rtc_retain_mem_crc(void)
+{
+    rtc_retain_mem->crc = crc32_le(UINT32_MAX, (uint8_t*)rtc_retain_mem, sizeof(rtc_retain_mem_t) - sizeof(rtc_retain_mem->crc));
+}
+
+void bootloader_common_reset_rtc_retain_mem(void)
+{
+    memset(rtc_retain_mem, 0, sizeof(rtc_retain_mem_t));
+}
+
+uint16_t bootloader_common_get_rtc_retain_mem_reboot_counter(void)
+{
+    if (check_rtc_retain_mem()) {
+        return rtc_retain_mem->reboot_counter;
+    }
+    return 0;
+}
+
+esp_partition_pos_t* bootloader_common_get_rtc_retain_mem_partition(void)
+{
+    if (check_rtc_retain_mem()) {
+        return &rtc_retain_mem->partition;
+    }
+    return NULL;
+}
+
+void bootloader_common_update_rtc_retain_mem(esp_partition_pos_t* partition, bool reboot_counter)
+{
+    if (reboot_counter) {
+        if (!check_rtc_retain_mem()) {
+            bootloader_common_reset_rtc_retain_mem();
+        }
+        if (++rtc_retain_mem->reboot_counter == 0) {
+            // do not allow to overflow. Stop it.
+            --rtc_retain_mem->reboot_counter;
+        }
+
+    }
+
+    if (partition != NULL) {
+        rtc_retain_mem->partition.offset = partition->offset;
+        rtc_retain_mem->partition.size   = partition->size;
+    }
+
+    update_rtc_retain_mem_crc();
+}
+
+rtc_retain_mem_t* bootloader_common_get_rtc_retain_mem(void)
+{
+    return rtc_retain_mem;
+}
+#endif

--- a/components/bootloader_support/src/bootloader_efuse_esp32.c
+++ b/components/bootloader_support/src/bootloader_efuse_esp32.c
@@ -1,0 +1,56 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bootloader_common.h"
+#include "bootloader_clock.h"
+#include "soc/efuse_reg.h"
+#include "soc/apb_ctrl_reg.h"
+
+uint8_t bootloader_common_get_chip_revision(void)
+{
+    uint8_t eco_bit0, eco_bit1, eco_bit2;
+    eco_bit0 = (REG_READ(EFUSE_BLK0_RDATA3_REG) & 0xF000) >> 15;
+    eco_bit1 = (REG_READ(EFUSE_BLK0_RDATA5_REG) & 0x100000) >> 20;
+    eco_bit2 = (REG_READ(APB_CTRL_DATE_REG) & 0x80000000) >> 31;
+    uint32_t combine_value = (eco_bit2 << 2) | (eco_bit1 << 1) | eco_bit0;
+    uint8_t chip_ver = 0;
+    switch (combine_value) {
+    case 0:
+        chip_ver = 0;
+        break;
+    case 1:
+        chip_ver = 1;
+        break;
+    case 3:
+        chip_ver = 2;
+        break;
+    case 7:
+        chip_ver = 3;
+        break;
+    default:
+        chip_ver = 0;
+        break;
+    }
+    return chip_ver;
+}
+
+int bootloader_clock_get_rated_freq_mhz()
+{
+    //Check if ESP32 is rated for a CPU frequency of 160MHz only
+    if (REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_RATED) &&
+        REG_GET_BIT(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_CPU_FREQ_LOW)) {
+        return 160;
+    }
+    return 240;
+}

--- a/components/bootloader_support/src/bootloader_efuse_esp32s2.c
+++ b/components/bootloader_support/src/bootloader_efuse_esp32s2.c
@@ -1,0 +1,24 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sdkconfig.h"
+#include "bootloader_clock.h"
+#include "bootloader_common.h"
+
+uint8_t bootloader_common_get_chip_revision(void)
+{
+    // should return the same value as esp_efuse_get_chip_ver()
+    /* No other revisions for ESP32-S2 */
+    return 0;
+}

--- a/components/bootloader_support/src/bootloader_flash.c
+++ b/components/bootloader_support/src/bootloader_flash.c
@@ -1,0 +1,367 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stddef.h>
+
+#include <bootloader_flash.h>
+#include <esp_log.h>
+#include <esp_flash_encrypt.h>
+#if CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/spi_flash.h"
+#endif
+
+#ifndef BOOTLOADER_BUILD
+/* Normal app version maps to esp_spi_flash.h operations...
+ */
+static const char *TAG = "bootloader_mmap";
+
+static spi_flash_mmap_handle_t map;
+
+uint32_t bootloader_mmap_get_free_pages(void)
+{
+    return spi_flash_mmap_get_free_pages(SPI_FLASH_MMAP_DATA);
+}
+
+const void *bootloader_mmap(uint32_t src_addr, uint32_t size)
+{
+    if (map) {
+        ESP_LOGE(TAG, "tried to bootloader_mmap twice");
+        return NULL; /* existing mapping in use... */
+    }
+    const void *result = NULL;
+    uint32_t src_page = src_addr & ~(SPI_FLASH_MMU_PAGE_SIZE - 1);
+    size += (src_addr - src_page);
+    esp_err_t err = spi_flash_mmap(src_page, size, SPI_FLASH_MMAP_DATA, &result, &map);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "spi_flash_mmap failed: 0x%x", err);
+        return NULL;
+    }
+    return (void *)((intptr_t)result + (src_addr - src_page));
+}
+
+void bootloader_munmap(const void *mapping)
+{
+    if (mapping && map) {
+        spi_flash_munmap(map);
+    }
+    map = 0;
+}
+
+esp_err_t bootloader_flash_read(size_t src, void *dest, size_t size, bool allow_decrypt)
+{
+    if (allow_decrypt && esp_flash_encryption_enabled()) {
+        return spi_flash_read_encrypted(src, dest, size);
+    } else {
+        return spi_flash_read(src, dest, size);
+    }
+}
+
+esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool write_encrypted)
+{
+    if (write_encrypted) {
+#if CONFIG_IDF_TARGET_ESP32
+        return spi_flash_write_encrypted(dest_addr, src, size);
+#elif CONFIG_IDF_TARGET_ESP32S2
+        return SPI_Encrypt_Write(dest_addr, src, size);
+#endif
+    } else {
+        return spi_flash_write(dest_addr, src, size);
+    }
+}
+
+esp_err_t bootloader_flash_erase_sector(size_t sector)
+{
+    return spi_flash_erase_sector(sector);
+}
+
+esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size)
+{
+    return spi_flash_erase_range(start_addr, size);
+}
+
+#else
+/* Bootloader version, uses ROM functions only */
+#include "soc/dport_reg.h"
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/cache.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/spi_flash.h"
+#include "esp32s2/rom/cache.h"
+#include "soc/cache_memory.h"
+#endif
+static const char *TAG = "bootloader_flash";
+
+#if CONFIG_IDF_TARGET_ESP32
+/* Use first 50 blocks in MMU for bootloader_mmap,
+   50th block for bootloader_flash_read
+*/
+#define MMU_BLOCK0_VADDR  SOC_DROM_LOW
+#define MMU_SIZE          (0x320000)
+#define MMU_BLOCK50_VADDR (MMU_BLOCK0_VADDR + MMU_SIZE)
+#define FLASH_READ_VADDR MMU_BLOCK50_VADDR
+#elif CONFIG_IDF_TARGET_ESP32S2
+/* Use first 63 blocks in MMU for bootloader_mmap,
+   63th block for bootloader_flash_read
+*/
+#define MMU_BLOCK0_VADDR  SOC_DROM_LOW
+#define MMU_SIZE          (0x3f0000)
+#define MMU_BLOCK63_VADDR (MMU_BLOCK0_VADDR + MMU_SIZE)
+#define FLASH_READ_VADDR MMU_BLOCK63_VADDR
+#endif
+
+#define MMU_FREE_PAGES    (MMU_SIZE / FLASH_BLOCK_SIZE)
+
+static bool mapped;
+
+// Current bootloader mapping (ab)used for bootloader_read()
+static uint32_t current_read_mapping = UINT32_MAX;
+
+uint32_t bootloader_mmap_get_free_pages(void)
+{
+    /**
+     * Allow mapping up to 50 of the 51 available MMU blocks (last one used for reads)
+     * Since, bootloader_mmap function below assumes it to be 0x320000 (50 pages), we can safely do this.
+     */
+    return MMU_FREE_PAGES;
+}
+
+const void *bootloader_mmap(uint32_t src_addr, uint32_t size)
+{
+    if (mapped) {
+        ESP_LOGE(TAG, "tried to bootloader_mmap twice");
+        return NULL; /* can't map twice */
+    }
+    if (size > MMU_SIZE) {
+        ESP_LOGE(TAG, "bootloader_mmap excess size %x", size);
+        return NULL;
+    }
+
+    uint32_t src_addr_aligned = src_addr & MMU_FLASH_MASK;
+    uint32_t count = bootloader_cache_pages_to_map(size, src_addr);
+#if CONFIG_IDF_TARGET_ESP32
+    Cache_Read_Disable(0);
+    Cache_Flush(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    uint32_t autoload = Cache_Suspend_ICache();
+    Cache_Invalidate_ICache_All();
+#endif
+    ESP_LOGD(TAG, "mmu set paddr=%08x count=%d size=%x src_addr=%x src_addr_aligned=%x",
+             src_addr & MMU_FLASH_MASK, count, size, src_addr, src_addr_aligned );
+#if CONFIG_IDF_TARGET_ESP32
+    int e = cache_flash_mmu_set(0, 0, MMU_BLOCK0_VADDR, src_addr_aligned, 64, count);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    int e = Cache_Ibus_MMU_Set(MMU_ACCESS_FLASH, MMU_BLOCK0_VADDR, src_addr_aligned, 64, count, 0);
+#endif
+    if (e != 0) {
+        ESP_LOGE(TAG, "cache_flash_mmu_set failed: %d\n", e);
+#if CONFIG_IDF_TARGET_ESP32
+        Cache_Read_Enable(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+        Cache_Resume_ICache(autoload);
+#endif
+        return NULL;
+    }
+#if CONFIG_IDF_TARGET_ESP32
+    Cache_Read_Enable(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    Cache_Resume_ICache(autoload);
+#endif
+
+    mapped = true;
+
+    return (void *)(MMU_BLOCK0_VADDR + (src_addr - src_addr_aligned));
+}
+
+void bootloader_munmap(const void *mapping)
+{
+    if (mapped)  {
+#if CONFIG_IDF_TARGET_ESP32
+        /* Full MMU reset */
+        Cache_Read_Disable(0);
+        Cache_Flush(0);
+        mmu_init(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+        //TODO, save the autoload value.
+        Cache_Suspend_ICache();
+        Cache_Invalidate_ICache_All();
+        Cache_MMU_Init();
+#endif
+        mapped = false;
+        current_read_mapping = UINT32_MAX;
+    }
+}
+
+static esp_err_t spi_to_esp_err(esp_rom_spiflash_result_t r)
+{
+    switch (r) {
+    case ESP_ROM_SPIFLASH_RESULT_OK:
+        return ESP_OK;
+    case ESP_ROM_SPIFLASH_RESULT_ERR:
+        return ESP_ERR_FLASH_OP_FAIL;
+    case ESP_ROM_SPIFLASH_RESULT_TIMEOUT:
+        return ESP_ERR_FLASH_OP_TIMEOUT;
+    default:
+        return ESP_FAIL;
+    }
+}
+
+static esp_err_t bootloader_flash_read_no_decrypt(size_t src_addr, void *dest, size_t size)
+{
+#if CONFIG_IDF_TARGET_ESP32
+    Cache_Read_Disable(0);
+    Cache_Flush(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    uint32_t autoload = Cache_Suspend_ICache();
+#endif
+    esp_rom_spiflash_result_t r = esp_rom_spiflash_read(src_addr, dest, size);
+#if CONFIG_IDF_TARGET_ESP32
+    Cache_Read_Enable(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    Cache_Resume_ICache(autoload);
+#endif
+
+    return spi_to_esp_err(r);
+}
+
+static esp_err_t bootloader_flash_read_allow_decrypt(size_t src_addr, void *dest, size_t size)
+{
+    uint32_t *dest_words = (uint32_t *)dest;
+
+    for (int word = 0; word < size / 4; word++) {
+        uint32_t word_src = src_addr + word * 4;  /* Read this offset from flash */
+        uint32_t map_at = word_src & MMU_FLASH_MASK; /* Map this 64KB block from flash */
+        uint32_t *map_ptr;
+        if (map_at != current_read_mapping) {
+            /* Move the 64KB mmu mapping window to fit map_at */
+#if CONFIG_IDF_TARGET_ESP32
+            Cache_Read_Disable(0);
+            Cache_Flush(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+            uint32_t autoload = Cache_Suspend_ICache();
+            Cache_Invalidate_ICache_All();
+#endif
+            ESP_LOGD(TAG, "mmu set block paddr=0x%08x (was 0x%08x)", map_at, current_read_mapping);
+#if CONFIG_IDF_TARGET_ESP32
+            int e = cache_flash_mmu_set(0, 0, FLASH_READ_VADDR, map_at, 64, 1);
+#elif CONFIG_IDF_TARGET_ESP32S2
+            int e = Cache_Ibus_MMU_Set(MMU_ACCESS_FLASH, MMU_BLOCK63_VADDR, map_at, 64, 1, 0);
+#endif
+            if (e != 0) {
+                ESP_LOGE(TAG, "cache_flash_mmu_set failed: %d\n", e);
+#if CONFIG_IDF_TARGET_ESP32
+                Cache_Read_Enable(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+                Cache_Resume_ICache(autoload);
+#endif
+                return ESP_FAIL;
+            }
+            current_read_mapping = map_at;
+#if CONFIG_IDF_TARGET_ESP32
+            Cache_Read_Enable(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+            Cache_Resume_ICache(autoload);
+#endif
+        }
+        map_ptr = (uint32_t *)(FLASH_READ_VADDR + (word_src - map_at));
+        dest_words[word] = *map_ptr;
+    }
+    return ESP_OK;
+}
+
+esp_err_t bootloader_flash_read(size_t src_addr, void *dest, size_t size, bool allow_decrypt)
+{
+    if (src_addr & 3) {
+        ESP_LOGE(TAG, "bootloader_flash_read src_addr 0x%x not 4-byte aligned", src_addr);
+        return ESP_FAIL;
+    }
+    if (size & 3) {
+        ESP_LOGE(TAG, "bootloader_flash_read size 0x%x not 4-byte aligned", size);
+        return ESP_FAIL;
+    }
+    if ((intptr_t)dest & 3) {
+        ESP_LOGE(TAG, "bootloader_flash_read dest 0x%x not 4-byte aligned", (intptr_t)dest);
+        return ESP_FAIL;
+    }
+
+    if (allow_decrypt) {
+        return bootloader_flash_read_allow_decrypt(src_addr, dest, size);
+    } else {
+        return bootloader_flash_read_no_decrypt(src_addr, dest, size);
+    }
+}
+
+esp_err_t bootloader_flash_write(size_t dest_addr, void *src, size_t size, bool write_encrypted)
+{
+    esp_err_t err;
+    size_t alignment = write_encrypted ? 32 : 4;
+    if ((dest_addr % alignment) != 0) {
+        ESP_LOGE(TAG, "bootloader_flash_write dest_addr 0x%x not %d-byte aligned", dest_addr, alignment);
+        return ESP_FAIL;
+    }
+    if ((size % alignment) != 0) {
+        ESP_LOGE(TAG, "bootloader_flash_write size 0x%x not %d-byte aligned", size, alignment);
+        return ESP_FAIL;
+    }
+    if (((intptr_t)src % 4) != 0) {
+        ESP_LOGE(TAG, "bootloader_flash_write src 0x%x not 4 byte aligned", (intptr_t)src);
+        return ESP_FAIL;
+    }
+
+    err = spi_to_esp_err(esp_rom_spiflash_unlock());
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (write_encrypted) {
+#if CONFIG_IDF_TARGET_ESP32
+        return spi_to_esp_err(esp_rom_spiflash_write_encrypted(dest_addr, src, size));
+#elif CONFIG_IDF_TARGET_ESP32S2
+        // TODO: use the same ROM AP here
+        return spi_to_esp_err(SPI_Encrypt_Write(dest_addr, src, size));
+#endif
+    } else {
+        return spi_to_esp_err(esp_rom_spiflash_write(dest_addr, src, size));
+    }
+}
+
+esp_err_t bootloader_flash_erase_sector(size_t sector)
+{
+    return spi_to_esp_err(esp_rom_spiflash_erase_sector(sector));
+}
+
+esp_err_t bootloader_flash_erase_range(uint32_t start_addr, uint32_t size)
+{
+    if (start_addr % FLASH_SECTOR_SIZE != 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (size % FLASH_SECTOR_SIZE != 0) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    size_t start = start_addr / FLASH_SECTOR_SIZE;
+    size_t end = start + size / FLASH_SECTOR_SIZE;
+    const size_t sectors_per_block = FLASH_BLOCK_SIZE / FLASH_SECTOR_SIZE;
+
+    esp_rom_spiflash_result_t rc = ESP_ROM_SPIFLASH_RESULT_OK;
+    for (size_t sector = start; sector != end && rc == ESP_ROM_SPIFLASH_RESULT_OK; ) {
+        if (sector % sectors_per_block == 0 && end - sector >= sectors_per_block) {
+            rc = esp_rom_spiflash_erase_block(sector / sectors_per_block);
+            sector += sectors_per_block;
+        } else {
+            rc = esp_rom_spiflash_erase_sector(sector);
+            ++sector;
+        }
+    }
+    return spi_to_esp_err(rc);
+}
+#endif

--- a/components/bootloader_support/src/bootloader_flash_config_esp32.c
+++ b/components/bootloader_support/src/bootloader_flash_config_esp32.c
@@ -1,0 +1,194 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdbool.h>
+#include <assert.h>
+#include "string.h"
+#include "sdkconfig.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp32/rom/gpio.h"
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/efuse.h"
+#include "soc/gpio_periph.h"
+#include "soc/efuse_reg.h"
+#include "soc/spi_reg.h"
+#include "soc/spi_caps.h"
+#include "flash_qio_mode.h"
+#include "bootloader_common.h"
+#include "bootloader_flash_config.h"
+
+void bootloader_flash_update_id(void)
+{
+    g_rom_flashchip.device_id = bootloader_read_flash_id();
+}
+
+void bootloader_flash_update_size(uint32_t size)
+{
+    g_rom_flashchip.chip_size = size;
+}
+
+void IRAM_ATTR bootloader_flash_cs_timing_config(void)
+{
+    SET_PERI_REG_MASK(SPI_USER_REG(0), SPI_CS_HOLD_M | SPI_CS_SETUP_M);
+    SET_PERI_REG_BITS(SPI_CTRL2_REG(0), SPI_HOLD_TIME_V, 1, SPI_HOLD_TIME_S);
+    SET_PERI_REG_BITS(SPI_CTRL2_REG(0), SPI_SETUP_TIME_V, 0, SPI_SETUP_TIME_S);
+    SET_PERI_REG_MASK(SPI_USER_REG(1), SPI_CS_HOLD_M | SPI_CS_SETUP_M);
+    SET_PERI_REG_BITS(SPI_CTRL2_REG(1), SPI_HOLD_TIME_V, 1, SPI_HOLD_TIME_S);
+    SET_PERI_REG_BITS(SPI_CTRL2_REG(1), SPI_SETUP_TIME_V, 0, SPI_SETUP_TIME_S);
+}
+
+void IRAM_ATTR bootloader_flash_clock_config(const esp_image_header_t* pfhdr)
+{
+    uint32_t spi_clk_div = 0;
+    switch (pfhdr->spi_speed) {
+        case ESP_IMAGE_SPI_SPEED_80M:
+            spi_clk_div = 1;
+            break;
+        case ESP_IMAGE_SPI_SPEED_40M:
+            spi_clk_div = 2;
+            break;
+        case ESP_IMAGE_SPI_SPEED_26M:
+            spi_clk_div = 3;
+            break;
+        case ESP_IMAGE_SPI_SPEED_20M:
+            spi_clk_div = 4;
+            break;
+        default:
+            break;
+    }
+    esp_rom_spiflash_config_clk(spi_clk_div, 0);
+    esp_rom_spiflash_config_clk(spi_clk_div, 1);
+}
+
+void IRAM_ATTR bootloader_flash_gpio_config(const esp_image_header_t* pfhdr)
+{
+    uint32_t drv = 2;
+    if (pfhdr->spi_speed == ESP_IMAGE_SPI_SPEED_80M) {
+        drv = 3;
+    }
+
+    uint32_t chip_ver = REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
+    uint32_t pkg_ver = chip_ver & 0x7;
+
+    if (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 ||
+        pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2 ||
+        pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4 ||
+        pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOV302) {
+        // For ESP32D2WD or ESP32-PICO series,the SPI pins are already configured
+        // flash clock signal should come from IO MUX.
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CLK_U, FUNC_SD_CLK_SPICLK);
+        SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CLK_U, FUN_DRV, drv, FUN_DRV_S);
+    } else {
+        const uint32_t spiconfig = ets_efuse_get_spiconfig();
+        if (spiconfig == EFUSE_SPICONFIG_SPI_DEFAULTS) {
+            gpio_matrix_out(SPI_IOMUX_PIN_NUM_CS, SPICS0_OUT_IDX, 0, 0);
+            gpio_matrix_out(SPI_IOMUX_PIN_NUM_MISO, SPIQ_OUT_IDX, 0, 0);
+            gpio_matrix_in(SPI_IOMUX_PIN_NUM_MISO, SPIQ_IN_IDX, 0);
+            gpio_matrix_out(SPI_IOMUX_PIN_NUM_MOSI, SPID_OUT_IDX, 0, 0);
+            gpio_matrix_in(SPI_IOMUX_PIN_NUM_MOSI, SPID_IN_IDX, 0);
+            gpio_matrix_out(SPI_IOMUX_PIN_NUM_WP, SPIWP_OUT_IDX, 0, 0);
+            gpio_matrix_in(SPI_IOMUX_PIN_NUM_WP, SPIWP_IN_IDX, 0);
+            gpio_matrix_out(SPI_IOMUX_PIN_NUM_HD, SPIHD_OUT_IDX, 0, 0);
+            gpio_matrix_in(SPI_IOMUX_PIN_NUM_HD, SPIHD_IN_IDX, 0);
+            //select pin function gpio
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA0_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA1_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA2_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA3_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CMD_U, PIN_FUNC_GPIO);
+            // flash clock signal should come from IO MUX.
+            // set drive ability for clock
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CLK_U, FUNC_SD_CLK_SPICLK);
+            SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CLK_U, FUN_DRV, drv, FUN_DRV_S);
+
+            uint32_t flash_id = g_rom_flashchip.device_id;
+            if (flash_id == FLASH_ID_GD25LQ32C) {
+                // Set drive ability for 1.8v flash in 80Mhz.
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA0_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA1_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA2_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA3_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CMD_U,   FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CLK_U,   FUN_DRV, 3, FUN_DRV_S);
+            }
+        }
+    }
+}
+
+void IRAM_ATTR bootloader_flash_dummy_config(const esp_image_header_t* pfhdr)
+{
+    int spi_cache_dummy = 0;
+    uint32_t modebit = READ_PERI_REG(SPI_CTRL_REG(0));
+    if (modebit & SPI_FASTRD_MODE) {
+        if (modebit & SPI_FREAD_QIO) {    //SPI mode is QIO
+            spi_cache_dummy = SPI0_R_QIO_DUMMY_CYCLELEN;
+        } else if (modebit & SPI_FREAD_DIO) {    //SPI mode is DIO
+            spi_cache_dummy = SPI0_R_DIO_DUMMY_CYCLELEN;
+            SET_PERI_REG_BITS(SPI_USER1_REG(0), SPI_USR_ADDR_BITLEN_V, SPI0_R_DIO_ADDR_BITSLEN, SPI_USR_ADDR_BITLEN_S);
+        } else if(modebit & (SPI_FREAD_QUAD | SPI_FREAD_DUAL))  {    //SPI mode is QOUT or DIO
+            spi_cache_dummy = SPI0_R_FAST_DUMMY_CYCLELEN;
+        }
+    }
+
+    extern uint8_t g_rom_spiflash_dummy_len_plus[];
+    switch (pfhdr->spi_speed) {
+        case ESP_IMAGE_SPI_SPEED_80M:
+            g_rom_spiflash_dummy_len_plus[0] = ESP_ROM_SPIFLASH_DUMMY_LEN_PLUS_80M;
+            g_rom_spiflash_dummy_len_plus[1] = ESP_ROM_SPIFLASH_DUMMY_LEN_PLUS_80M;
+            break;
+        case ESP_IMAGE_SPI_SPEED_40M:
+            g_rom_spiflash_dummy_len_plus[0] = ESP_ROM_SPIFLASH_DUMMY_LEN_PLUS_40M;
+            g_rom_spiflash_dummy_len_plus[1] = ESP_ROM_SPIFLASH_DUMMY_LEN_PLUS_40M;
+            break;
+        case ESP_IMAGE_SPI_SPEED_26M:
+        case ESP_IMAGE_SPI_SPEED_20M:
+            g_rom_spiflash_dummy_len_plus[0] = ESP_ROM_SPIFLASH_DUMMY_LEN_PLUS_20M;
+            g_rom_spiflash_dummy_len_plus[1] = ESP_ROM_SPIFLASH_DUMMY_LEN_PLUS_20M;
+            break;
+        default:
+            break;
+    }
+
+    SET_PERI_REG_BITS(SPI_USER1_REG(0), SPI_USR_DUMMY_CYCLELEN_V, spi_cache_dummy + g_rom_spiflash_dummy_len_plus[0],
+            SPI_USR_DUMMY_CYCLELEN_S);
+}
+
+#define ESP32_D2WD_WP_GPIO 7 /* ESP32-D2WD & ESP32-PICO-D4 has this GPIO wired to WP pin of flash */
+#define ESP32_PICO_V3_GPIO 18 /* ESP32-PICO-V3* use this GPIO for WP pin of flash */
+
+int bootloader_flash_get_wp_pin(void)
+{
+#if CONFIG_BOOTLOADER_SPI_CUSTOM_WP_PIN
+    return CONFIG_BOOTLOADER_SPI_WP_PIN; // can be set for bootloader when QIO or QOUT config in use
+#elif CONFIG_SPIRAM_CUSTOM_SPIWP_SD3_PIN
+    return CONFIG_SPIRAM_SPIWP_SD3_PIN; // can be set for app when DIO or DOUT config used for PSRAM only
+#else
+    // no custom value, find it based on the package eFuse value
+    uint8_t chip_ver;
+    uint32_t pkg_ver = REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
+    switch(pkg_ver) {
+    case EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5:
+        return ESP32_D2WD_WP_GPIO;
+    case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2:
+    case EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4:
+        /* Same package IDs are used for ESP32-PICO-V3 and ESP32-PICO-D4, silicon version differentiates */
+        chip_ver = bootloader_common_get_chip_revision();
+        return (chip_ver < 3) ? ESP32_D2WD_WP_GPIO : ESP32_PICO_V3_GPIO;
+    case EFUSE_RD_CHIP_VER_PKG_ESP32PICOV302:
+        return ESP32_PICO_V3_GPIO;
+    default:
+        return SPI_WP_GPIO_NUM;
+    }
+#endif
+}

--- a/components/bootloader_support/src/bootloader_flash_config_esp32s2.c
+++ b/components/bootloader_support/src/bootloader_flash_config_esp32s2.c
@@ -1,0 +1,90 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdbool.h>
+#include <assert.h>
+#include "string.h"
+#include "sdkconfig.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp32s2/rom/gpio.h"
+#include "esp32s2/rom/spi_flash.h"
+#include "esp32s2/rom/efuse.h"
+#include "soc/gpio_periph.h"
+#include "soc/efuse_reg.h"
+#include "soc/spi_reg.h"
+#include "soc/spi_mem_reg.h"
+#include "soc/spi_caps.h"
+#include "flash_qio_mode.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_common.h"
+
+#define FLASH_IO_MATRIX_DUMMY_40M   0
+#define FLASH_IO_MATRIX_DUMMY_80M   0
+
+#define FLASH_IO_DRIVE_GD_WITH_1V8PSRAM    3
+
+void bootloader_flash_update_id()
+{
+    g_rom_flashchip.device_id = bootloader_read_flash_id();
+}
+
+void bootloader_flash_update_size(uint32_t size)
+{
+    g_rom_flashchip.chip_size = size;
+}
+
+void IRAM_ATTR bootloader_flash_cs_timing_config()
+{
+    SET_PERI_REG_MASK(SPI_MEM_USER_REG(0), SPI_MEM_CS_HOLD_M | SPI_MEM_CS_SETUP_M);
+    SET_PERI_REG_BITS(SPI_MEM_CTRL2_REG(0), SPI_MEM_CS_HOLD_TIME_V, 0, SPI_MEM_CS_HOLD_TIME_S);
+    SET_PERI_REG_BITS(SPI_MEM_CTRL2_REG(0), SPI_MEM_CS_SETUP_TIME_V, 0, SPI_MEM_CS_SETUP_TIME_S);
+    SET_PERI_REG_MASK(SPI_MEM_USER_REG(1), SPI_MEM_CS_HOLD_M | SPI_MEM_CS_SETUP_M);
+    SET_PERI_REG_BITS(SPI_MEM_CTRL2_REG(1), SPI_MEM_CS_HOLD_TIME_V, 1, SPI_MEM_CS_HOLD_TIME_S);
+    SET_PERI_REG_BITS(SPI_MEM_CTRL2_REG(1), SPI_MEM_CS_SETUP_TIME_V, 0, SPI_MEM_CS_SETUP_TIME_S);
+}
+
+void IRAM_ATTR bootloader_flash_clock_config(const esp_image_header_t* pfhdr)
+{
+    uint32_t spi_clk_div = 0;
+    switch (pfhdr->spi_speed) {
+        case ESP_IMAGE_SPI_SPEED_80M:
+            spi_clk_div = 1;
+            break;
+        case ESP_IMAGE_SPI_SPEED_40M:
+            spi_clk_div = 2;
+            break;
+        case ESP_IMAGE_SPI_SPEED_26M:
+            spi_clk_div = 3;
+            break;
+        case ESP_IMAGE_SPI_SPEED_20M:
+            spi_clk_div = 4;
+            break;
+        default:
+            break;
+    }
+    esp_rom_spiflash_config_clk(spi_clk_div, 0);
+    esp_rom_spiflash_config_clk(spi_clk_div, 1);
+}
+
+void IRAM_ATTR bootloader_flash_set_dummy_out(void)
+{
+    REG_SET_BIT(SPI_MEM_CTRL_REG(0), SPI_MEM_FDUMMY_OUT | SPI_MEM_D_POL | SPI_MEM_Q_POL);
+    REG_SET_BIT(SPI_MEM_CTRL_REG(1), SPI_MEM_FDUMMY_OUT | SPI_MEM_D_POL | SPI_MEM_Q_POL);
+}
+
+void IRAM_ATTR bootloader_flash_dummy_config(const esp_image_header_t* pfhdr)
+{
+    bootloader_configure_spi_pins(1);
+    bootloader_flash_set_dummy_out();
+}

--- a/components/bootloader_support/src/bootloader_init.c
+++ b/components/bootloader_support/src/bootloader_init.c
@@ -1,0 +1,110 @@
+// Copyright 2015-2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string.h>
+#include <stdint.h>
+#include "sdkconfig.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+#include "bootloader_init.h"
+#include "bootloader_flash.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_random.h"
+#include "bootloader_clock.h"
+#include "bootloader_common.h"
+#include "esp_flash_encrypt.h"
+#include "soc/cpu.h"
+#include "soc/rtc.h"
+#include "hal/wdt_hal.h"
+
+static const char *TAG = "boot";
+
+esp_image_header_t WORD_ALIGNED_ATTR bootloader_image_hdr;
+
+void bootloader_clear_bss_section(void)
+{
+    memset(&_bss_start, 0, (&_bss_end - &_bss_start) * sizeof(_bss_start));
+}
+
+esp_err_t bootloader_read_bootloader_header(void)
+{
+    /* load bootloader image header */
+    if (bootloader_flash_read(ESP_BOOTLOADER_OFFSET, &bootloader_image_hdr, sizeof(esp_image_header_t), true) != ESP_OK) {
+        ESP_LOGE(TAG, "failed to load bootloader image header!");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t bootloader_check_bootloader_validity(void)
+{
+    /* read chip revision from efuse */
+    uint8_t revision = bootloader_common_get_chip_revision();
+    ESP_LOGI(TAG, "chip revision: %d", revision);
+    /* compare with the one set in bootloader image header */
+    if (bootloader_common_check_chip_validity(&bootloader_image_hdr, ESP_IMAGE_BOOTLOADER) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+void bootloader_config_wdt(void)
+{
+    /*
+     * At this point, the flashboot protection of RWDT and MWDT0 will have been
+     * automatically enabled. We can disable flashboot protection as it's not
+     * needed anymore. If configured to do so, we also initialize the RWDT to
+     * protect the remainder of the bootloader process.
+     */
+    //Disable RWDT flashboot protection.
+    wdt_hal_context_t rtc_wdt_ctx = {.inst = WDT_RWDT, .rwdt_dev = &RTCCNTL};
+    wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+    wdt_hal_set_flashboot_en(&rtc_wdt_ctx, false);
+    wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+
+#ifdef CONFIG_BOOTLOADER_WDT_ENABLE
+    //Initialize and start RWDT to protect the  for bootloader if configured to do so
+    ESP_LOGD(TAG, "Enabling RTCWDT(%d ms)", CONFIG_BOOTLOADER_WDT_TIME_MS);
+    wdt_hal_init(&rtc_wdt_ctx, WDT_RWDT, 0, false);
+    uint32_t stage_timeout_ticks = (uint32_t)((uint64_t)CONFIG_BOOTLOADER_WDT_TIME_MS * rtc_clk_slow_freq_get_hz() / 1000);
+    wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+    wdt_hal_config_stage(&rtc_wdt_ctx, WDT_STAGE0, stage_timeout_ticks, WDT_STAGE_ACTION_RESET_RTC);
+    wdt_hal_enable(&rtc_wdt_ctx);
+    wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+#endif
+
+    //Disable MWDT0 flashboot protection. But only after we've enabled the RWDT first so that there's not gap in WDT protection.
+    wdt_hal_context_t wdt_ctx = {.inst = WDT_MWDT0, .mwdt_dev = &TIMERG0};
+    wdt_hal_write_protect_disable(&wdt_ctx);
+    wdt_hal_set_flashboot_en(&wdt_ctx, false);
+    wdt_hal_write_protect_enable(&wdt_ctx);
+}
+
+void bootloader_enable_random(void)
+{
+    ESP_LOGI(TAG, "Enabling RNG early entropy source...");
+    bootloader_random_enable();
+}
+
+void bootloader_print_banner(void)
+{
+    ESP_LOGI(TAG, "ESP-IDF %s 2nd stage bootloader", IDF_VER);
+    ESP_LOGI(TAG, "compile time " __TIME__);
+}
+
+void __assert_func(const char *file, int line, const char *func, const char *expr)
+{
+    ESP_LOGE(TAG, "Assert failed in %s, %s:%d (%s)", func, file, line, expr);
+    while (1) {
+    }
+}

--- a/components/bootloader_support/src/bootloader_mem.c
+++ b/components/bootloader_support/src/bootloader_mem.c
@@ -1,0 +1,48 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdbool.h>
+
+#include "xtensa/config/core.h"
+#include "hal/cpu_hal.h"
+#include "hal/mpu_hal.h"
+#include "hal/mpu_types.h"
+#include "soc/mpu_caps.h"
+#include "bootloader_mem.h"
+#include "xt_instr_macros.h"
+#include "xtensa/config/specreg.h"
+
+static inline void cpu_configure_region_protection(void)
+{
+    /* Currently, the only supported chips esp32 and esp32s2
+     * have the same configuration. Move this to the port layer once
+     * more chips with different configurations are supported.
+     * 
+     * Both chips have the address space divided into 8 regions, 512MB each.
+     */
+    const int illegal_regions[] = {0, 4, 5, 6, 7}; // 0x00000000, 0x80000000, 0xa0000000, 0xc0000000, 0xe0000000
+    for (int i = 0; i < sizeof(illegal_regions) / sizeof(illegal_regions[0]); ++i) {
+        mpu_hal_set_region_access(illegal_regions[i], MPU_REGION_ILLEGAL);
+    }
+
+    mpu_hal_set_region_access(1, MPU_REGION_RW); // 0x20000000
+}
+
+void bootloader_init_mem(void)
+{
+    cpu_hal_init_hwloop();
+
+    // protect memory region
+    cpu_configure_region_protection();
+}

--- a/components/bootloader_support/src/bootloader_random.c
+++ b/components/bootloader_support/src/bootloader_random.c
@@ -1,0 +1,56 @@
+// Copyright 2010-2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+#include "bootloader_random.h"
+#include "soc/cpu.h"
+#include "soc/wdev_reg.h"
+
+#ifndef BOOTLOADER_BUILD
+#include "esp_system.h"
+#include "driver/periph_ctrl.h"
+
+void bootloader_fill_random(void *buffer, size_t length)
+{
+    return esp_fill_random(buffer, length);
+}
+
+#else
+void bootloader_fill_random(void *buffer, size_t length)
+{
+    uint8_t *buffer_bytes = (uint8_t *)buffer;
+    uint32_t random;
+    uint32_t start, now;
+
+    assert(buffer != NULL);
+
+    for (int i = 0; i < length; i++) {
+        if (i == 0 || i % 4 == 0) { /* redundant check is for a compiler warning */
+            /* in bootloader with ADC feeding HWRNG, we accumulate 1
+               bit of entropy per 40 APB cycles (==80 CPU cycles.)
+
+               To avoid reading the entire RNG hardware state out
+               as-is, we repeatedly read the RNG register and XOR all
+               values.
+            */
+            random = REG_READ(WDEV_RND_REG);
+            RSR(CCOUNT, start);
+            do {
+                random ^= REG_READ(WDEV_RND_REG);
+                RSR(CCOUNT, now);
+            } while (now - start < 80 * 32 * 2); /* extra factor of 2 is precautionary */
+        }
+        buffer_bytes[i] = random >> ((i % 4) * 8);
+    }
+}
+#endif // BOOTLOADER_BUILD

--- a/components/bootloader_support/src/bootloader_random_esp32.c
+++ b/components/bootloader_support/src/bootloader_random_esp32.c
@@ -1,0 +1,128 @@
+// Copyright 2016-2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+#include "bootloader_random.h"
+#include "soc/rtc_periph.h"
+#include "soc/sens_periph.h"
+#include "soc/syscon_periph.h"
+#include "soc/dport_reg.h"
+#include "soc/i2s_periph.h"
+#include "esp_log.h"
+#include "soc/io_mux_reg.h"
+
+#ifndef BOOTLOADER_BUILD
+#include "driver/periph_ctrl.h"
+#endif
+
+void bootloader_random_enable(void)
+{
+    /* Ensure the hardware RNG is enabled following a soft reset.  This should always be the case already (this clock is
+       never disabled while the CPU is running), this is a "belts and braces" type check.
+     */
+#ifdef BOOTLOADER_BUILD
+    DPORT_SET_PERI_REG_MASK(DPORT_WIFI_CLK_EN_REG, DPORT_WIFI_CLK_RNG_EN);
+#else
+    periph_module_enable(PERIPH_RNG_MODULE);
+#endif // BOOTLOADER_BUILD
+
+    /* Enable SAR ADC in test mode to feed ADC readings of the 1.1V
+       reference via I2S into the RNG entropy input.
+
+       Note: I2S requires the PLL to be running, so the call to rtc_set_cpu_freq(CPU_80M)
+       in early bootloader startup must have been made.
+    */
+    SET_PERI_REG_BITS(RTC_CNTL_TEST_MUX_REG, RTC_CNTL_DTEST_RTC, 2, RTC_CNTL_DTEST_RTC_S);
+    SET_PERI_REG_MASK(RTC_CNTL_TEST_MUX_REG, RTC_CNTL_ENT_RTC);
+    SET_PERI_REG_MASK(SENS_SAR_START_FORCE_REG, SENS_SAR2_EN_TEST);
+
+#ifdef BOOTLOADER_BUILD
+    DPORT_SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_I2S0_CLK_EN);
+#else
+    periph_module_enable(PERIPH_I2S0_MODULE);
+#endif // BOOTLOADER_BUILD
+    CLEAR_PERI_REG_MASK(SENS_SAR_START_FORCE_REG, SENS_ULP_CP_FORCE_START_TOP);
+    CLEAR_PERI_REG_MASK(SENS_SAR_START_FORCE_REG, SENS_ULP_CP_START_TOP);
+
+    // Test pattern configuration byte 0xAD:
+    //--[7:4] channel_sel: 10-->en_test
+    //--[3:2] bit_width  : 3-->12bit
+    //--[1:0] atten      : 1-->3dB attenuation
+    WRITE_PERI_REG(SYSCON_SARADC_SAR2_PATT_TAB1_REG, 0xADADADAD);
+    WRITE_PERI_REG(SYSCON_SARADC_SAR2_PATT_TAB2_REG, 0xADADADAD);
+    WRITE_PERI_REG(SYSCON_SARADC_SAR2_PATT_TAB3_REG, 0xADADADAD);
+    WRITE_PERI_REG(SYSCON_SARADC_SAR2_PATT_TAB4_REG, 0xADADADAD);
+    SET_PERI_REG_BITS(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 3, SENS_FORCE_XPD_SAR_S);
+    SET_PERI_REG_MASK(SENS_SAR_READ_CTRL_REG, SENS_SAR1_DIG_FORCE);
+    SET_PERI_REG_MASK(SENS_SAR_READ_CTRL2_REG, SENS_SAR2_DIG_FORCE);
+
+    SET_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR2_MUX);
+    SET_PERI_REG_BITS(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR_CLK_DIV, 4, SYSCON_SARADC_SAR_CLK_DIV_S);
+    SET_PERI_REG_BITS(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_RSTB_WAIT, 8, SYSCON_SARADC_RSTB_WAIT_S); /* was 1 */
+    SET_PERI_REG_BITS(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_START_WAIT, 10, SYSCON_SARADC_START_WAIT_S);
+    SET_PERI_REG_BITS(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_WORK_MODE, 0, SYSCON_SARADC_WORK_MODE_S);
+    SET_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR_SEL);
+    CLEAR_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_DATA_SAR_SEL);
+    SET_PERI_REG_BITS(I2S_SAMPLE_RATE_CONF_REG(0), I2S_RX_BCK_DIV_NUM, 20, I2S_RX_BCK_DIV_NUM_S);
+    SET_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_DATA_TO_I2S);
+
+    CLEAR_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_CAMERA_EN);
+    SET_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_LCD_EN);
+    SET_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_DATA_ENABLE);
+    SET_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_DATA_ENABLE_TEST_EN);
+    SET_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_START);
+}
+
+void bootloader_random_disable(void)
+{
+    /* Reset some i2s configuration (possibly redundant as we reset entire
+       I2S peripheral further down). */
+    CLEAR_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_START);
+    SET_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_RESET);
+    CLEAR_PERI_REG_MASK(I2S_CONF_REG(0), I2S_RX_RESET);
+    CLEAR_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_CAMERA_EN);
+    CLEAR_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_LCD_EN);
+    CLEAR_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_DATA_ENABLE_TEST_EN);
+    CLEAR_PERI_REG_MASK(I2S_CONF2_REG(0), I2S_DATA_ENABLE);
+
+    /* Disable i2s clock */
+#ifdef BOOTLOADER_BUILD
+    DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_CLK_EN_REG, DPORT_I2S0_CLK_EN);
+#else
+    periph_module_disable(PERIPH_I2S0_MODULE);
+#endif // BOOTLOADER_BUILD
+
+    /* Restore SYSCON mode registers */
+    CLEAR_PERI_REG_MASK(SENS_SAR_READ_CTRL_REG, SENS_SAR1_DIG_FORCE);
+    CLEAR_PERI_REG_MASK(SENS_SAR_READ_CTRL2_REG, SENS_SAR2_DIG_FORCE);
+
+    /* Restore SAR ADC mode */
+    CLEAR_PERI_REG_MASK(SENS_SAR_START_FORCE_REG, SENS_SAR2_EN_TEST);
+    CLEAR_PERI_REG_MASK(SYSCON_SARADC_CTRL_REG, SYSCON_SARADC_SAR2_MUX
+                        | SYSCON_SARADC_SAR_SEL | SYSCON_SARADC_DATA_TO_I2S);
+    SET_PERI_REG_BITS(SENS_SAR_MEAS_WAIT2_REG, SENS_FORCE_XPD_SAR, 0, SENS_FORCE_XPD_SAR_S);
+
+    SET_PERI_REG_BITS(SYSCON_SARADC_FSM_REG, SYSCON_SARADC_START_WAIT, 8, SYSCON_SARADC_START_WAIT_S);
+
+    /* Reset i2s peripheral */
+#ifdef BOOTLOADER_BUILD
+    DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_I2S0_RST);
+    DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_I2S0_RST);
+#else
+    periph_module_reset(PERIPH_I2S0_MODULE);
+#endif
+
+    /* Disable pull supply voltage to SAR ADC */
+    CLEAR_PERI_REG_MASK(RTC_CNTL_TEST_MUX_REG, RTC_CNTL_ENT_RTC);
+    SET_PERI_REG_BITS(RTC_CNTL_TEST_MUX_REG, RTC_CNTL_DTEST_RTC, 0, RTC_CNTL_DTEST_RTC_S);
+}

--- a/components/bootloader_support/src/bootloader_random_esp32s2.c
+++ b/components/bootloader_support/src/bootloader_random_esp32s2.c
@@ -1,0 +1,106 @@
+// Copyright 2019-2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+#include "bootloader_random.h"
+#include "soc/rtc_periph.h"
+#include "soc/sens_periph.h"
+#include "soc/syscon_periph.h"
+#include "soc/dport_reg.h"
+#include "soc/i2s_periph.h"
+#include "esp_log.h"
+#include "soc/io_mux_reg.h"
+#include "soc/apb_saradc_reg.h"
+#include "regi2c_ctrl.h"
+#include "hal/adc_ll.h"
+
+#ifndef BOOTLOADER_BUILD
+#include "driver/periph_ctrl.h"
+#endif
+
+void bootloader_random_enable(void)
+{
+    /* Ensure the Wifi clock for RNG modiule is enabled following a soft reset.  This should always be the case already
+       (this clock is never disabled while the CPU is running), this is a "belt and braces" type check.
+     */
+#ifdef BOOTLOADER_BUILD
+    DPORT_SET_PERI_REG_MASK(DPORT_WIFI_CLK_EN_REG, DPORT_WIFI_CLK_RNG_EN);
+#else
+    periph_module_enable(PERIPH_RNG_MODULE);
+#endif // BOOTLOADER_BUILD
+
+    // Enable 8M clock source for RNG (this is actually enough to produce strong random results,
+    // but enabling the SAR ADC as well adds some insurance.)
+    REG_SET_BIT(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_DIG_CLK8M_EN);
+
+    // Enable SAR ADC to read a disconnected input for additional entropy
+    SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN0_REG,DPORT_APB_SARADC_CLK_EN);
+
+    REG_SET_FIELD(APB_SARADC_APB_ADC_CLKM_CONF_REG, APB_SARADC_CLK_SEL, 2);
+
+    CLEAR_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_FORCE_PD_M);
+    SET_PERI_REG_MASK(RTC_CNTL_ANA_CONF_REG, RTC_CNTL_SAR_I2C_FORCE_PU_M);
+    CLEAR_PERI_REG_MASK(ANA_CONFIG_REG, BIT(18));
+    SET_PERI_REG_MASK(ANA_CONFIG2_REG, BIT(16));
+
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SAR1_DREF_ADDR, 0x4);
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SAR2_DREF_ADDR, 0x4);
+
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 1);
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 1);
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+
+    REG_SET_FIELD(APB_SARADC_CTRL_REG, APB_SARADC_SAR1_PATT_LEN, 0);
+    WRITE_PERI_REG(APB_SARADC_SAR1_PATT_TAB1_REG,0xafffffff);    // set adc1 channel & bitwidth & atten
+
+    REG_SET_FIELD(APB_SARADC_CTRL_REG, APB_SARADC_SAR2_PATT_LEN, 0);
+    WRITE_PERI_REG(APB_SARADC_SAR2_PATT_TAB1_REG,0xafffffff); //set adc2 channel & bitwidth & atten
+
+    SET_PERI_REG_MASK(SENS_SAR_MEAS1_MUX_REG,SENS_SAR1_DIG_FORCE);
+
+    REG_SET_FIELD(APB_SARADC_CTRL_REG,APB_SARADC_WORK_MODE, 1);
+
+    CLEAR_PERI_REG_MASK(APB_SARADC_CTRL2_REG,APB_SARADC_MEAS_NUM_LIMIT);
+
+    REG_SET_FIELD(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR, 3);
+
+    SET_PERI_REG_MASK(APB_SARADC_CTRL2_REG,APB_SARADC_TIMER_SEL);
+
+    REG_SET_FIELD(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_TARGET, 100);
+
+    CLEAR_PERI_REG_MASK(APB_SARADC_CTRL_REG,APB_SARADC_START_FORCE);
+
+    SET_PERI_REG_MASK(APB_SARADC_CTRL2_REG,APB_SARADC_TIMER_EN);
+}
+
+void bootloader_random_disable(void)
+{
+    /* Restore internal I2C bus state */
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SAR1_DREF_ADDR, 0x1);
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SAR2_DREF_ADDR, 0x1);
+
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SARADC_ENCAL_REF_ADDR, 0);
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SARADC_ENT_TSENS_ADDR, 0);
+    REGI2C_WRITE_MASK(I2C_SAR_ADC, ADC_SARADC_ENT_RTC_ADDR, 0);
+
+    /* Restore SARADC to default mode */
+    CLEAR_PERI_REG_MASK(SENS_SAR_MEAS1_MUX_REG, SENS_SAR1_DIG_FORCE);
+    SET_PERI_REG_MASK(DPORT_PERIP_CLK_EN0_REG, DPORT_APB_SARADC_CLK_EN);
+    SET_PERI_REG_BITS(SENS_SAR_POWER_XPD_SAR_REG, SENS_FORCE_XPD_SAR, 0, SENS_FORCE_XPD_SAR_S);
+    CLEAR_PERI_REG_MASK(APB_SARADC_CTRL2_REG, APB_SARADC_TIMER_EN);
+
+    /* Note: the 8M CLK entropy source continues running even after this function is called,
+       but as mentioned above it's better to enable Wi-Fi or BT or call bootloader_random_enable()
+       in order to get a secondary entropy source.
+    */
+}

--- a/components/bootloader_support/src/bootloader_utility.c
+++ b/components/bootloader_support/src/bootloader_utility.c
@@ -1,0 +1,855 @@
+// Copyright 2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+#include <sys/param.h>
+
+#include "esp_attr.h"
+#include "esp_log.h"
+
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/cache.h"
+#include "esp32/rom/efuse.h"
+#include "esp32/rom/ets_sys.h"
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/crc.h"
+#include "esp32/rom/rtc.h"
+#include "esp32/rom/uart.h"
+#include "esp32/rom/gpio.h"
+#include "esp32/rom/secure_boot.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/cache.h"
+#include "esp32s2/rom/efuse.h"
+#include "esp32s2/rom/ets_sys.h"
+#include "esp32s2/rom/spi_flash.h"
+#include "esp32s2/rom/crc.h"
+#include "esp32s2/rom/rtc.h"
+#include "esp32s2/rom/uart.h"
+#include "esp32s2/rom/gpio.h"
+#include "esp32s2/rom/secure_boot.h"
+#include "soc/extmem_reg.h"
+#include "soc/cache_memory.h"
+#else
+#error "Unsupported IDF_TARGET"
+#endif
+
+#include "soc/soc.h"
+#include "soc/cpu.h"
+#include "soc/rtc.h"
+#include "soc/dport_reg.h"
+#include "soc/gpio_periph.h"
+#include "soc/efuse_periph.h"
+#include "soc/rtc_periph.h"
+#include "soc/timer_periph.h"
+
+#include "sdkconfig.h"
+#include "esp_image_format.h"
+#include "esp_secure_boot.h"
+#include "esp_flash_encrypt.h"
+#include "esp_flash_partitions.h"
+#include "bootloader_flash.h"
+#include "bootloader_random.h"
+#include "bootloader_config.h"
+#include "bootloader_common.h"
+#include "bootloader_utility.h"
+#include "bootloader_sha.h"
+#include "esp_efuse.h"
+
+static const char *TAG = "boot";
+
+/* Reduce literal size for some generic string literals */
+#define MAP_ERR_MSG "Image contains multiple %s segments. Only the last one will be mapped."
+
+static bool ota_has_initial_contents;
+
+static void load_image(const esp_image_metadata_t *image_data);
+static void unpack_load_app(const esp_image_metadata_t *data);
+static void set_cache_and_start_app(uint32_t drom_addr,
+                                    uint32_t drom_load_addr,
+                                    uint32_t drom_size,
+                                    uint32_t irom_addr,
+                                    uint32_t irom_load_addr,
+                                    uint32_t irom_size,
+                                    uint32_t entry_addr);
+
+// Read ota_info partition and fill array from two otadata structures.
+static esp_err_t read_otadata(const esp_partition_pos_t *ota_info, esp_ota_select_entry_t *two_otadata)
+{
+    const esp_ota_select_entry_t *ota_select_map;
+    if (ota_info->offset == 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // partition table has OTA data partition
+    if (ota_info->size < 2 * SPI_SEC_SIZE) {
+        ESP_LOGE(TAG, "ota_info partition size %d is too small (minimum %d bytes)", ota_info->size, sizeof(esp_ota_select_entry_t));
+        return ESP_FAIL; // can't proceed
+    }
+
+    ESP_LOGD(TAG, "OTA data offset 0x%x", ota_info->offset);
+    ota_select_map = bootloader_mmap(ota_info->offset, ota_info->size);
+    if (!ota_select_map) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", ota_info->offset, ota_info->size);
+        return ESP_FAIL; // can't proceed
+    }
+
+    memcpy(&two_otadata[0], ota_select_map, sizeof(esp_ota_select_entry_t));
+    memcpy(&two_otadata[1], (uint8_t *)ota_select_map + SPI_SEC_SIZE, sizeof(esp_ota_select_entry_t));
+    bootloader_munmap(ota_select_map);
+
+    return ESP_OK;
+}
+
+bool bootloader_utility_load_partition_table(bootloader_state_t *bs)
+{
+    const esp_partition_info_t *partitions;
+    const char *partition_usage;
+    esp_err_t err;
+    int num_partitions;
+
+    partitions = bootloader_mmap(ESP_PARTITION_TABLE_OFFSET, ESP_PARTITION_TABLE_MAX_LEN);
+    if (!partitions) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", ESP_PARTITION_TABLE_OFFSET, ESP_PARTITION_TABLE_MAX_LEN);
+        return false;
+    }
+    ESP_LOGD(TAG, "mapped partition table 0x%x at 0x%x", ESP_PARTITION_TABLE_OFFSET, (intptr_t)partitions);
+
+    err = esp_partition_table_verify(partitions, true, &num_partitions);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to verify partition table");
+        return false;
+    }
+
+    ESP_LOGI(TAG, "Partition Table:");
+    ESP_LOGI(TAG, "## Label            Usage          Type ST Offset   Length");
+
+    for (int i = 0; i < num_partitions; i++) {
+        const esp_partition_info_t *partition = &partitions[i];
+        ESP_LOGD(TAG, "load partition table entry 0x%x", (intptr_t)partition);
+        ESP_LOGD(TAG, "type=%x subtype=%x", partition->type, partition->subtype);
+        partition_usage = "unknown";
+
+        /* valid partition table */
+        switch (partition->type) {
+        case PART_TYPE_APP: /* app partition */
+            switch (partition->subtype) {
+            case PART_SUBTYPE_FACTORY: /* factory binary */
+                bs->factory = partition->pos;
+                partition_usage = "factory app";
+                break;
+            case PART_SUBTYPE_TEST: /* test binary */
+                bs->test = partition->pos;
+                partition_usage = "test app";
+                break;
+            default:
+                /* OTA binary */
+                if ((partition->subtype & ~PART_SUBTYPE_OTA_MASK) == PART_SUBTYPE_OTA_FLAG) {
+                    bs->ota[partition->subtype & PART_SUBTYPE_OTA_MASK] = partition->pos;
+                    ++bs->app_count;
+                    partition_usage = "OTA app";
+                } else {
+                    partition_usage = "Unknown app";
+                }
+                break;
+            }
+            break; /* PART_TYPE_APP */
+        case PART_TYPE_DATA: /* data partition */
+            switch (partition->subtype) {
+            case PART_SUBTYPE_DATA_OTA: /* ota data */
+                bs->ota_info = partition->pos;
+                partition_usage = "OTA data";
+                break;
+            case PART_SUBTYPE_DATA_RF:
+                partition_usage = "RF data";
+                break;
+            case PART_SUBTYPE_DATA_WIFI:
+                partition_usage = "WiFi data";
+                break;
+            case PART_SUBTYPE_DATA_NVS_KEYS:
+                partition_usage = "NVS keys";
+                break;
+            case PART_SUBTYPE_DATA_EFUSE_EM:
+                partition_usage = "efuse";
+#ifdef CONFIG_BOOTLOADER_EFUSE_SECURE_VERSION_EMULATE
+                esp_efuse_init(partition->pos.offset, partition->pos.size);
+#endif
+                break;
+            default:
+                partition_usage = "Unknown data";
+                break;
+            }
+            break; /* PARTITION_USAGE_DATA */
+        default: /* other partition type */
+            break;
+        }
+
+        /* print partition type info */
+        ESP_LOGI(TAG, "%2d %-16s %-16s %02x %02x %08x %08x", i, partition->label, partition_usage,
+                 partition->type, partition->subtype,
+                 partition->pos.offset, partition->pos.size);
+    }
+
+    bootloader_munmap(partitions);
+
+    ESP_LOGI(TAG, "End of partition table");
+    return true;
+}
+
+/* Given a partition index, return the partition position data from the bootloader_state_t structure */
+static esp_partition_pos_t index_to_partition(const bootloader_state_t *bs, int index)
+{
+    if (index == FACTORY_INDEX) {
+        return bs->factory;
+    }
+
+    if (index == TEST_APP_INDEX) {
+        return bs->test;
+    }
+
+    if (index >= 0 && index < MAX_OTA_SLOTS && index < bs->app_count) {
+        return bs->ota[index];
+    }
+
+    esp_partition_pos_t invalid = { 0 };
+    return invalid;
+}
+
+static void log_invalid_app_partition(int index)
+{
+    const char *not_bootable = " is not bootable"; /* save a few string literal bytes */
+    switch (index) {
+    case FACTORY_INDEX:
+        ESP_LOGE(TAG, "Factory app partition%s", not_bootable);
+        break;
+    case TEST_APP_INDEX:
+        ESP_LOGE(TAG, "Factory test app partition%s", not_bootable);
+        break;
+    default:
+        ESP_LOGE(TAG, "OTA app partition slot %d%s", index, not_bootable);
+        break;
+    }
+}
+
+static esp_err_t write_otadata(esp_ota_select_entry_t *otadata, uint32_t offset, bool write_encrypted)
+{
+    esp_err_t err = bootloader_flash_erase_sector(offset / FLASH_SECTOR_SIZE);
+    if (err == ESP_OK) {
+        err = bootloader_flash_write(offset, otadata, sizeof(esp_ota_select_entry_t), write_encrypted);
+    }
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error in write_otadata operation. err = 0x%x", err);
+    }
+    return err;
+}
+
+static bool check_anti_rollback(const esp_partition_pos_t *partition)
+{
+#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+    esp_app_desc_t app_desc;
+    esp_err_t err = bootloader_common_get_partition_description(partition, &app_desc);
+    return err == ESP_OK && esp_efuse_check_secure_version(app_desc.secure_version) == true;
+#else
+    return true;
+#endif
+}
+
+#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+static void update_anti_rollback(const esp_partition_pos_t *partition)
+{
+    esp_app_desc_t app_desc;
+    esp_err_t err = bootloader_common_get_partition_description(partition, &app_desc);
+    if (err == ESP_OK) {
+        esp_efuse_update_secure_version(app_desc.secure_version);
+    }
+}
+
+static int get_active_otadata_with_check_anti_rollback(const bootloader_state_t *bs, esp_ota_select_entry_t *two_otadata)
+{
+    uint32_t ota_seq;
+    uint32_t ota_slot;
+    bool valid_otadata[2];
+
+    valid_otadata[0] = bootloader_common_ota_select_valid(&two_otadata[0]);
+    valid_otadata[1] = bootloader_common_ota_select_valid(&two_otadata[1]);
+
+    bool sec_ver_valid_otadata[2] = { 0 };
+    for (int i = 0; i < 2; ++i) {
+        if (valid_otadata[i] == true) {
+            ota_seq = two_otadata[i].ota_seq - 1; // Raw OTA sequence number. May be more than # of OTA slots
+            ota_slot = ota_seq % bs->app_count; // Actual OTA partition selection
+            if (check_anti_rollback(&bs->ota[ota_slot]) == false) {
+                // invalid. This otadata[i] will not be selected as active.
+                ESP_LOGD(TAG, "OTA slot %d has an app with secure_version, this version is smaller than in the device. This OTA slot will not be selected.", ota_slot);
+            } else {
+                sec_ver_valid_otadata[i] = true;
+            }
+        }
+    }
+
+    return bootloader_common_select_otadata(two_otadata, sec_ver_valid_otadata, true);
+}
+#endif
+
+int bootloader_utility_get_selected_boot_partition(const bootloader_state_t *bs)
+{
+    esp_ota_select_entry_t otadata[2];
+    int boot_index = FACTORY_INDEX;
+
+    if (bs->ota_info.offset == 0) {
+        return FACTORY_INDEX;
+    }
+
+    if (read_otadata(&bs->ota_info, otadata) != ESP_OK) {
+        return INVALID_INDEX;
+    }
+    ota_has_initial_contents = false;
+
+    ESP_LOGD(TAG, "otadata[0]: sequence values 0x%08x", otadata[0].ota_seq);
+    ESP_LOGD(TAG, "otadata[1]: sequence values 0x%08x", otadata[1].ota_seq);
+
+#ifdef CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+    bool write_encrypted = esp_flash_encryption_enabled();
+    for (int i = 0; i < 2; ++i) {
+        if (otadata[i].ota_state == ESP_OTA_IMG_PENDING_VERIFY) {
+            ESP_LOGD(TAG, "otadata[%d] is marking as ABORTED", i);
+            otadata[i].ota_state = ESP_OTA_IMG_ABORTED;
+            write_otadata(&otadata[i], bs->ota_info.offset + FLASH_SECTOR_SIZE * i, write_encrypted);
+        }
+    }
+#endif
+
+#ifndef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+    if ((bootloader_common_ota_select_invalid(&otadata[0]) &&
+            bootloader_common_ota_select_invalid(&otadata[1])) ||
+            bs->app_count == 0) {
+        ESP_LOGD(TAG, "OTA sequence numbers both empty (all-0xFF) or partition table does not have bootable ota_apps (app_count=%d)", bs->app_count);
+        if (bs->factory.offset != 0) {
+            ESP_LOGI(TAG, "Defaulting to factory image");
+            boot_index = FACTORY_INDEX;
+        } else {
+            ESP_LOGI(TAG, "No factory image, trying OTA 0");
+            boot_index = 0;
+            // Try to boot from ota_0.
+            if ((otadata[0].ota_seq == UINT32_MAX || otadata[0].crc != bootloader_common_ota_select_crc(&otadata[0])) &&
+                    (otadata[1].ota_seq == UINT32_MAX || otadata[1].crc != bootloader_common_ota_select_crc(&otadata[1]))) {
+                // Factory is not found and both otadata are initial(0xFFFFFFFF) or incorrect crc.
+                // will set correct ota_seq.
+                ota_has_initial_contents = true;
+            }
+        }
+    } else {
+        int active_otadata = bootloader_common_get_active_otadata(otadata);
+#else
+    ESP_LOGI(TAG, "Enabled a check secure version of app for anti rollback");
+    ESP_LOGI(TAG, "Secure version (from eFuse) = %d", esp_efuse_read_secure_version());
+    // When CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK is enabled factory partition should not be in partition table, only two ota_app are there.
+    if ((otadata[0].ota_seq == UINT32_MAX || otadata[0].crc != bootloader_common_ota_select_crc(&otadata[0])) &&
+            (otadata[1].ota_seq == UINT32_MAX || otadata[1].crc != bootloader_common_ota_select_crc(&otadata[1]))) {
+        ESP_LOGI(TAG, "otadata[0..1] in initial state");
+        // both otadata are initial(0xFFFFFFFF) or incorrect crc.
+        // will set correct ota_seq.
+        ota_has_initial_contents = true;
+    } else {
+        int active_otadata = get_active_otadata_with_check_anti_rollback(bs, otadata);
+#endif
+        if (active_otadata != -1) {
+            ESP_LOGD(TAG, "Active otadata[%d]", active_otadata);
+            uint32_t ota_seq = otadata[active_otadata].ota_seq - 1; // Raw OTA sequence number. May be more than # of OTA slots
+            boot_index = ota_seq % bs->app_count; // Actual OTA partition selection
+            ESP_LOGD(TAG, "Mapping seq %d -> OTA slot %d", ota_seq, boot_index);
+#ifdef CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+            if (otadata[active_otadata].ota_state == ESP_OTA_IMG_NEW) {
+                ESP_LOGD(TAG, "otadata[%d] is selected as new and marked PENDING_VERIFY state", active_otadata);
+                otadata[active_otadata].ota_state = ESP_OTA_IMG_PENDING_VERIFY;
+                write_otadata(&otadata[active_otadata], bs->ota_info.offset + FLASH_SECTOR_SIZE * active_otadata, write_encrypted);
+            }
+#endif // CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+
+#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+            if (otadata[active_otadata].ota_state == ESP_OTA_IMG_VALID) {
+                update_anti_rollback(&bs->ota[boot_index]);
+            }
+#endif // CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+
+        } else if (bs->factory.offset != 0) {
+            ESP_LOGE(TAG, "ota data partition invalid, falling back to factory");
+            boot_index = FACTORY_INDEX;
+        } else {
+            ESP_LOGE(TAG, "ota data partition invalid and no factory, will try all partitions");
+            boot_index = FACTORY_INDEX;
+        }
+    }
+
+    return boot_index;
+}
+
+/* Return true if a partition has a valid app image that was successfully loaded */
+static bool try_load_partition(const esp_partition_pos_t *partition, esp_image_metadata_t *data)
+{
+    if (partition->size == 0) {
+        ESP_LOGD(TAG, "Can't boot from zero-length partition");
+        return false;
+    }
+#ifdef BOOTLOADER_BUILD
+    if (bootloader_load_image(partition, data) == ESP_OK) {
+        ESP_LOGI(TAG, "Loaded app from partition at offset 0x%x",
+                 partition->offset);
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+// ota_has_initial_contents flag is set if factory does not present in partition table and
+// otadata has initial content(0xFFFFFFFF), then set actual ota_seq.
+static void set_actual_ota_seq(const bootloader_state_t *bs, int index)
+{
+    if (index > FACTORY_INDEX && ota_has_initial_contents == true) {
+        esp_ota_select_entry_t otadata;
+        memset(&otadata, 0xFF, sizeof(otadata));
+        otadata.ota_seq = index + 1;
+        otadata.ota_state = ESP_OTA_IMG_VALID;
+        otadata.crc = bootloader_common_ota_select_crc(&otadata);
+
+        bool write_encrypted = esp_flash_encryption_enabled();
+        write_otadata(&otadata, bs->ota_info.offset + FLASH_SECTOR_SIZE * 0, write_encrypted);
+        ESP_LOGI(TAG, "Set actual ota_seq=%d in otadata[0]", otadata.ota_seq);
+#ifdef CONFIG_BOOTLOADER_APP_ANTI_ROLLBACK
+        update_anti_rollback(&bs->ota[index]);
+#endif
+    }
+#if defined( CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP ) || defined( CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC )
+    esp_partition_pos_t partition = index_to_partition(bs, index);
+    bootloader_common_update_rtc_retain_mem(&partition, true);
+#endif
+}
+
+#ifdef CONFIG_BOOTLOADER_SKIP_VALIDATE_IN_DEEP_SLEEP
+void bootloader_utility_load_boot_image_from_deep_sleep(void)
+{
+    if (rtc_get_reset_reason(0) == DEEPSLEEP_RESET) {
+        esp_partition_pos_t *partition = bootloader_common_get_rtc_retain_mem_partition();
+        if (partition != NULL) {
+            esp_image_metadata_t image_data;
+            if (bootloader_load_image_no_verify(partition, &image_data) == ESP_OK) {
+                ESP_LOGI(TAG, "Fast booting app from partition at offset 0x%x", partition->offset);
+                bootloader_common_update_rtc_retain_mem(NULL, true);
+                load_image(&image_data);
+            }
+        }
+        ESP_LOGE(TAG, "Fast booting is not successful");
+        ESP_LOGI(TAG, "Try to load an app as usual with all validations");
+    }
+}
+#endif
+
+#define TRY_LOG_FORMAT "Trying partition index %d offs 0x%x size 0x%x"
+
+void bootloader_utility_load_boot_image(const bootloader_state_t *bs, int start_index)
+{
+    int index = start_index;
+    esp_partition_pos_t part;
+    esp_image_metadata_t image_data;
+
+    if (start_index == TEST_APP_INDEX) {
+        if (try_load_partition(&bs->test, &image_data)) {
+            load_image(&image_data);
+        } else {
+            ESP_LOGE(TAG, "No bootable test partition in the partition table");
+            bootloader_reset();
+        }
+    }
+
+    /* work backwards from start_index, down to the factory app */
+    for (index = start_index; index >= FACTORY_INDEX; index--) {
+        part = index_to_partition(bs, index);
+        if (part.size == 0) {
+            continue;
+        }
+        ESP_LOGD(TAG, TRY_LOG_FORMAT, index, part.offset, part.size);
+        if (check_anti_rollback(&part) && try_load_partition(&part, &image_data)) {
+            set_actual_ota_seq(bs, index);
+            load_image(&image_data);
+        }
+        log_invalid_app_partition(index);
+    }
+
+    /* failing that work forwards from start_index, try valid OTA slots */
+    for (index = start_index + 1; index < bs->app_count; index++) {
+        part = index_to_partition(bs, index);
+        if (part.size == 0) {
+            continue;
+        }
+        ESP_LOGD(TAG, TRY_LOG_FORMAT, index, part.offset, part.size);
+        if (check_anti_rollback(&part) && try_load_partition(&part, &image_data)) {
+            set_actual_ota_seq(bs, index);
+            load_image(&image_data);
+        }
+        log_invalid_app_partition(index);
+    }
+
+    if (try_load_partition(&bs->test, &image_data)) {
+        ESP_LOGW(TAG, "Falling back to test app as only bootable partition");
+        load_image(&image_data);
+    }
+
+    ESP_LOGE(TAG, "No bootable app partitions in the partition table");
+    bzero(&image_data, sizeof(esp_image_metadata_t));
+    bootloader_reset();
+}
+
+// Copy loaded segments to RAM, set up caches for mapped segments, and start application.
+static void load_image(const esp_image_metadata_t *image_data)
+{
+    /**
+     * Rough steps for a first boot, when encryption and secure boot are both disabled:
+     *   1) Generate secure boot key and write to EFUSE.
+     *   2) Write plaintext digest based on plaintext bootloader
+     *   3) Generate flash encryption key and write to EFUSE.
+     *   4) Encrypt flash in-place including bootloader, then digest,
+     *      then app partitions and other encrypted partitions
+     *   5) Burn EFUSE to enable flash encryption (FLASH_CRYPT_CNT)
+     *   6) Burn EFUSE to enable secure boot (ABS_DONE_0)
+     *
+     * If power failure happens during Step 1, probably the next boot will continue from Step 2.
+     * There is some small chance that EFUSEs will be part-way through being written so will be
+     * somehow corrupted here. Thankfully this window of time is very small, but if that's the
+     * case, one has to use the espefuse tool to manually set the remaining bits and enable R/W
+     * protection. Once the relevant EFUSE bits are set and R/W protected, Step 1 will be skipped
+     * successfully on further reboots.
+     *
+     * If power failure happens during Step 2, Step 1 will be skipped and Step 2 repeated:
+     * the digest will get re-written on the next boot.
+     *
+     * If power failure happens during Step 3, it's possible that EFUSE was partially written
+     * with the generated flash encryption key, though the time window for that would again
+     * be very small. On reboot, Step 1 will be skipped and Step 2 repeated, though, Step 3
+     * may fail due to the above mentioned reason, in which case, one has to use the espefuse
+     * tool to manually set the remaining bits and enable R/W protection. Once the relevant EFUSE
+     * bits are set and R/W protected, Step 3 will be skipped successfully on further reboots.
+     *
+     * If power failure happens after start of 4 and before end of 5, the next boot will fail
+     * (bootloader header is encrypted and flash encryption isn't enabled yet, so it looks like
+     * noise to the ROM bootloader). The check in the ROM is pretty basic so if the first byte of
+     * ciphertext happens to be the magic byte E9 then it may try to boot, but it will definitely
+     * crash (no chance that the remaining ciphertext will look like a valid bootloader image).
+     * Only solution is to reflash with all plaintext and the whole process starts again: skips
+     * Step 1, repeats Step 2, skips Step 3, etc.
+     *
+     * If power failure happens after 5 but before 6, the device will reboot with flash
+     * encryption on and will regenerate an encrypted digest in Step 2. This should still
+     * be valid as the input data for the digest is read via flash cache (so will be decrypted)
+     * and the code in secure_boot_generate() tells bootloader_flash_write() to encrypt the data
+     * on write if flash encryption is enabled. Steps 3 - 5 are skipped (encryption already on),
+     * then Step 6 enables secure boot.
+     */
+
+#if defined(CONFIG_SECURE_BOOT) || defined(CONFIG_SECURE_FLASH_ENC_ENABLED)
+    esp_err_t err;
+#endif
+
+#ifdef CONFIG_SECURE_BOOT_V2_ENABLED
+    err = esp_secure_boot_v2_permanently_enable(image_data);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Secure Boot v2 failed (%d)", err);
+        return;
+    }
+#endif
+
+#ifdef CONFIG_SECURE_BOOT_V1_ENABLED
+    /* Steps 1 & 2 (see above for full description):
+     *   1) Generate secure boot EFUSE key
+     *   2) Compute digest of plaintext bootloader
+     */
+    err = esp_secure_boot_generate_digest();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Bootloader digest generation for secure boot failed (%d).", err);
+        return;
+    }
+#endif
+
+#ifdef CONFIG_SECURE_FLASH_ENC_ENABLED
+    /* Steps 3, 4 & 5 (see above for full description):
+     *   3) Generate flash encryption EFUSE key
+     *   4) Encrypt flash contents
+     *   5) Burn EFUSE to enable flash encryption
+     */
+    ESP_LOGI(TAG, "Checking flash encryption...");
+    bool flash_encryption_enabled = esp_flash_encryption_enabled();
+    err = esp_flash_encrypt_check_and_update();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Flash encryption check failed (%d).", err);
+        return;
+    }
+#endif
+
+#ifdef CONFIG_SECURE_BOOT_V1_ENABLED
+    /* Step 6 (see above for full description):
+     *   6) Burn EFUSE to enable secure boot
+     */
+    ESP_LOGI(TAG, "Checking secure boot...");
+    err = esp_secure_boot_permanently_enable();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "FAILED TO ENABLE SECURE BOOT (%d).", err);
+        /* Panic here as secure boot is not properly enabled
+           due to one of the reasons in above function
+        */
+        abort();
+    }
+#endif
+
+#ifdef CONFIG_SECURE_FLASH_ENC_ENABLED
+    if (!flash_encryption_enabled && esp_flash_encryption_enabled()) {
+        /* Flash encryption was just enabled for the first time,
+           so issue a system reset to ensure flash encryption
+           cache resets properly */
+        ESP_LOGI(TAG, "Resetting with flash encryption enabled...");
+        uart_tx_wait_idle(0);
+        bootloader_reset();
+    }
+#endif
+
+    ESP_LOGI(TAG, "Disabling RNG early entropy source...");
+    bootloader_random_disable();
+
+    // copy loaded segments to RAM, set up caches for mapped segments, and start application
+    unpack_load_app(image_data);
+}
+
+static void unpack_load_app(const esp_image_metadata_t *data)
+{
+    uint32_t drom_addr = 0;
+    uint32_t drom_load_addr = 0;
+    uint32_t drom_size = 0;
+    uint32_t irom_addr = 0;
+    uint32_t irom_load_addr = 0;
+    uint32_t irom_size = 0;
+
+    // Find DROM & IROM addresses, to configure cache mappings
+    for (int i = 0; i < data->image.segment_count; i++) {
+        const esp_image_segment_header_t *header = &data->segments[i];
+        if (header->load_addr >= SOC_DROM_LOW && header->load_addr < SOC_DROM_HIGH) {
+            if (drom_addr != 0) {
+                ESP_LOGE(TAG, MAP_ERR_MSG, "DROM");
+            } else {
+                ESP_LOGD(TAG, "Mapping segment %d as %s", i, "DROM");
+            }
+            drom_addr = data->segment_data[i];
+            drom_load_addr = header->load_addr;
+            drom_size = header->data_len;
+        }
+        if (header->load_addr >= SOC_IROM_LOW && header->load_addr < SOC_IROM_HIGH) {
+            if (irom_addr != 0) {
+                ESP_LOGE(TAG, MAP_ERR_MSG, "IROM");
+            } else {
+                ESP_LOGD(TAG, "Mapping segment %d as %s", i, "IROM");
+            }
+            irom_addr = data->segment_data[i];
+            irom_load_addr = header->load_addr;
+            irom_size = header->data_len;
+        }
+    }
+
+    ESP_LOGD(TAG, "calling set_cache_and_start_app");
+    set_cache_and_start_app(drom_addr,
+                            drom_load_addr,
+                            drom_size,
+                            irom_addr,
+                            irom_load_addr,
+                            irom_size,
+                            data->image.entry_addr);
+}
+
+static void set_cache_and_start_app(
+    uint32_t drom_addr,
+    uint32_t drom_load_addr,
+    uint32_t drom_size,
+    uint32_t irom_addr,
+    uint32_t irom_load_addr,
+    uint32_t irom_size,
+    uint32_t entry_addr)
+{
+    int rc;
+    ESP_LOGD(TAG, "configure drom and irom and start");
+#if CONFIG_IDF_TARGET_ESP32
+    Cache_Read_Disable(0);
+    Cache_Flush(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    uint32_t autoload = Cache_Suspend_ICache();
+    Cache_Invalidate_ICache_All();
+#endif
+
+    /* Clear the MMU entries that are already set up,
+       so the new app only has the mappings it creates.
+    */
+#if CONFIG_IDF_TARGET_ESP32
+    for (int i = 0; i < DPORT_FLASH_MMU_TABLE_SIZE; i++) {
+        DPORT_PRO_FLASH_MMU_TABLE[i] = DPORT_FLASH_MMU_TABLE_INVALID_VAL;
+    }
+#elif CONFIG_IDF_TARGET_ESP32S2
+    for (int i = 0; i < FLASH_MMU_TABLE_SIZE; i++) {
+        FLASH_MMU_TABLE[i] = MMU_TABLE_INVALID_VAL;
+    }
+#endif
+    uint32_t drom_load_addr_aligned = drom_load_addr & MMU_FLASH_MASK;
+    uint32_t drom_page_count = bootloader_cache_pages_to_map(drom_size, drom_load_addr);
+    ESP_LOGV(TAG, "d mmu set paddr=%08x vaddr=%08x size=%d n=%d",
+             drom_addr & MMU_FLASH_MASK, drom_load_addr_aligned, drom_size, drom_page_count);
+#if CONFIG_IDF_TARGET_ESP32
+    rc = cache_flash_mmu_set(0, 0, drom_load_addr_aligned, drom_addr & MMU_FLASH_MASK, 64, drom_page_count);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    rc = Cache_Ibus_MMU_Set(MMU_ACCESS_FLASH, drom_load_addr & 0xffff0000, drom_addr & 0xffff0000, 64, drom_page_count, 0);
+#endif
+    ESP_LOGV(TAG, "rc=%d", rc);
+#if CONFIG_IDF_TARGET_ESP32
+    rc = cache_flash_mmu_set(1, 0, drom_load_addr_aligned, drom_addr & MMU_FLASH_MASK, 64, drom_page_count);
+    ESP_LOGV(TAG, "rc=%d", rc);
+#endif
+    uint32_t irom_load_addr_aligned = irom_load_addr & MMU_FLASH_MASK;
+    uint32_t irom_page_count = bootloader_cache_pages_to_map(irom_size, irom_load_addr);
+    ESP_LOGV(TAG, "i mmu set paddr=%08x vaddr=%08x size=%d n=%d",
+             irom_addr & MMU_FLASH_MASK, irom_load_addr_aligned, irom_size, irom_page_count);
+#if CONFIG_IDF_TARGET_ESP32
+    rc = cache_flash_mmu_set(0, 0, irom_load_addr_aligned, irom_addr & MMU_FLASH_MASK, 64, irom_page_count);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    uint32_t iram1_used = 0;
+    if (irom_load_addr + irom_size > IRAM1_ADDRESS_LOW) {
+        iram1_used = 1;
+    }
+    if (iram1_used) {
+        rc = Cache_Ibus_MMU_Set(MMU_ACCESS_FLASH, IRAM0_ADDRESS_LOW, 0, 64, 64, 1);
+        rc = Cache_Ibus_MMU_Set(MMU_ACCESS_FLASH, IRAM1_ADDRESS_LOW, 0, 64, 64, 1);
+        REG_CLR_BIT(EXTMEM_PRO_ICACHE_CTRL1_REG, EXTMEM_PRO_ICACHE_MASK_IRAM1);
+    }
+    rc = Cache_Ibus_MMU_Set(MMU_ACCESS_FLASH, irom_load_addr & 0xffff0000, irom_addr & 0xffff0000, 64, irom_page_count, 0);
+#endif
+    ESP_LOGV(TAG, "rc=%d", rc);
+#if CONFIG_IDF_TARGET_ESP32
+    rc = cache_flash_mmu_set(1, 0, irom_load_addr_aligned, irom_addr & MMU_FLASH_MASK, 64, irom_page_count);
+    ESP_LOGV(TAG, "rc=%d", rc);
+    DPORT_REG_CLR_BIT( DPORT_PRO_CACHE_CTRL1_REG,
+                       (DPORT_PRO_CACHE_MASK_IRAM0) | (DPORT_PRO_CACHE_MASK_IRAM1 & 0) |
+                       (DPORT_PRO_CACHE_MASK_IROM0 & 0) | DPORT_PRO_CACHE_MASK_DROM0 |
+                       DPORT_PRO_CACHE_MASK_DRAM1 );
+    DPORT_REG_CLR_BIT( DPORT_APP_CACHE_CTRL1_REG,
+                       (DPORT_APP_CACHE_MASK_IRAM0) | (DPORT_APP_CACHE_MASK_IRAM1 & 0) |
+                       (DPORT_APP_CACHE_MASK_IROM0 & 0) | DPORT_APP_CACHE_MASK_DROM0 |
+                       DPORT_APP_CACHE_MASK_DRAM1 );
+#elif CONFIG_IDF_TARGET_ESP32S2
+    REG_CLR_BIT( EXTMEM_PRO_ICACHE_CTRL1_REG, (EXTMEM_PRO_ICACHE_MASK_IRAM0) | (EXTMEM_PRO_ICACHE_MASK_IRAM1 & 0) | EXTMEM_PRO_ICACHE_MASK_DROM0 );
+#endif
+#if CONFIG_IDF_TARGET_ESP32
+    Cache_Read_Enable(0);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    Cache_Resume_ICache(autoload);
+#endif
+    // Application will need to do Cache_Flush(1) and Cache_Read_Enable(1)
+
+    ESP_LOGD(TAG, "start: 0x%08x", entry_addr);
+    typedef void (*entry_t)(void) __attribute__((noreturn));
+    entry_t entry = ((entry_t) entry_addr);
+
+    // TODO: we have used quite a bit of stack at this point.
+    // use "movsp" instruction to reset stack back to where ROM stack starts.
+    (*entry)();
+}
+
+void bootloader_reset(void)
+{
+#ifdef BOOTLOADER_BUILD
+    uart_tx_flush(0);    /* Ensure any buffered log output is displayed */
+    uart_tx_flush(1);
+    ets_delay_us(1000); /* Allow last byte to leave FIFO */
+    REG_WRITE(RTC_CNTL_OPTIONS0_REG, RTC_CNTL_SW_SYS_RST);
+    while (1) { }       /* This line will never be reached, used to keep gcc happy */
+#else
+    abort();            /* This function should really not be called from application code */
+#endif
+}
+
+esp_err_t bootloader_sha256_hex_to_str(char *out_str, const uint8_t *in_array_hex, size_t len)
+{
+    if (out_str == NULL || in_array_hex == NULL || len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    for (int i = 0; i < len; i++) {
+        for (int shift = 0; shift < 2; shift++) {
+            uint8_t nibble = (in_array_hex[i] >> (shift ? 0 : 4)) & 0x0F;
+            if (nibble < 10) {
+                out_str[i * 2 + shift] = '0' + nibble;
+            } else {
+                out_str[i * 2 + shift] = 'a' + nibble - 10;
+            }
+        }
+    }
+    return ESP_OK;
+}
+
+void bootloader_debug_buffer(const void *buffer, size_t length, const char *label)
+{
+#if BOOT_LOG_LEVEL >= LOG_LEVEL_DEBUG
+    assert(length <= 128); // Avoid unbounded VLA size
+    const uint8_t *bytes = (const uint8_t *)buffer;
+    char hexbuf[length * 2 + 1];
+    hexbuf[length * 2] = 0;
+    for (int i = 0; i < length; i++) {
+        for (int shift = 0; shift < 2; shift++) {
+            uint8_t nibble = (bytes[i] >> (shift ? 0 : 4)) & 0x0F;
+            if (nibble < 10) {
+                hexbuf[i * 2 + shift] = '0' + nibble;
+            } else {
+                hexbuf[i * 2 + shift] = 'a' + nibble - 10;
+            }
+        }
+    }
+    ESP_LOGD(TAG, "%s: %s", label, hexbuf);
+#endif
+}
+
+esp_err_t bootloader_sha256_flash_contents(uint32_t flash_offset, uint32_t len, uint8_t *digest)
+{
+
+    if (digest == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Handling firmware images larger than MMU capacity */
+    uint32_t mmu_free_pages_count = bootloader_mmap_get_free_pages();
+    bootloader_sha256_handle_t sha_handle = NULL;
+
+    sha_handle = bootloader_sha256_start();
+    if (sha_handle == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    while (len > 0) {
+        uint32_t mmu_page_offset = ((flash_offset & MMAP_ALIGNED_MASK) != 0) ? 1 : 0; /* Skip 1st MMU Page if it is already populated */
+        uint32_t partial_image_len = MIN(len, ((mmu_free_pages_count - mmu_page_offset) * SPI_FLASH_MMU_PAGE_SIZE)); /* Read the image that fits in the free MMU pages */
+
+        const void * image = bootloader_mmap(flash_offset, partial_image_len);
+        if (image == NULL) {
+            bootloader_sha256_finish(sha_handle, NULL);
+            return ESP_FAIL;
+        }
+        bootloader_sha256_data(sha_handle, image, partial_image_len);
+        bootloader_munmap(image);
+
+        flash_offset += partial_image_len;
+        len -= partial_image_len;
+    }
+    bootloader_sha256_finish(sha_handle, digest);
+    return ESP_OK;
+}

--- a/components/bootloader_support/src/esp32/bootloader_esp32.c
+++ b/components/bootloader_support/src/esp32/bootloader_esp32.c
@@ -1,0 +1,473 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdint.h>
+#include "sdkconfig.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+#include "esp_image_format.h"
+#include "flash_qio_mode.h"
+
+#include "bootloader_init.h"
+#include "bootloader_clock.h"
+#include "bootloader_common.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_mem.h"
+
+#include "soc/cpu.h"
+#include "soc/dport_reg.h"
+#include "soc/efuse_reg.h"
+#include "soc/gpio_periph.h"
+#include "soc/gpio_sig_map.h"
+#include "soc/io_mux_reg.h"
+#include "soc/rtc.h"
+#include "soc/spi_periph.h"
+
+#include "esp32/rom/cache.h"
+#include "esp32/rom/efuse.h"
+#include "esp32/rom/ets_sys.h"
+#include "esp32/rom/gpio.h"
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/rtc.h"
+#include "esp32/rom/uart.h"
+
+static const char *TAG = "boot.esp32";
+
+#define FLASH_CLK_IO SPI_CLK_GPIO_NUM
+#define FLASH_CS_IO SPI_CS0_GPIO_NUM
+#define FLASH_SPIQ_IO SPI_Q_GPIO_NUM
+#define FLASH_SPID_IO SPI_D_GPIO_NUM
+#define FLASH_SPIWP_IO SPI_WP_GPIO_NUM
+#define FLASH_SPIHD_IO SPI_HD_GPIO_NUM
+
+void bootloader_configure_spi_pins(int drv)
+{
+    uint32_t chip_ver = REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
+    uint32_t pkg_ver = chip_ver & 0x7;
+
+    if (pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32D2WDQ5 ||
+        pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD2 ||
+        pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOD4 ||
+        pkg_ver == EFUSE_RD_CHIP_VER_PKG_ESP32PICOV302) {
+        // For ESP32D2WD or ESP32-PICO series,the SPI pins are already configured
+        // flash clock signal should come from IO MUX.
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CLK_U, FUNC_SD_CLK_SPICLK);
+        SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CLK_U, FUN_DRV, drv, FUN_DRV_S);
+    } else {
+        const uint32_t spiconfig = ets_efuse_get_spiconfig();
+        if (spiconfig == EFUSE_SPICONFIG_SPI_DEFAULTS) {
+            gpio_matrix_out(FLASH_CS_IO, SPICS0_OUT_IDX, 0, 0);
+            gpio_matrix_out(FLASH_SPIQ_IO, SPIQ_OUT_IDX, 0, 0);
+            gpio_matrix_in(FLASH_SPIQ_IO, SPIQ_IN_IDX, 0);
+            gpio_matrix_out(FLASH_SPID_IO, SPID_OUT_IDX, 0, 0);
+            gpio_matrix_in(FLASH_SPID_IO, SPID_IN_IDX, 0);
+            gpio_matrix_out(FLASH_SPIWP_IO, SPIWP_OUT_IDX, 0, 0);
+            gpio_matrix_in(FLASH_SPIWP_IO, SPIWP_IN_IDX, 0);
+            gpio_matrix_out(FLASH_SPIHD_IO, SPIHD_OUT_IDX, 0, 0);
+            gpio_matrix_in(FLASH_SPIHD_IO, SPIHD_IN_IDX, 0);
+            //select pin function gpio
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA0_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA1_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA2_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA3_U, PIN_FUNC_GPIO);
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CMD_U, PIN_FUNC_GPIO);
+            // flash clock signal should come from IO MUX.
+            // set drive ability for clock
+            PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CLK_U, FUNC_SD_CLK_SPICLK);
+            SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CLK_U, FUN_DRV, drv, FUN_DRV_S);
+
+#if CONFIG_SPIRAM_TYPE_ESPPSRAM32 || CONFIG_SPIRAM_TYPE_ESPPSRAM64
+            uint32_t flash_id = g_rom_flashchip.device_id;
+            if (flash_id == FLASH_ID_GD25LQ32C) {
+                // Set drive ability for 1.8v flash in 80Mhz.
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA0_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA1_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA2_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_DATA3_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CMD_U, FUN_DRV, 3, FUN_DRV_S);
+                SET_PERI_REG_BITS(PERIPHS_IO_MUX_SD_CLK_U, FUN_DRV, 3, FUN_DRV_S);
+            }
+#endif
+        }
+    }
+}
+
+static void bootloader_reset_mmu(void)
+{
+    /* completely reset MMU in case serial bootloader was running */
+    Cache_Read_Disable(0);
+#if !CONFIG_FREERTOS_UNICORE
+    Cache_Read_Disable(1);
+#endif
+    Cache_Flush(0);
+#if !CONFIG_FREERTOS_UNICORE
+    Cache_Flush(1);
+#endif
+    mmu_init(0);
+#if !CONFIG_FREERTOS_UNICORE
+    /* The lines which manipulate DPORT_APP_CACHE_MMU_IA_CLR bit are
+        necessary to work around a hardware bug. */
+    DPORT_REG_SET_BIT(DPORT_APP_CACHE_CTRL1_REG, DPORT_APP_CACHE_MMU_IA_CLR);
+    mmu_init(1);
+    DPORT_REG_CLR_BIT(DPORT_APP_CACHE_CTRL1_REG, DPORT_APP_CACHE_MMU_IA_CLR);
+#endif
+
+    /* normal ROM boot exits with DROM0 cache unmasked,
+        but serial bootloader exits with it masked. */
+    DPORT_REG_CLR_BIT(DPORT_PRO_CACHE_CTRL1_REG, DPORT_PRO_CACHE_MASK_DROM0);
+#if !CONFIG_FREERTOS_UNICORE
+    DPORT_REG_CLR_BIT(DPORT_APP_CACHE_CTRL1_REG, DPORT_APP_CACHE_MASK_DROM0);
+#endif
+}
+
+static esp_err_t bootloader_check_rated_cpu_clock(void)
+{
+    int rated_freq = bootloader_clock_get_rated_freq_mhz();
+    if (rated_freq < CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ) {
+        ESP_LOGE(TAG, "Chip CPU frequency rated for %dMHz, configured for %dMHz. Modify CPU frequency in menuconfig",
+                 rated_freq, CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ);
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static void update_flash_config(const esp_image_header_t *bootloader_hdr)
+{
+    uint32_t size;
+    switch (bootloader_hdr->spi_size) {
+    case ESP_IMAGE_FLASH_SIZE_1MB:
+        size = 1;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_2MB:
+        size = 2;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_4MB:
+        size = 4;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_8MB:
+        size = 8;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_16MB:
+        size = 16;
+        break;
+    default:
+        size = 2;
+    }
+    Cache_Read_Disable(0);
+    // Set flash chip size
+    esp_rom_spiflash_config_param(g_rom_flashchip.device_id, size * 0x100000, 0x10000, 0x1000, 0x100, 0xffff);
+    // TODO: set mode
+    // TODO: set frequency
+    Cache_Flush(0);
+    Cache_Read_Enable(0);
+}
+
+static void print_flash_info(const esp_image_header_t *bootloader_hdr)
+{
+    ESP_LOGD(TAG, "magic %02x", bootloader_hdr->magic);
+    ESP_LOGD(TAG, "segments %02x", bootloader_hdr->segment_count);
+    ESP_LOGD(TAG, "spi_mode %02x", bootloader_hdr->spi_mode);
+    ESP_LOGD(TAG, "spi_speed %02x", bootloader_hdr->spi_speed);
+    ESP_LOGD(TAG, "spi_size %02x", bootloader_hdr->spi_size);
+
+    const char *str;
+    switch (bootloader_hdr->spi_speed) {
+    case ESP_IMAGE_SPI_SPEED_40M:
+        str = "40MHz";
+        break;
+    case ESP_IMAGE_SPI_SPEED_26M:
+        str = "26.7MHz";
+        break;
+    case ESP_IMAGE_SPI_SPEED_20M:
+        str = "20MHz";
+        break;
+    case ESP_IMAGE_SPI_SPEED_80M:
+        str = "80MHz";
+        break;
+    default:
+        str = "20MHz";
+        break;
+    }
+    ESP_LOGI(TAG, "SPI Speed      : %s", str);
+
+    /* SPI mode could have been set to QIO during boot already,
+       so test the SPI registers not the flash header */
+    uint32_t spi_ctrl = REG_READ(SPI_CTRL_REG(0));
+    if (spi_ctrl & SPI_FREAD_QIO) {
+        str = "QIO";
+    } else if (spi_ctrl & SPI_FREAD_QUAD) {
+        str = "QOUT";
+    } else if (spi_ctrl & SPI_FREAD_DIO) {
+        str = "DIO";
+    } else if (spi_ctrl & SPI_FREAD_DUAL) {
+        str = "DOUT";
+    } else if (spi_ctrl & SPI_FASTRD_MODE) {
+        str = "FAST READ";
+    } else {
+        str = "SLOW READ";
+    }
+    ESP_LOGI(TAG, "SPI Mode       : %s", str);
+
+    switch (bootloader_hdr->spi_size) {
+    case ESP_IMAGE_FLASH_SIZE_1MB:
+        str = "1MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_2MB:
+        str = "2MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_4MB:
+        str = "4MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_8MB:
+        str = "8MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_16MB:
+        str = "16MB";
+        break;
+    default:
+        str = "2MB";
+        break;
+    }
+    ESP_LOGI(TAG, "SPI Flash Size : %s", str);
+}
+
+static void IRAM_ATTR bootloader_init_flash_configure(void)
+{
+    bootloader_flash_gpio_config(&bootloader_image_hdr);
+    bootloader_flash_dummy_config(&bootloader_image_hdr);
+    bootloader_flash_cs_timing_config();
+}
+
+static esp_err_t bootloader_init_spi_flash(void)
+{
+    bootloader_init_flash_configure();
+#ifndef CONFIG_SPI_FLASH_ROM_DRIVER_PATCH
+    const uint32_t spiconfig = ets_efuse_get_spiconfig();
+    if (spiconfig != EFUSE_SPICONFIG_SPI_DEFAULTS && spiconfig != EFUSE_SPICONFIG_HSPI_DEFAULTS) {
+        ESP_LOGE(TAG, "SPI flash pins are overridden. Enable CONFIG_SPI_FLASH_ROM_DRIVER_PATCH in menuconfig");
+        return ESP_FAIL;
+    }
+#endif
+
+    esp_rom_spiflash_unlock();
+
+#if CONFIG_ESPTOOLPY_FLASHMODE_QIO || CONFIG_ESPTOOLPY_FLASHMODE_QOUT
+    bootloader_enable_qio_mode();
+#endif
+
+    print_flash_info(&bootloader_image_hdr);
+    update_flash_config(&bootloader_image_hdr);
+    return ESP_OK;
+}
+
+static void bootloader_init_uart_console(void)
+{
+#if CONFIG_ESP_CONSOLE_UART_NONE
+    ets_install_putc1(NULL);
+    ets_install_putc2(NULL);
+#else // CONFIG_ESP_CONSOLE_UART_NONE
+    const int uart_num = CONFIG_ESP_CONSOLE_UART_NUM;
+
+    uartAttach();
+    ets_install_uart_printf();
+
+    // Wait for UART FIFO to be empty.
+    uart_tx_wait_idle(0);
+
+#if CONFIG_ESP_CONSOLE_UART_CUSTOM
+    // Some constants to make the following code less upper-case
+    const int uart_tx_gpio = CONFIG_ESP_CONSOLE_UART_TX_GPIO;
+    const int uart_rx_gpio = CONFIG_ESP_CONSOLE_UART_RX_GPIO;
+    // Switch to the new UART (this just changes UART number used for
+    // ets_printf in ROM code).
+    uart_tx_switch(uart_num);
+    // If console is attached to UART1 or if non-default pins are used,
+    // need to reconfigure pins using GPIO matrix
+    if (uart_num != 0 || uart_tx_gpio != 1 || uart_rx_gpio != 3) {
+        // Change pin mode for GPIO1/3 from UART to GPIO
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0RXD_U, FUNC_U0RXD_GPIO3);
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_GPIO1);
+        // Route GPIO signals to/from pins
+        // (arrays should be optimized away by the compiler)
+        const uint32_t tx_idx_list[3] = {U0TXD_OUT_IDX, U1TXD_OUT_IDX, U2TXD_OUT_IDX};
+        const uint32_t rx_idx_list[3] = {U0RXD_IN_IDX, U1RXD_IN_IDX, U2RXD_IN_IDX};
+        const uint32_t uart_reset[3] = {DPORT_UART_RST, DPORT_UART1_RST, DPORT_UART2_RST};
+        const uint32_t tx_idx = tx_idx_list[uart_num];
+        const uint32_t rx_idx = rx_idx_list[uart_num];
+
+        PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[uart_rx_gpio]);
+        gpio_pad_pullup(uart_rx_gpio);
+
+        gpio_matrix_out(uart_tx_gpio, tx_idx, 0, 0);
+        gpio_matrix_in(uart_rx_gpio, rx_idx, 0);
+
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, uart_reset[uart_num]);
+        DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, uart_reset[uart_num]);
+    }
+#endif // CONFIG_ESP_CONSOLE_UART_CUSTOM
+
+    // Set configured UART console baud rate
+    const int uart_baud = CONFIG_ESP_CONSOLE_UART_BAUDRATE;
+    uart_div_modify(uart_num, (rtc_clk_apb_freq_get() << 4) / uart_baud);
+
+#endif // CONFIG_ESP_CONSOLE_UART_NONE
+}
+
+static void wdt_reset_cpu0_info_enable(void)
+{
+    //We do not reset core1 info here because it didn't work before cpu1 was up. So we put it into call_start_cpu1.
+    DPORT_REG_SET_BIT(DPORT_PRO_CPU_RECORD_CTRL_REG, DPORT_PRO_CPU_PDEBUG_ENABLE | DPORT_PRO_CPU_RECORD_ENABLE);
+    DPORT_REG_CLR_BIT(DPORT_PRO_CPU_RECORD_CTRL_REG, DPORT_PRO_CPU_RECORD_ENABLE);
+}
+
+static void wdt_reset_info_dump(int cpu)
+{
+    uint32_t inst = 0, pid = 0, stat = 0, data = 0, pc = 0,
+             lsstat = 0, lsaddr = 0, lsdata = 0, dstat = 0;
+    const char *cpu_name = cpu ? "APP" : "PRO";
+
+    if (cpu == 0) {
+        stat = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_STATUS_REG);
+        pid = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PID_REG);
+        inst = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGINST_REG);
+        dstat = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGSTATUS_REG);
+        data = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGDATA_REG);
+        pc = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGPC_REG);
+        lsstat = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGLS0STAT_REG);
+        lsaddr = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGLS0ADDR_REG);
+        lsdata = DPORT_REG_READ(DPORT_PRO_CPU_RECORD_PDEBUGLS0DATA_REG);
+    } else {
+#if !CONFIG_FREERTOS_UNICORE
+        stat = DPORT_REG_READ(DPORT_APP_CPU_RECORD_STATUS_REG);
+        pid = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PID_REG);
+        inst = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGINST_REG);
+        dstat = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGSTATUS_REG);
+        data = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGDATA_REG);
+        pc = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGPC_REG);
+        lsstat = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGLS0STAT_REG);
+        lsaddr = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGLS0ADDR_REG);
+        lsdata = DPORT_REG_READ(DPORT_APP_CPU_RECORD_PDEBUGLS0DATA_REG);
+#endif
+    }
+
+    if (DPORT_RECORD_PDEBUGINST_SZ(inst) == 0 &&
+            DPORT_RECORD_PDEBUGSTATUS_BBCAUSE(dstat) == DPORT_RECORD_PDEBUGSTATUS_BBCAUSE_WAITI) {
+        ESP_LOGW(TAG, "WDT reset info: %s CPU PC=0x%x (waiti mode)", cpu_name, pc);
+    } else {
+        ESP_LOGW(TAG, "WDT reset info: %s CPU PC=0x%x", cpu_name, pc);
+    }
+    ESP_LOGD(TAG, "WDT reset info: %s CPU STATUS        0x%08x", cpu_name, stat);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PID           0x%08x", cpu_name, pid);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGINST    0x%08x", cpu_name, inst);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGSTATUS  0x%08x", cpu_name, dstat);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGDATA    0x%08x", cpu_name, data);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGPC      0x%08x", cpu_name, pc);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGLS0STAT 0x%08x", cpu_name, lsstat);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGLS0ADDR 0x%08x", cpu_name, lsaddr);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGLS0DATA 0x%08x", cpu_name, lsdata);
+}
+
+static void bootloader_check_wdt_reset(void)
+{
+    int wdt_rst = 0;
+    RESET_REASON rst_reas[2];
+
+    rst_reas[0] = rtc_get_reset_reason(0);
+    rst_reas[1] = rtc_get_reset_reason(1);
+    if (rst_reas[0] == RTCWDT_SYS_RESET || rst_reas[0] == TG0WDT_SYS_RESET || rst_reas[0] == TG1WDT_SYS_RESET ||
+            rst_reas[0] == TGWDT_CPU_RESET || rst_reas[0] == RTCWDT_CPU_RESET) {
+        ESP_LOGW(TAG, "PRO CPU has been reset by WDT.");
+        wdt_rst = 1;
+    }
+    if (rst_reas[1] == RTCWDT_SYS_RESET || rst_reas[1] == TG0WDT_SYS_RESET || rst_reas[1] == TG1WDT_SYS_RESET ||
+            rst_reas[1] == TGWDT_CPU_RESET || rst_reas[1] == RTCWDT_CPU_RESET) {
+        ESP_LOGW(TAG, "APP CPU has been reset by WDT.");
+        wdt_rst = 1;
+    }
+    if (wdt_rst) {
+        // if reset by WDT dump info from trace port
+        wdt_reset_info_dump(0);
+#if !CONFIG_FREERTOS_UNICORE
+        wdt_reset_info_dump(1);
+#endif
+    }
+    wdt_reset_cpu0_info_enable();
+}
+
+void abort(void)
+{
+#if !CONFIG_ESP_SYSTEM_PANIC_SILENT_REBOOT
+    ets_printf("abort() was called at PC 0x%08x\r\n", (intptr_t)__builtin_return_address(0) - 3);
+#endif
+    if (esp_cpu_in_ocd_debug_mode()) {
+        __asm__("break 0,0");
+    }
+    while (1) {
+    }
+}
+
+esp_err_t bootloader_init(void)
+{
+    esp_err_t ret = ESP_OK;
+
+    bootloader_init_mem();
+
+    // check that static RAM is after the stack
+#ifndef NDEBUG
+    {
+        assert(&_bss_start <= &_bss_end);
+        assert(&_data_start <= &_data_end);
+        int *sp = get_sp();
+        assert(sp < &_bss_start);
+        assert(sp < &_data_start);
+    }
+#endif
+    // clear bss section
+    bootloader_clear_bss_section();
+    // bootst up vddsdio
+    bootloader_common_vddsdio_configure();
+    // reset MMU
+    bootloader_reset_mmu();
+    // check rated CPU clock
+    if ((ret = bootloader_check_rated_cpu_clock()) != ESP_OK) {
+        goto err;
+    }
+    // config clock
+    bootloader_clock_configure();
+    // initialize uart console, from now on, we can use esp_log
+    bootloader_init_uart_console();
+    /* print 2nd bootloader banner */
+    bootloader_print_banner();
+    // update flash ID
+    bootloader_flash_update_id();
+    // read bootloader header
+    if ((ret = bootloader_read_bootloader_header()) != ESP_OK) {
+        goto err;
+    }
+    // read chip revision and check if it's compatible to bootloader
+    if ((ret = bootloader_check_bootloader_validity()) != ESP_OK) {
+        goto err;
+    }
+    // initialize spi flash
+    if ((ret = bootloader_init_spi_flash()) != ESP_OK) {
+        goto err;
+    }
+    // check whether a WDT reset happend
+    bootloader_check_wdt_reset();
+    // config WDT
+    bootloader_config_wdt();
+    // enable RNG early entropy source
+    bootloader_enable_random();
+err:
+    return ret;
+}

--- a/components/bootloader_support/src/esp32/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32/bootloader_sha.c
@@ -1,0 +1,127 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "bootloader_sha.h"
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/param.h>
+
+#include "esp32/rom/sha.h"
+#include "soc/dport_reg.h"
+#include "soc/hwcrypto_periph.h"
+
+static uint32_t words_hashed;
+
+// Words per SHA256 block
+static const size_t BLOCK_WORDS = (64 / sizeof(uint32_t));
+// Words in final SHA256 digest
+static const size_t DIGEST_WORDS = (32 / sizeof(uint32_t));
+
+bootloader_sha256_handle_t bootloader_sha256_start(void)
+{
+    // Enable SHA hardware
+    ets_sha_enable();
+    words_hashed = 0;
+    return (bootloader_sha256_handle_t)&words_hashed; // Meaningless non-NULL value
+}
+
+void bootloader_sha256_data(bootloader_sha256_handle_t handle, const void *data, size_t data_len)
+{
+    assert(handle != NULL);
+    assert(data_len % 4 == 0);
+
+    const uint32_t *w = (const uint32_t *)data;
+    size_t word_len = data_len / 4;
+    uint32_t *sha_text_reg = (uint32_t *)(SHA_TEXT_BASE);
+
+    //ets_printf("word_len %d so far %d\n", word_len, words_hashed);
+    while (word_len > 0) {
+        size_t block_count = words_hashed % BLOCK_WORDS;
+        size_t copy_words = (BLOCK_WORDS - block_count);
+
+        copy_words = MIN(word_len, copy_words);
+
+        // Wait for SHA engine idle
+        while (REG_READ(SHA_256_BUSY_REG) != 0) { }
+
+        // Copy to memory block
+        //ets_printf("block_count %d copy_words %d\n", block_count, copy_words);
+        for (int i = 0; i < copy_words; i++) {
+            sha_text_reg[block_count + i] = __builtin_bswap32(w[i]);
+        }
+        asm volatile ("memw");
+
+        // Update counters
+        words_hashed += copy_words;
+        block_count += copy_words;
+        word_len -= copy_words;
+        w += copy_words;
+
+        // If we loaded a full block, run the SHA engine
+        if (block_count == BLOCK_WORDS) {
+            //ets_printf("running engine @ count %d\n", words_hashed);
+            if (words_hashed == BLOCK_WORDS) {
+                REG_WRITE(SHA_256_START_REG, 1);
+            } else {
+                REG_WRITE(SHA_256_CONTINUE_REG, 1);
+            }
+            block_count = 0;
+        }
+    }
+}
+
+void bootloader_sha256_finish(bootloader_sha256_handle_t handle, uint8_t *digest)
+{
+    assert(handle != NULL);
+
+    if (digest == NULL) {
+        return; // We'd free resources here, but there are none to free
+    }
+
+    uint32_t data_words = words_hashed;
+
+    // Pad to a 55 byte long block loaded in the engine
+    // (leaving 1 byte 0x80 plus variable padding plus 8 bytes of length,
+    // to fill a 64 byte block.)
+    int block_bytes = (words_hashed % BLOCK_WORDS) * 4;
+    int pad_bytes = 55 - block_bytes;
+    if (pad_bytes < 0) {
+        pad_bytes += 64;
+    }
+    static const uint8_t padding[64] = { 0x80, 0, };
+
+    pad_bytes += 5; // 1 byte for 0x80 plus first 4 bytes of the 64-bit length
+    assert(pad_bytes % 4 == 0); // should be, as (block_bytes % 4 == 0)
+
+    bootloader_sha256_data(handle, padding, pad_bytes);
+
+    assert(words_hashed % BLOCK_WORDS == 60 / 4); // 32-bits left in block
+
+    // Calculate 32-bit length for final 32 bits of data
+    uint32_t bit_count = __builtin_bswap32( data_words * 32 );
+    bootloader_sha256_data(handle, &bit_count, sizeof(bit_count));
+
+    assert(words_hashed % BLOCK_WORDS == 0);
+
+    while (REG_READ(SHA_256_BUSY_REG) == 1) { }
+    REG_WRITE(SHA_256_LOAD_REG, 1);
+    while (REG_READ(SHA_256_BUSY_REG) == 1) { }
+
+    uint32_t *digest_words = (uint32_t *)digest;
+    uint32_t *sha_text_reg = (uint32_t *)(SHA_TEXT_BASE);
+    for (int i = 0; i < DIGEST_WORDS; i++) {
+        digest_words[i] = __builtin_bswap32(sha_text_reg[i]);
+    }
+    asm volatile ("memw");
+}

--- a/components/bootloader_support/src/esp32/flash_encrypt.c
+++ b/components/bootloader_support/src/esp32/flash_encrypt.c
@@ -1,0 +1,384 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <strings.h>
+
+#include "bootloader_flash.h"
+#include "esp_image_format.h"
+#include "esp_flash_encrypt.h"
+#include "esp_flash_partitions.h"
+#include "esp_secure_boot.h"
+#include "esp_efuse.h"
+#include "esp_log.h"
+#include "esp32/rom/secure_boot.h"
+#include "hal/wdt_hal.h"
+
+#include "esp32/rom/cache.h"
+#include "esp32/rom/spi_flash.h"   /* TODO: Remove this */
+
+/* This file implements FLASH ENCRYPTION related APIs to perform
+ * various operations such as programming necessary flash encryption
+ * eFuses, detect whether flash encryption is enabled (by reading eFuse)
+ * and if required encrypt the partitions in flash memory
+ */
+
+static const char *TAG = "flash_encrypt";
+
+/* Static functions for stages of flash encryption */
+static esp_err_t initialise_flash_encryption(void);
+static esp_err_t encrypt_flash_contents(uint32_t flash_crypt_cnt, bool flash_crypt_wr_dis) __attribute__((unused));
+static esp_err_t encrypt_bootloader(void);
+static esp_err_t encrypt_and_load_partition_table(esp_partition_info_t *partition_table, int *num_partitions);
+static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partition);
+
+esp_err_t esp_flash_encrypt_check_and_update(void)
+{
+    uint32_t efuse_blk0 = REG_READ(EFUSE_BLK0_RDATA0_REG);
+    ESP_LOGV(TAG, "efuse_blk0 raw value %08x", efuse_blk0);
+    uint32_t flash_crypt_cnt = (efuse_blk0 & EFUSE_RD_FLASH_CRYPT_CNT_M) >> EFUSE_RD_FLASH_CRYPT_CNT_S;
+    bool flash_crypt_wr_dis = efuse_blk0 & EFUSE_WR_DIS_FLASH_CRYPT_CNT;
+    ESP_LOGV(TAG, "efuse FLASH_CRYPT_CNT 0x%x WR_DIS_FLASH_CRYPT_CNT 0x%x", flash_crypt_cnt, flash_crypt_wr_dis);
+
+    if (__builtin_parity(flash_crypt_cnt) == 1) {
+        /* Flash is already encrypted */
+        int left = (7 - __builtin_popcount(flash_crypt_cnt)) / 2;
+        if (flash_crypt_wr_dis) {
+            left = 0; /* can't update FLASH_CRYPT_CNT, no more flashes */
+        }
+        ESP_LOGI(TAG, "flash encryption is enabled (%d plaintext flashes left)", left);
+        return ESP_OK;
+    }
+    else {
+#ifndef CONFIG_SECURE_FLASH_REQUIRE_ALREADY_ENABLED
+        /* Flash is not encrypted, so encrypt it! */
+        return encrypt_flash_contents(flash_crypt_cnt, flash_crypt_wr_dis);
+#else
+        ESP_LOGE(TAG, "flash encryption is not enabled, and SECURE_FLASH_REQUIRE_ALREADY_ENABLED "
+                      "is set, refusing to boot.");
+        return ESP_ERR_INVALID_STATE;
+#endif // CONFIG_SECURE_FLASH_REQUIRE_ALREADY_ENABLED
+    }
+}
+
+static esp_err_t initialise_flash_encryption(void)
+{
+    uint32_t new_wdata0 = 0;
+    uint32_t new_wdata5 = 0;
+    uint32_t new_wdata6 = 0;
+
+    uint32_t coding_scheme = REG_GET_FIELD(EFUSE_BLK0_RDATA6_REG, EFUSE_CODING_SCHEME);
+    if (coding_scheme != EFUSE_CODING_SCHEME_VAL_NONE && coding_scheme != EFUSE_CODING_SCHEME_VAL_34) {
+        ESP_LOGE(TAG, "Unknown/unsupported CODING_SCHEME value 0x%x", coding_scheme);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /* Before first flash encryption pass, need to initialise key & crypto config */
+
+    /* Generate key */
+    uint32_t dis_reg = REG_READ(EFUSE_BLK0_RDATA0_REG);
+    bool efuse_key_read_protected = dis_reg & EFUSE_RD_DIS_BLK1;
+    bool efuse_key_write_protected = dis_reg & EFUSE_WR_DIS_BLK1;
+    if (efuse_key_read_protected == false
+        && efuse_key_write_protected == false
+        && REG_READ(EFUSE_BLK1_RDATA0_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA1_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA2_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA3_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA4_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA5_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA6_REG) == 0
+        && REG_READ(EFUSE_BLK1_RDATA7_REG) == 0) {
+        ESP_LOGI(TAG, "Generating new flash encryption key...");
+        esp_efuse_write_random_key(EFUSE_BLK1_WDATA0_REG);
+        // defer efuse programming step to the end
+
+        ESP_LOGI(TAG, "Read & write protecting new key...");
+        new_wdata0 |= EFUSE_WR_DIS_BLK1 | EFUSE_RD_DIS_BLK1;
+    } else {
+
+        if(!(efuse_key_read_protected && efuse_key_write_protected)) {
+            ESP_LOGE(TAG, "Flash encryption key has to be either unset or both read and write protected");
+            return ESP_ERR_INVALID_STATE;
+        }
+        ESP_LOGW(TAG, "Using pre-loaded flash encryption key in EFUSE block 1");
+    }
+    /* CRYPT_CONFIG determines which bits of the AES block key are XORed
+       with bits from the flash address, to provide the key tweak.
+
+       CRYPT_CONFIG == 0 is effectively AES ECB mode (NOT SUPPORTED)
+
+       For now this is hardcoded to XOR all 256 bits of the key.
+
+       If you need to override it, you can pre-burn this efuse to the
+       desired value and then write-protect it, in which case this
+       operation does nothing. Please note this is not recommended!
+    */
+    ESP_LOGI(TAG, "Setting CRYPT_CONFIG efuse to 0xF");
+    new_wdata5 |= EFUSE_FLASH_CRYPT_CONFIG_M;
+
+#ifndef CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_ENC
+    ESP_LOGI(TAG, "Disable UART bootloader encryption...");
+    new_wdata6 |= EFUSE_DISABLE_DL_ENCRYPT;
+#else
+    ESP_LOGW(TAG, "Not disabling UART bootloader encryption");
+#endif
+
+#ifndef CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_DEC
+    ESP_LOGI(TAG, "Disable UART bootloader decryption...");
+    new_wdata6 |= EFUSE_DISABLE_DL_DECRYPT;
+#else
+    ESP_LOGW(TAG, "Not disabling UART bootloader decryption - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_CACHE
+    ESP_LOGI(TAG, "Disable UART bootloader MMU cache...");
+    new_wdata6 |= EFUSE_DISABLE_DL_CACHE;
+#else
+    ESP_LOGW(TAG, "Not disabling UART bootloader MMU cache - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_JTAG
+    ESP_LOGI(TAG, "Disable JTAG...");
+    new_wdata6 |= EFUSE_RD_DISABLE_JTAG;
+#else
+    ESP_LOGW(TAG, "Not disabling JTAG - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_ROM_BASIC
+    ESP_LOGI(TAG, "Disable ROM BASIC interpreter fallback...");
+    new_wdata6 |= EFUSE_RD_CONSOLE_DEBUG_DISABLE;
+#else
+    ESP_LOGW(TAG, "Not disabling ROM BASIC fallback - SECURITY COMPROMISED");
+#endif
+
+#if defined(CONFIG_SECURE_BOOT_V2_ENABLED) && !defined(CONFIG_SECURE_BOOT_V2_ALLOW_EFUSE_RD_DIS)
+    // This bit is set when enabling Secure Boot V2, but we can't enable it until this later point in the first boot
+    // otherwise the Flash Encryption key cannot be read protected
+    new_wdata0 |= EFUSE_WR_DIS_RD_DIS;
+#endif
+
+    REG_WRITE(EFUSE_BLK0_WDATA0_REG, new_wdata0);
+    REG_WRITE(EFUSE_BLK0_WDATA5_REG, new_wdata5);
+    REG_WRITE(EFUSE_BLK0_WDATA6_REG, new_wdata6);
+    esp_efuse_burn_new_values();
+
+    return ESP_OK;
+}
+
+/* Encrypt all flash data that should be encrypted */
+static esp_err_t encrypt_flash_contents(uint32_t flash_crypt_cnt, bool flash_crypt_wr_dis)
+{
+    esp_err_t err;
+    esp_partition_info_t partition_table[ESP_PARTITION_TABLE_MAX_ENTRIES];
+    int num_partitions;
+
+    /* If the last flash_crypt_cnt bit is burned or write-disabled, the
+       device can't re-encrypt itself. */
+    if (flash_crypt_wr_dis || flash_crypt_cnt == 0xFF) {
+        ESP_LOGE(TAG, "Cannot re-encrypt data (FLASH_CRYPT_CNT 0x%02x write disabled %d", flash_crypt_cnt, flash_crypt_wr_dis);
+        return ESP_FAIL;
+    }
+
+    if (flash_crypt_cnt == 0) {
+        /* Very first flash of encrypted data: generate keys, etc. */
+        err = initialise_flash_encryption();
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    err = encrypt_bootloader();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = encrypt_and_load_partition_table(partition_table, &num_partitions);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    /* Now iterate the just-loaded partition table, looking for entries to encrypt
+     */
+
+    /* Go through each partition and encrypt if necessary */
+    for (int i = 0; i < num_partitions; i++) {
+        err = encrypt_partition(i, &partition_table[i]);
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    ESP_LOGD(TAG, "All flash regions checked for encryption pass");
+
+    uint32_t new_flash_crypt_cnt;
+#ifdef CONFIG_SECURE_FLASH_ENCRYPTION_MODE_RELEASE
+    // Go straight to max, permanently enabled
+    ESP_LOGI(TAG, "Setting FLASH_CRYPT_CNT for permanent encryption");
+    new_flash_crypt_cnt = EFUSE_FLASH_CRYPT_CNT;
+#else
+    /* Set least significant 0-bit in flash_crypt_cnt */
+    int ffs_inv = __builtin_ffs((~flash_crypt_cnt) & EFUSE_RD_FLASH_CRYPT_CNT);
+    /* ffs_inv shouldn't be zero, as zero implies flash_crypt_cnt == EFUSE_RD_FLASH_CRYPT_CNT (0x7F) */
+    new_flash_crypt_cnt = flash_crypt_cnt + (1 << (ffs_inv - 1));
+#endif
+    ESP_LOGD(TAG, "FLASH_CRYPT_CNT 0x%x -> 0x%x", flash_crypt_cnt, new_flash_crypt_cnt);
+    uint32_t wdata0_reg = ((new_flash_crypt_cnt & EFUSE_FLASH_CRYPT_CNT) << EFUSE_FLASH_CRYPT_CNT_S);
+
+    REG_WRITE(EFUSE_BLK0_WDATA0_REG, wdata0_reg);
+    esp_efuse_burn_new_values();
+
+    ESP_LOGI(TAG, "Flash encryption completed");
+
+    return ESP_OK;
+}
+
+static esp_err_t encrypt_bootloader(void)
+{
+    esp_err_t err;
+    uint32_t image_length;
+    /* Check for plaintext bootloader (verification will fail if it's already encrypted) */
+    if (esp_image_verify_bootloader(&image_length) == ESP_OK) {
+        ESP_LOGD(TAG, "bootloader is plaintext. Encrypting...");
+
+#if CONFIG_SECURE_BOOT_V2_ENABLED
+        /* The image length obtained from esp_image_verify_bootloader includes the sector boundary padding and the signature block lengths */
+        if (ESP_BOOTLOADER_OFFSET + image_length > ESP_PARTITION_TABLE_OFFSET) {
+            ESP_LOGE(TAG, "Bootloader is too large to fit Secure Boot V2 signature sector and partition table (configured offset 0x%x)", ESP_PARTITION_TABLE_OFFSET);
+            return ESP_ERR_INVALID_STATE;
+        }
+#endif // CONFIG_SECURE_BOOT_V2_ENABLED
+
+        err = esp_flash_encrypt_region(ESP_BOOTLOADER_OFFSET, image_length);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt bootloader in place: 0x%x", err);
+            return err;
+        }
+
+#ifdef CONFIG_SECURE_BOOT_V1_ENABLED
+        /* If secure boot is enabled and bootloader was plaintext, also
+         * need to encrypt secure boot IV+digest.
+         */
+        ESP_LOGD(TAG, "Encrypting secure bootloader IV & digest...");
+        err = esp_flash_encrypt_region(FLASH_OFFS_SECURE_BOOT_IV_DIGEST,
+                                       FLASH_SECTOR_SIZE);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt bootloader IV & digest in place: 0x%x", err);
+            return err;
+        }
+#endif
+    }
+    else {
+        ESP_LOGW(TAG, "no valid bootloader was found");
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t encrypt_and_load_partition_table(esp_partition_info_t *partition_table, int *num_partitions)
+{
+    esp_err_t err;
+    /* Check for plaintext partition table */
+    err = bootloader_flash_read(ESP_PARTITION_TABLE_OFFSET, partition_table, ESP_PARTITION_TABLE_MAX_LEN, false);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read partition table data");
+        return err;
+    }
+    if (esp_partition_table_verify(partition_table, false, num_partitions) == ESP_OK) {
+        ESP_LOGD(TAG, "partition table is plaintext. Encrypting...");
+        esp_err_t err = esp_flash_encrypt_region(ESP_PARTITION_TABLE_OFFSET,
+                                                 FLASH_SECTOR_SIZE);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt partition table in place. %x", err);
+            return err;
+        }
+    }
+    else {
+        ESP_LOGE(TAG, "Failed to read partition table data - not plaintext?");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Valid partition table loded */
+    return ESP_OK;
+}
+
+
+static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partition)
+{
+    esp_err_t err;
+    bool should_encrypt = (partition->flags & PART_FLAG_ENCRYPTED);
+
+    if (partition->type == PART_TYPE_APP) {
+      /* check if the partition holds a valid unencrypted app */
+      esp_image_metadata_t data_ignored;
+      err = esp_image_verify(ESP_IMAGE_VERIFY,
+                           &partition->pos,
+                           &data_ignored);
+      should_encrypt = (err == ESP_OK);
+    } else if ((partition->type == PART_TYPE_DATA && partition->subtype == PART_SUBTYPE_DATA_OTA)
+                || (partition->type == PART_TYPE_DATA && partition->subtype == PART_SUBTYPE_DATA_NVS_KEYS)) {
+        /* check if we have ota data partition and the partition should be encrypted unconditionally */
+        should_encrypt = true;
+    }
+
+    if (!should_encrypt) {
+        return ESP_OK;
+    }
+    else {
+        /* should_encrypt */
+        ESP_LOGI(TAG, "Encrypting partition %d at offset 0x%x...", index, partition->pos.offset);
+
+        err = esp_flash_encrypt_region(partition->pos.offset, partition->pos.size);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt partition %d", index);
+        }
+        return err;
+    }
+}
+
+
+esp_err_t esp_flash_encrypt_region(uint32_t src_addr, size_t data_length)
+{
+    esp_err_t err;
+    uint32_t buf[FLASH_SECTOR_SIZE / sizeof(uint32_t)];
+
+    if (src_addr % FLASH_SECTOR_SIZE != 0) {
+        ESP_LOGE(TAG, "esp_flash_encrypt_region bad src_addr 0x%x",src_addr);
+        return ESP_FAIL;
+    }
+
+    wdt_hal_context_t rtc_wdt_ctx = {.inst = WDT_RWDT, .rwdt_dev = &RTCCNTL};
+    for (size_t i = 0; i < data_length; i += FLASH_SECTOR_SIZE) {
+        wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+        wdt_hal_feed(&rtc_wdt_ctx);
+        wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+        uint32_t sec_start = i + src_addr;
+        err = bootloader_flash_read(sec_start, buf, FLASH_SECTOR_SIZE, false);
+        if (err != ESP_OK) {
+            goto flash_failed;
+        }
+        err = bootloader_flash_erase_sector(sec_start / FLASH_SECTOR_SIZE);
+        if (err != ESP_OK) {
+            goto flash_failed;
+        }
+        err = bootloader_flash_write(sec_start, buf, FLASH_SECTOR_SIZE, true);
+        if (err != ESP_OK) {
+            goto flash_failed;
+        }
+    }
+    return ESP_OK;
+
+ flash_failed:
+    ESP_LOGE(TAG, "flash operation failed: 0x%x", err);
+    return err;
+}

--- a/components/bootloader_support/src/esp32/secure_boot.c
+++ b/components/bootloader_support/src/esp32/secure_boot.c
@@ -1,0 +1,447 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+
+#include "esp_attr.h"
+#include "esp_types.h"
+#include "esp_log.h"
+
+#include "esp32/rom/cache.h"
+#include "esp32/rom/ets_sys.h"
+#include "esp32/rom/crc.h"
+
+#include "soc/efuse_periph.h"
+#include "soc/rtc_periph.h"
+#include "bootloader_sha.h"
+#include "bootloader_utility.h"
+
+#include "sdkconfig.h"
+
+#include "bootloader_flash.h"
+#include "bootloader_random.h"
+#include "esp_image_format.h"
+#include "esp_secure_boot.h"
+#include "esp_flash_encrypt.h"
+#include "esp_efuse.h"
+
+/* The following API implementations are used only when called
+ * from the bootloader code.
+ */
+
+#ifdef CONFIG_SECURE_BOOT_V1_ENABLED
+static const char *TAG = "secure_boot_v1";
+/**
+ *  @function :     secure_boot_generate
+ *  @description:   generate boot digest (aka "abstract") & iv
+ *
+ *  @inputs:        image_len - length of image to calculate digest for
+ */
+static bool secure_boot_generate(uint32_t image_len){
+    esp_err_t err;
+    esp_secure_boot_iv_digest_t digest;
+    const uint32_t *image;
+
+    /* hardware secure boot engine only takes full blocks, so round up the
+       image length. The additional data should all be 0xFF (or the appended SHA, if it falls in the same block).
+    */
+    if (image_len % sizeof(digest.iv) != 0) {
+        image_len = (image_len / sizeof(digest.iv) + 1) * sizeof(digest.iv);
+    }
+    ets_secure_boot_start();
+    ets_secure_boot_rd_iv((uint32_t *)digest.iv);
+    ets_secure_boot_hash(NULL);
+    /* iv stored in sec 0 */
+    err = bootloader_flash_erase_sector(0);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "SPI erase failed: 0x%x", err);
+        return false;
+    }
+
+    /* generate digest from image contents */
+    image = bootloader_mmap(ESP_BOOTLOADER_OFFSET, image_len);
+    if (!image) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x1000, 0x%x) failed", image_len);
+        return false;
+    }
+    for (int i = 0; i < image_len; i+= sizeof(digest.iv)) {
+        ets_secure_boot_hash(&image[i/sizeof(uint32_t)]);
+    }
+    bootloader_munmap(image);
+
+    ets_secure_boot_obtain();
+    ets_secure_boot_rd_abstract((uint32_t *)digest.digest);
+    ets_secure_boot_finish();
+
+    ESP_LOGD(TAG, "write iv+digest to flash");
+    err = bootloader_flash_write(FLASH_OFFS_SECURE_BOOT_IV_DIGEST, &digest,
+                           sizeof(digest), esp_flash_encryption_enabled());
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "SPI write failed: 0x%x", err);
+        return false;
+    }
+    Cache_Read_Enable(0);
+    return true;
+}
+
+esp_err_t esp_secure_boot_generate_digest(void)
+{
+    esp_err_t err;
+    if (esp_secure_boot_enabled()) {
+        ESP_LOGI(TAG, "bootloader secure boot is already enabled."
+                      " No need to generate digest. continuing..");
+        return ESP_OK;
+    }
+
+    uint32_t coding_scheme = REG_GET_FIELD(EFUSE_BLK0_RDATA6_REG, EFUSE_CODING_SCHEME);
+    if (coding_scheme != EFUSE_CODING_SCHEME_VAL_NONE && coding_scheme != EFUSE_CODING_SCHEME_VAL_34) {
+        ESP_LOGE(TAG, "Unknown/unsupported CODING_SCHEME value 0x%x", coding_scheme);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /* Verify the bootloader */
+    esp_image_metadata_t bootloader_data = { 0 };
+    err = esp_image_verify_bootloader_data(&bootloader_data);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "bootloader image appears invalid! error %d", err);
+        return err;
+    }
+
+    /* Generate secure boot key and keep in EFUSE */
+    uint32_t dis_reg = REG_READ(EFUSE_BLK0_RDATA0_REG);
+    bool efuse_key_read_protected = dis_reg & EFUSE_RD_DIS_BLK2;
+    bool efuse_key_write_protected = dis_reg & EFUSE_WR_DIS_BLK2;
+    if (efuse_key_read_protected == false
+        && efuse_key_write_protected == false
+        && REG_READ(EFUSE_BLK2_RDATA0_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA1_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA2_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA3_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA4_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA5_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA6_REG) == 0
+        && REG_READ(EFUSE_BLK2_RDATA7_REG) == 0) {
+        ESP_LOGI(TAG, "Generating new secure boot key...");
+        esp_efuse_write_random_key(EFUSE_BLK2_WDATA0_REG);
+        esp_efuse_burn_new_values();
+    } else {
+        ESP_LOGW(TAG, "Using pre-loaded secure boot key in EFUSE block 2");
+    }
+
+    /* Generate secure boot digest using programmed key in EFUSE */
+    ESP_LOGI(TAG, "Generating secure boot digest...");
+    uint32_t image_len = bootloader_data.image_len;
+    if(bootloader_data.image.hash_appended) {
+        /* Secure boot digest doesn't cover the hash */
+        image_len -= ESP_IMAGE_HASH_LEN;
+    }
+    if (false == secure_boot_generate(image_len)){
+        ESP_LOGE(TAG, "secure boot generation failed");
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "Digest generation complete.");
+
+    return ESP_OK;
+}
+
+esp_err_t esp_secure_boot_permanently_enable(void)
+{
+    uint32_t new_wdata0 = 0;
+    uint32_t new_wdata6 = 0;
+
+    if (esp_secure_boot_enabled()) {
+        ESP_LOGI(TAG, "bootloader secure boot is already enabled, continuing..");
+        return ESP_OK;
+    }
+
+    uint32_t dis_reg = REG_READ(EFUSE_BLK0_RDATA0_REG);
+    bool efuse_key_read_protected = dis_reg & EFUSE_RD_DIS_BLK2;
+    bool efuse_key_write_protected = dis_reg & EFUSE_WR_DIS_BLK2;
+    if (efuse_key_read_protected == false
+        && efuse_key_write_protected == false) {
+        ESP_LOGI(TAG, "Read & write protecting new key...");
+        new_wdata0 = EFUSE_WR_DIS_BLK2 | EFUSE_RD_DIS_BLK2;
+        efuse_key_read_protected = true;
+        efuse_key_write_protected = true;
+    }
+
+    if (!efuse_key_read_protected) {
+        ESP_LOGE(TAG, "Pre-loaded key is not read protected. Refusing to blow secure boot efuse.");
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!efuse_key_write_protected) {
+        ESP_LOGE(TAG, "Pre-loaded key is not write protected. Refusing to blow secure boot efuse.");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "blowing secure boot efuse...");
+    ESP_LOGD(TAG, "before updating, EFUSE_BLK0_RDATA6 %x", REG_READ(EFUSE_BLK0_RDATA6_REG));
+
+    new_wdata6 |= EFUSE_RD_ABS_DONE_0;
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_JTAG
+    ESP_LOGI(TAG, "Disable JTAG...");
+    new_wdata6 |= EFUSE_RD_DISABLE_JTAG;
+#else
+    ESP_LOGW(TAG, "Not disabling JTAG - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_ROM_BASIC
+    ESP_LOGI(TAG, "Disable ROM BASIC interpreter fallback...");
+    new_wdata6 |= EFUSE_RD_CONSOLE_DEBUG_DISABLE;
+#else
+    ESP_LOGW(TAG, "Not disabling ROM BASIC fallback - SECURITY COMPROMISED");
+#endif
+
+    REG_WRITE(EFUSE_BLK0_WDATA0_REG, new_wdata0);
+    REG_WRITE(EFUSE_BLK0_WDATA6_REG, new_wdata6);
+    esp_efuse_burn_new_values();
+    uint32_t after = REG_READ(EFUSE_BLK0_RDATA6_REG);
+    ESP_LOGD(TAG, "after updating, EFUSE_BLK0_RDATA6 %x", after);
+    if (after & EFUSE_RD_ABS_DONE_0) {
+        ESP_LOGI(TAG, "secure boot is now enabled for bootloader image");
+        return ESP_OK;
+    } else {
+        ESP_LOGE(TAG, "secure boot not enabled for bootloader image, EFUSE_RD_ABS_DONE_0 is probably write protected!");
+        return ESP_ERR_INVALID_STATE;
+    }
+}
+#elif CONFIG_SECURE_BOOT_V2_ENABLED
+
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+static const char *TAG = "secure_boot_v2";
+
+#define SIG_BLOCK_MAGIC_BYTE 0xe7
+#define CRC_SIGN_BLOCK_LEN 1196
+#define SIG_BLOCK_PADDING 4096
+
+#define DIGEST_LEN 32
+
+static esp_err_t validate_signature_block(const ets_secure_boot_signature_t *sig_block, uint8_t *digest)
+{
+    uint32_t crc = crc32_le(0, (uint8_t *)sig_block, CRC_SIGN_BLOCK_LEN);
+    if (sig_block->block[0].magic_byte == SIG_BLOCK_MAGIC_BYTE && sig_block->block[0].block_crc == crc && !memcmp(digest, sig_block->block[0].image_digest, DIGEST_LEN)) {
+        ESP_LOGI(TAG, "valid signature block found");
+        return ESP_OK;
+    }
+    return ESP_FAIL;
+}
+
+static esp_err_t secure_boot_v2_digest_generate(uint32_t flash_offset, uint32_t flash_size, uint8_t *public_key_digest)
+{
+    esp_err_t ret = ESP_FAIL;
+
+    uint8_t image_digest[DIGEST_LEN] = {0};
+    size_t sig_block_addr = flash_offset + ALIGN_UP(flash_size, FLASH_SECTOR_SIZE);
+    ret = bootloader_sha256_flash_contents(flash_offset, sig_block_addr - flash_offset, image_digest);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "error generating image digest, %d", ret);
+        return ret;
+    }
+
+    ESP_LOGD(TAG, "reading signature block");
+    const ets_secure_boot_signature_t *sig_block = bootloader_mmap(sig_block_addr, sizeof(ets_secure_boot_signature_t));
+    if (sig_block == NULL) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", sig_block_addr, sizeof(ets_secure_boot_signature_t));
+        return ret;
+    }
+
+    /* Validating Signature block */
+    ret = validate_signature_block(sig_block, image_digest);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "signature block (address 0x%x) validation failed %d", sig_block_addr, ret);
+        goto done;
+    }
+
+    /* Verifying Signature block */
+    uint8_t verified_digest[DIGEST_LEN] = {0};
+
+    /* Generating the SHA of the public key components in the signature block */
+    bootloader_sha256_handle_t sig_block_sha;
+    sig_block_sha = bootloader_sha256_start();
+    bootloader_sha256_data(sig_block_sha, &sig_block->block[0].key, sizeof(sig_block->block[0].key));
+    bootloader_sha256_finish(sig_block_sha, public_key_digest);
+
+    secure_boot_v2_status_t error;
+    error = ets_secure_boot_verify_signature(sig_block, image_digest, public_key_digest, verified_digest);
+    if (error != SBV2_SUCCESS) {
+        ESP_LOGE(TAG, "secure boot v2 verification failed %d", error);
+        ret = ESP_FAIL;
+        goto done;
+    } else {
+        ret = ESP_OK;
+    }
+
+done:
+    bootloader_munmap(sig_block);
+    return ret;
+}
+
+esp_err_t esp_secure_boot_v2_permanently_enable(const esp_image_metadata_t *image_data)
+{
+    uint32_t new_wdata0 = 0;
+    uint32_t new_wdata6 = 0;
+
+    ESP_LOGI(TAG, "enabling secure boot v2...");
+    esp_err_t ret;
+    if (esp_secure_boot_enabled()) {
+        ESP_LOGI(TAG, "secure boot v2 is already enabled. Continuing..");
+        return ESP_OK;
+    }
+
+    uint32_t coding_scheme = REG_GET_FIELD(EFUSE_BLK0_RDATA6_REG, EFUSE_CODING_SCHEME);
+    if (coding_scheme != EFUSE_CODING_SCHEME_VAL_NONE) {
+        ESP_LOGE(TAG, "No coding schemes are supported in secure boot v2.(Detected scheme: 0x%x)", coding_scheme);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /* Verify the bootloader */
+    esp_image_metadata_t bootloader_data = { 0 };
+    ret = esp_image_verify_bootloader_data(&bootloader_data);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "bootloader image appears invalid! error %d", ret);
+        return ret;
+    }
+
+    uint8_t boot_pub_key_digest[DIGEST_LEN];
+    uint32_t dis_reg = REG_READ(EFUSE_BLK0_RDATA0_REG);
+    bool efuse_key_read_protected = dis_reg & EFUSE_RD_DIS_BLK2;
+    bool efuse_key_write_protected = dis_reg & EFUSE_WR_DIS_BLK2;
+    uint32_t efuse_blk2_r0, efuse_blk2_r1, efuse_blk2_r2, efuse_blk2_r3, efuse_blk2_r4, efuse_blk2_r5, efuse_blk2_r6, efuse_blk2_r7;
+    efuse_blk2_r0 = REG_READ(EFUSE_BLK2_RDATA0_REG);
+    efuse_blk2_r1 = REG_READ(EFUSE_BLK2_RDATA1_REG);
+    efuse_blk2_r2 = REG_READ(EFUSE_BLK2_RDATA2_REG);
+    efuse_blk2_r3 = REG_READ(EFUSE_BLK2_RDATA3_REG);
+    efuse_blk2_r4 = REG_READ(EFUSE_BLK2_RDATA4_REG);
+    efuse_blk2_r5 = REG_READ(EFUSE_BLK2_RDATA5_REG);
+    efuse_blk2_r6 = REG_READ(EFUSE_BLK2_RDATA6_REG);
+    efuse_blk2_r7 = REG_READ(EFUSE_BLK2_RDATA7_REG);
+
+    if (efuse_key_read_protected == true) {
+        ESP_LOGE(TAG, "Secure Boot v2 digest(BLK2) read protected, aborting....");
+        return ESP_FAIL;
+    }
+
+    if (efuse_key_write_protected == false
+        && efuse_blk2_r0 == 0 && efuse_blk2_r1 == 0
+        && efuse_blk2_r2 == 0 && efuse_blk2_r3 == 0
+        && efuse_blk2_r4 == 0 && efuse_blk2_r5 == 0
+        && efuse_blk2_r6 == 0 && efuse_blk2_r7 == 0) {
+        /* Verifies the signature block appended to the image matches with the signature block of the app to be loaded */
+        ret = secure_boot_v2_digest_generate(bootloader_data.start_addr, bootloader_data.image_len - SIG_BLOCK_PADDING, boot_pub_key_digest);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Public key digest generation failed");
+            return ret;
+        }
+
+        ESP_LOGI(TAG, "Burning public key hash to efuse.");
+        uint32_t *boot_public_key_digest_ptr = (uint32_t *) boot_pub_key_digest;
+        for (int i = 0; i < 8 ; i++) {
+            REG_WRITE(EFUSE_BLK2_WDATA0_REG + 4 * i, boot_public_key_digest_ptr[i]);
+            ESP_LOGD(TAG, "EFUSE_BLKx_WDATA%d_REG = 0x%08x", i, boot_public_key_digest_ptr[i]);
+        }
+
+    } else {
+        uint32_t efuse_blk2_digest[8];
+        efuse_blk2_digest[0] = efuse_blk2_r0;
+        efuse_blk2_digest[1] = efuse_blk2_r1;
+        efuse_blk2_digest[2] = efuse_blk2_r2;
+        efuse_blk2_digest[3] = efuse_blk2_r3;
+        efuse_blk2_digest[4] = efuse_blk2_r4;
+        efuse_blk2_digest[5] = efuse_blk2_r5;
+        efuse_blk2_digest[6] = efuse_blk2_r6;
+        efuse_blk2_digest[7] = efuse_blk2_r7;
+        memcpy(boot_pub_key_digest, efuse_blk2_digest, DIGEST_LEN);
+        ESP_LOGW(TAG, "Using pre-loaded secure boot v2 public key digest in EFUSE block 2");
+    }
+
+    if (efuse_key_write_protected == false) {
+        ESP_LOGI(TAG, "Write protecting public key digest...");
+        new_wdata0 |= EFUSE_WR_DIS_BLK2; // delay burning until second half of this function
+        efuse_key_write_protected = true;
+    }
+
+    uint8_t app_pub_key_digest[DIGEST_LEN];
+    ret = secure_boot_v2_digest_generate(image_data->start_addr, image_data->image_len - SIG_BLOCK_PADDING, app_pub_key_digest);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Application signature block is invalid.");
+        return ret;
+    }
+
+    /* Confirming if the public key in the bootloader's signature block matches with the one in the application's signature block */
+    if (memcmp(boot_pub_key_digest, app_pub_key_digest, DIGEST_LEN) != 0) {
+        ESP_LOGE(TAG, "Application not signed with a valid private key.");
+        return ESP_FAIL;
+    }
+
+    if (efuse_key_read_protected) {
+        ESP_LOGE(TAG, "Efuse BLK2 (public key digest) is read protected. Refusing to blow secure boot efuse.");
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!efuse_key_write_protected) {
+        ESP_LOGE(TAG, "Efuse BLK2 (public key digest) is not write protected. Refusing to blow secure boot efuse.");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "blowing secure boot efuse...");
+    ESP_LOGD(TAG, "before updating, EFUSE_BLK0_RDATA6 %x", REG_READ(EFUSE_BLK0_RDATA6_REG));
+
+    new_wdata6 |= EFUSE_RD_ABS_DONE_1;
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_JTAG
+    ESP_LOGI(TAG, "Disable JTAG...");
+    new_wdata6 |= EFUSE_RD_DISABLE_JTAG;
+#else
+    ESP_LOGW(TAG, "Not disabling JTAG - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_ROM_BASIC
+    ESP_LOGI(TAG, "Disable ROM BASIC interpreter fallback...");
+    new_wdata6 |= EFUSE_RD_CONSOLE_DEBUG_DISABLE;
+#else
+    ESP_LOGW(TAG, "Not disabling ROM BASIC fallback - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_V2_ALLOW_EFUSE_RD_DIS
+    bool rd_dis_now = true;
+#ifdef CONFIG_SECURE_FLASH_ENC_ENABLED
+    /* If flash encryption is not enabled yet then don't read-disable efuses yet, do it later in the boot
+       when Flash Encryption is being enabled */
+    rd_dis_now = esp_flash_encryption_enabled();
+#endif
+    if (rd_dis_now) {
+        ESP_LOGI(TAG, "Prevent read disabling of additional efuses...");
+        new_wdata0 |= EFUSE_WR_DIS_RD_DIS;
+    }
+#else
+    ESP_LOGW(TAG, "Allowing read disabling of additional efuses - SECURITY COMPROMISED");
+#endif
+
+    REG_WRITE(EFUSE_BLK0_WDATA0_REG, new_wdata0);
+    REG_WRITE(EFUSE_BLK0_WDATA6_REG, new_wdata6);
+    esp_efuse_burn_new_values();
+    uint32_t after = REG_READ(EFUSE_BLK0_RDATA6_REG);
+    ESP_LOGD(TAG, "after updating, EFUSE_BLK0_RDATA0 0x%08x EFUSE_BLK0_RDATA6 0x%08x",
+             REG_READ(EFUSE_BLK0_RDATA0_REG), after);
+    if (after & EFUSE_RD_ABS_DONE_1) {
+        ESP_LOGI(TAG, "secure boot v2 is now enabled.");
+        return ESP_OK;
+    } else {
+        ESP_LOGE(TAG, " secure boot v2 not enabled, EFUSE_RD_ABS_DONE_1 is probably write protected!");
+        return ESP_ERR_INVALID_STATE;
+    }
+}
+
+#endif // CONFIG_SECURE_BOOT_V2_ENABLED

--- a/components/bootloader_support/src/esp32/secure_boot_signatures.c
+++ b/components/bootloader_support/src/esp32/secure_boot_signatures.c
@@ -1,0 +1,184 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+
+#include "bootloader_flash.h"
+#include "bootloader_sha.h"
+#include "bootloader_utility.h"
+#include "esp_log.h"
+#include "esp_image_format.h"
+#include "esp_secure_boot.h"
+#include "esp_spi_flash.h"
+#include "esp_fault.h"
+#include "esp32/rom/sha.h"
+#include "uECC_verify_antifault.h"
+
+#include <sys/param.h>
+#include <string.h>
+
+static const char *TAG = "secure_boot";
+#define DIGEST_LEN 32
+
+#ifdef CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
+extern const uint8_t signature_verification_key_start[] asm("_binary_signature_verification_key_bin_start");
+extern const uint8_t signature_verification_key_end[] asm("_binary_signature_verification_key_bin_end");
+
+#define SIGNATURE_VERIFICATION_KEYLEN 64
+
+esp_err_t esp_secure_boot_verify_signature(uint32_t src_addr, uint32_t length)
+{
+    uint8_t digest[DIGEST_LEN];
+    uint8_t verified_digest[DIGEST_LEN] = { 0 }; /* ignored in this function */
+    const esp_secure_boot_sig_block_t *sigblock;
+
+    ESP_LOGD(TAG, "verifying signature src_addr 0x%x length 0x%x", src_addr, length);
+
+    esp_err_t err = bootloader_sha256_flash_contents(src_addr, length, digest);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    // Map the signature block
+    sigblock = (const esp_secure_boot_sig_block_t *) bootloader_mmap(src_addr + length, sizeof(esp_secure_boot_sig_block_t));
+    if(!sigblock) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", src_addr + length, sizeof(esp_secure_boot_sig_block_t));
+        return ESP_FAIL;
+    }
+    // Verify the signature
+    err = esp_secure_boot_verify_ecdsa_signature_block(sigblock, digest, verified_digest);
+    // Unmap
+    bootloader_munmap(sigblock);
+
+    return err;
+}
+
+esp_err_t esp_secure_boot_verify_signature_block(const esp_secure_boot_sig_block_t *sig_block, const uint8_t *image_digest)
+{
+    uint8_t verified_digest[DIGEST_LEN] = { 0 };
+    return esp_secure_boot_verify_ecdsa_signature_block(sig_block, image_digest, verified_digest);
+}
+
+esp_err_t esp_secure_boot_verify_ecdsa_signature_block(const esp_secure_boot_sig_block_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest)
+{
+    ptrdiff_t keylen;
+
+    keylen = signature_verification_key_end - signature_verification_key_start;
+    if (keylen != SIGNATURE_VERIFICATION_KEYLEN) {
+        ESP_LOGE(TAG, "Embedded public verification key has wrong length %d", keylen);
+        return ESP_FAIL;
+    }
+
+    if (sig_block->version != 0) {
+        ESP_LOGE(TAG, "image has invalid signature version field 0x%08x", sig_block->version);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, "Verifying secure boot signature");
+
+    bool is_valid;
+    is_valid = uECC_verify_antifault(signature_verification_key_start,
+                           image_digest,
+                           DIGEST_LEN,
+                           sig_block->signature,
+                           uECC_secp256r1(),
+                           verified_digest);
+    ESP_LOGD(TAG, "Verification result %d", is_valid);
+
+    return is_valid ? ESP_OK : ESP_ERR_IMAGE_INVALID;
+}
+
+#elif CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
+esp_err_t esp_secure_boot_verify_signature(uint32_t src_addr, uint32_t length)
+{
+    uint8_t digest[DIGEST_LEN] = {0};
+    uint8_t verified_digest[DIGEST_LEN] = {0}; // ignored in this function
+    const uint8_t *data;
+
+    /* Padding to round off the input to the nearest 4k boundary */
+    int padded_length = ALIGN_UP(length, FLASH_SECTOR_SIZE);
+    ESP_LOGD(TAG, "verifying src_addr 0x%x length", src_addr, padded_length);
+
+    data = bootloader_mmap(src_addr, padded_length + sizeof(ets_secure_boot_signature_t));
+    if (data == NULL) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", src_addr, padded_length);
+        return ESP_FAIL;
+    }
+
+    /* Calculate digest of main image */
+    esp_err_t err = bootloader_sha256_flash_contents(src_addr, padded_length, digest);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Digest calculation failed 0x%x, 0x%x", src_addr, padded_length);
+        bootloader_munmap(data);
+        return err;
+    }
+
+    const ets_secure_boot_signature_t *sig_block = (const ets_secure_boot_signature_t *)(data + padded_length);
+    err = esp_secure_boot_verify_rsa_signature_block(sig_block, digest, verified_digest);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Secure Boot V2 verification failed.");
+    }
+
+    bootloader_munmap(data);
+    return err;
+}
+
+esp_err_t esp_secure_boot_verify_rsa_signature_block(const ets_secure_boot_signature_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest)
+{
+    secure_boot_v2_status_t r;
+    uint8_t efuse_trusted_digest[DIGEST_LEN] = {0}, sig_block_trusted_digest[DIGEST_LEN] = {0};
+
+    memcpy(efuse_trusted_digest, (uint8_t *)EFUSE_BLK2_RDATA0_REG, DIGEST_LEN); /* EFUSE_BLK2_RDATA0_REG - Stores the Secure Boot Public Key Digest */
+
+    if (!ets_use_secure_boot_v2()) {
+        ESP_LOGI(TAG, "Secure Boot eFuse bit(ABS_DONE_1) not yet programmed.");
+
+        /* Generating the SHA of the public key components in the signature block */
+        bootloader_sha256_handle_t sig_block_sha;
+        sig_block_sha = bootloader_sha256_start();
+        bootloader_sha256_data(sig_block_sha, &sig_block->block[0].key, sizeof(sig_block->block[0].key));
+        bootloader_sha256_finish(sig_block_sha, (unsigned char *)sig_block_trusted_digest);
+
+#if CONFIG_SECURE_BOOT_V2_ENABLED
+        if (memcmp(efuse_trusted_digest, sig_block_trusted_digest, DIGEST_LEN) != 0) {
+            /* Most likely explanation for this is that BLK2 is empty, and we're going to burn it
+               after we verify that the signature is valid. However, if BLK2 is not empty then we need to
+               fail here.
+            */
+            bool all_zeroes = true;
+            for (int i = 0; i < DIGEST_LEN; i++) {
+                all_zeroes = all_zeroes && (efuse_trusted_digest[i] == 0);
+            }
+            if (!all_zeroes) {
+                ESP_LOGE(TAG, "Different public key digest burned to eFuse BLK2");
+                return ESP_ERR_INVALID_STATE;
+            }
+        }
+
+        ESP_FAULT_ASSERT(!ets_use_secure_boot_v2());
+#endif
+
+        memcpy(efuse_trusted_digest, sig_block_trusted_digest, DIGEST_LEN);
+    }
+
+    ESP_LOGI(TAG, "Verifying with RSA-PSS...");
+    r = ets_secure_boot_verify_signature(sig_block, image_digest, efuse_trusted_digest, verified_digest);
+    if (r != SBV2_SUCCESS) {
+        ESP_LOGE(TAG, "Secure Boot V2 verification failed.");
+    }
+
+    return (r == SBV2_SUCCESS) ? ESP_OK : ESP_ERR_IMAGE_INVALID;
+}
+#endif

--- a/components/bootloader_support/src/esp32s2/bootloader_esp32s2.c
+++ b/components/bootloader_support/src/esp32s2/bootloader_esp32s2.c
@@ -1,0 +1,395 @@
+// Copyright 2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdint.h>
+#include "sdkconfig.h"
+#include "bootloader_common.h"
+#include "soc/efuse_reg.h"
+#include "soc/gpio_periph.h"
+#include "soc/gpio_sig_map.h"
+#include "soc/io_mux_reg.h"
+#include "esp32s2/rom/efuse.h"
+#include "esp32s2/rom/gpio.h"
+#include "esp32s2/rom/spi_flash.h"
+
+#include "bootloader_init.h"
+#include "bootloader_clock.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_mem.h"
+
+#include "esp32s2/rom/cache.h"
+#include "esp32s2/rom/ets_sys.h"
+#include "esp32s2/rom/spi_flash.h"
+#include "esp32s2/rom/rtc.h"
+#include "esp32s2/rom/uart.h"
+#include "esp_attr.h"
+#include "esp_log.h"
+#include "esp_image_format.h"
+#include "flash_qio_mode.h"
+#include "soc/assist_debug_reg.h"
+#include "soc/cpu.h"
+#include "soc/dport_reg.h"
+#include "soc/extmem_reg.h"
+#include "soc/rtc.h"
+#include "soc/spi_periph.h"
+#include <string.h>
+
+static const char *TAG = "boot.esp32s2";
+void bootloader_configure_spi_pins(int drv)
+{
+    const uint32_t spiconfig = ets_efuse_get_spiconfig();
+    uint8_t wp_pin = ets_efuse_get_wp_pad();
+    uint8_t clk_gpio_num = SPI_CLK_GPIO_NUM;
+    uint8_t q_gpio_num   = SPI_Q_GPIO_NUM;
+    uint8_t d_gpio_num   = SPI_D_GPIO_NUM;
+    uint8_t cs0_gpio_num = SPI_CS0_GPIO_NUM;
+    uint8_t hd_gpio_num  = SPI_HD_GPIO_NUM;
+    uint8_t wp_gpio_num  = SPI_WP_GPIO_NUM;
+    if (spiconfig == 0) {
+
+    } else {
+        clk_gpio_num = spiconfig         & 0x3f;
+        q_gpio_num = (spiconfig >> 6)    & 0x3f;
+        d_gpio_num = (spiconfig >> 12)   & 0x3f;
+        cs0_gpio_num = (spiconfig >> 18) & 0x3f;
+        hd_gpio_num = (spiconfig >> 24)  & 0x3f;
+        wp_gpio_num = wp_pin;
+    }
+    gpio_pad_set_drv(clk_gpio_num, drv);
+    gpio_pad_set_drv(q_gpio_num,   drv);
+    gpio_pad_set_drv(d_gpio_num,   drv);
+    gpio_pad_set_drv(cs0_gpio_num, drv);
+    if (hd_gpio_num <= MAX_PAD_GPIO_NUM) {
+        gpio_pad_set_drv(hd_gpio_num, drv);
+    }
+    if (wp_gpio_num <= MAX_PAD_GPIO_NUM) {
+        gpio_pad_set_drv(wp_gpio_num, drv);
+    }
+}
+
+static void bootloader_reset_mmu(void)
+{
+    //ToDo: save the autoload value
+    Cache_Suspend_ICache();
+    Cache_Invalidate_ICache_All();
+    Cache_MMU_Init();
+
+    /* normal ROM boot exits with DROM0 cache unmasked,
+    but serial bootloader exits with it masked. */
+    REG_CLR_BIT(EXTMEM_PRO_ICACHE_CTRL1_REG, EXTMEM_PRO_ICACHE_MASK_DROM0);
+}
+
+static void update_flash_config(const esp_image_header_t *bootloader_hdr)
+{
+    uint32_t size;
+    switch (bootloader_hdr->spi_size) {
+    case ESP_IMAGE_FLASH_SIZE_1MB:
+        size = 1;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_2MB:
+        size = 2;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_4MB:
+        size = 4;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_8MB:
+        size = 8;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_16MB:
+        size = 16;
+        break;
+    default:
+        size = 2;
+    }
+    uint32_t autoload = Cache_Suspend_ICache();
+    // Set flash chip size
+    esp_rom_spiflash_config_param(g_rom_flashchip.device_id, size * 0x100000, 0x10000, 0x1000, 0x100, 0xffff);
+    // TODO: set mode
+    // TODO: set frequency
+    Cache_Resume_ICache(autoload);
+}
+
+static void print_flash_info(const esp_image_header_t *bootloader_hdr)
+{
+    ESP_LOGD(TAG, "magic %02x", bootloader_hdr->magic);
+    ESP_LOGD(TAG, "segments %02x", bootloader_hdr->segment_count);
+    ESP_LOGD(TAG, "spi_mode %02x", bootloader_hdr->spi_mode);
+    ESP_LOGD(TAG, "spi_speed %02x", bootloader_hdr->spi_speed);
+    ESP_LOGD(TAG, "spi_size %02x", bootloader_hdr->spi_size);
+
+    const char *str;
+    switch (bootloader_hdr->spi_speed) {
+    case ESP_IMAGE_SPI_SPEED_40M:
+        str = "40MHz";
+        break;
+    case ESP_IMAGE_SPI_SPEED_26M:
+        str = "26.7MHz";
+        break;
+    case ESP_IMAGE_SPI_SPEED_20M:
+        str = "20MHz";
+        break;
+    case ESP_IMAGE_SPI_SPEED_80M:
+        str = "80MHz";
+        break;
+    default:
+        str = "20MHz";
+        break;
+    }
+    ESP_LOGI(TAG, "SPI Speed      : %s", str);
+
+    /* SPI mode could have been set to QIO during boot already,
+       so test the SPI registers not the flash header */
+    uint32_t spi_ctrl = REG_READ(SPI_MEM_CTRL_REG(0));
+    if (spi_ctrl & SPI_MEM_FREAD_QIO) {
+        str = "QIO";
+    } else if (spi_ctrl & SPI_MEM_FREAD_QUAD) {
+        str = "QOUT";
+    } else if (spi_ctrl & SPI_MEM_FREAD_DIO) {
+        str = "DIO";
+    } else if (spi_ctrl & SPI_MEM_FREAD_DUAL) {
+        str = "DOUT";
+    } else if (spi_ctrl & SPI_MEM_FASTRD_MODE) {
+        str = "FAST READ";
+    } else {
+        str = "SLOW READ";
+    }
+    ESP_LOGI(TAG, "SPI Mode       : %s", str);
+
+    switch (bootloader_hdr->spi_size) {
+    case ESP_IMAGE_FLASH_SIZE_1MB:
+        str = "1MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_2MB:
+        str = "2MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_4MB:
+        str = "4MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_8MB:
+        str = "8MB";
+        break;
+    case ESP_IMAGE_FLASH_SIZE_16MB:
+        str = "16MB";
+        break;
+    default:
+        str = "2MB";
+        break;
+    }
+    ESP_LOGI(TAG, "SPI Flash Size : %s", str);
+}
+
+static void IRAM_ATTR bootloader_init_flash_configure(void)
+{
+    bootloader_flash_dummy_config(&bootloader_image_hdr);
+    bootloader_flash_cs_timing_config();
+}
+
+static esp_err_t bootloader_init_spi_flash(void)
+{
+    bootloader_init_flash_configure();
+#ifndef CONFIG_SPI_FLASH_ROM_DRIVER_PATCH
+    const uint32_t spiconfig = ets_efuse_get_spiconfig();
+    if (spiconfig != EFUSE_SPICONFIG_SPI_DEFAULTS && spiconfig != EFUSE_SPICONFIG_HSPI_DEFAULTS) {
+        ESP_LOGE(TAG, "SPI flash pins are overridden. Enable CONFIG_SPI_FLASH_ROM_DRIVER_PATCH in menuconfig");
+        return ESP_FAIL;
+    }
+#endif
+
+    esp_rom_spiflash_unlock();
+
+#if CONFIG_ESPTOOLPY_FLASHMODE_QIO || CONFIG_ESPTOOLPY_FLASHMODE_QOUT
+    bootloader_enable_qio_mode();
+#endif
+
+    print_flash_info(&bootloader_image_hdr);
+    update_flash_config(&bootloader_image_hdr);
+    return ESP_OK;
+}
+
+static void bootloader_init_uart_console(void)
+{
+#if CONFIG_ESP_CONSOLE_UART_NONE
+    ets_install_putc1(NULL);
+    ets_install_putc2(NULL);
+#else // CONFIG_ESP_CONSOLE_UART_NONE
+    const int uart_num = CONFIG_ESP_CONSOLE_UART_NUM;
+
+    uartAttach(NULL);
+    ets_install_uart_printf();
+
+    // Wait for UART FIFO to be empty.
+    uart_tx_wait_idle(0);
+
+#if CONFIG_ESP_CONSOLE_UART_CUSTOM
+    // Some constants to make the following code less upper-case
+    const int uart_tx_gpio = CONFIG_ESP_CONSOLE_UART_TX_GPIO;
+    const int uart_rx_gpio = CONFIG_ESP_CONSOLE_UART_RX_GPIO;
+    // Switch to the new UART (this just changes UART number used for
+    // ets_printf in ROM code).
+    uart_tx_switch(uart_num);
+    // If console is attached to UART1 or if non-default pins are used,
+    // need to reconfigure pins using GPIO matrix
+    if (uart_num != 0 || uart_tx_gpio != 43 || uart_rx_gpio != 44) {
+        // Change pin mode UART to GPIO
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0RXD_U, FUNC_U0RXD_GPIO44);
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_GPIO43);
+        // Route GPIO signals to/from pins
+        // (arrays should be optimized away by the compiler)
+        const uint32_t tx_idx_list[2] = {U0TXD_OUT_IDX, U1TXD_OUT_IDX};
+        const uint32_t rx_idx_list[2] = {U0RXD_IN_IDX, U1RXD_IN_IDX};
+        const uint32_t uart_reset[2] = {DPORT_UART_RST, DPORT_UART1_RST};
+        const uint32_t tx_idx = tx_idx_list[uart_num];
+        const uint32_t rx_idx = rx_idx_list[uart_num];
+
+        PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[uart_rx_gpio]);
+        gpio_pad_pullup(uart_rx_gpio);
+
+        gpio_matrix_out(uart_tx_gpio, tx_idx, 0, 0);
+        gpio_matrix_in(uart_rx_gpio, rx_idx, 0);
+
+        DPORT_SET_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, uart_reset[uart_num]);
+        DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, uart_reset[uart_num]);
+    }
+#endif // CONFIG_ESP_CONSOLE_UART_CUSTOM
+
+    // Set configured UART console baud rate
+    const int uart_baud = CONFIG_ESP_CONSOLE_UART_BAUDRATE;
+    uart_div_modify(uart_num, (rtc_clk_apb_freq_get() << 4) / uart_baud);
+
+#endif // CONFIG_ESP_CONSOLE_UART_NONE
+}
+
+static void wdt_reset_cpu0_info_enable(void)
+{
+    DPORT_REG_SET_BIT(DPORT_PERI_CLK_EN_REG, DPORT_PERI_EN_ASSIST_DEBUG);
+    DPORT_REG_CLR_BIT(DPORT_PERI_RST_EN_REG, DPORT_PERI_EN_ASSIST_DEBUG);
+    REG_WRITE(ASSIST_DEBUG_PRO_PDEBUGENABLE, 1);
+    REG_WRITE(ASSIST_DEBUG_PRO_RCD_RECORDING, 1);
+}
+
+static void wdt_reset_info_dump(int cpu)
+{
+    uint32_t inst = 0, pid = 0, stat = 0, data = 0, pc = 0,
+             lsstat = 0, lsaddr = 0, lsdata = 0, dstat = 0;
+    const char *cpu_name = cpu ? "APP" : "PRO";
+
+    stat = 0xdeadbeef;
+    pid = 0;
+    inst = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGINST);
+    dstat = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGSTATUS);
+    data = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGDATA);
+    pc = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGPC);
+    lsstat = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGLS0STAT);
+    lsaddr = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGLS0ADDR);
+    lsdata = REG_READ(ASSIST_DEBUG_PRO_RCD_PDEBUGLS0DATA);
+
+    if (DPORT_RECORD_PDEBUGINST_SZ(inst) == 0 &&
+            DPORT_RECORD_PDEBUGSTATUS_BBCAUSE(dstat) == DPORT_RECORD_PDEBUGSTATUS_BBCAUSE_WAITI) {
+        ESP_LOGW(TAG, "WDT reset info: %s CPU PC=0x%x (waiti mode)", cpu_name, pc);
+    } else {
+        ESP_LOGW(TAG, "WDT reset info: %s CPU PC=0x%x", cpu_name, pc);
+    }
+    ESP_LOGD(TAG, "WDT reset info: %s CPU STATUS        0x%08x", cpu_name, stat);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PID           0x%08x", cpu_name, pid);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGINST    0x%08x", cpu_name, inst);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGSTATUS  0x%08x", cpu_name, dstat);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGDATA    0x%08x", cpu_name, data);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGPC      0x%08x", cpu_name, pc);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGLS0STAT 0x%08x", cpu_name, lsstat);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGLS0ADDR 0x%08x", cpu_name, lsaddr);
+    ESP_LOGD(TAG, "WDT reset info: %s CPU PDEBUGLS0DATA 0x%08x", cpu_name, lsdata);
+}
+
+static void bootloader_check_wdt_reset(void)
+{
+    int wdt_rst = 0;
+    RESET_REASON rst_reas[2];
+
+    rst_reas[0] = rtc_get_reset_reason(0);
+    if (rst_reas[0] == RTCWDT_SYS_RESET || rst_reas[0] == TG0WDT_SYS_RESET || rst_reas[0] == TG1WDT_SYS_RESET ||
+        rst_reas[0] == TG0WDT_CPU_RESET || rst_reas[0] == TG1WDT_CPU_RESET || rst_reas[0] == RTCWDT_CPU_RESET) {
+        ESP_LOGW(TAG, "PRO CPU has been reset by WDT.");
+        wdt_rst = 1;
+    }
+    if (wdt_rst) {
+        // if reset by WDT dump info from trace port
+        wdt_reset_info_dump(0);
+    }
+    wdt_reset_cpu0_info_enable();
+}
+
+void abort(void)
+{
+#if !CONFIG_ESP_SYSTEM_PANIC_SILENT_REBOOT
+    ets_printf("abort() was called at PC 0x%08x\r\n", (intptr_t)__builtin_return_address(0) - 3);
+#endif
+    if (esp_cpu_in_ocd_debug_mode()) {
+        __asm__("break 0,0");
+    }
+    while (1) {
+    }
+}
+
+static void bootloader_super_wdt_auto_feed(void)
+{
+    REG_SET_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_AUTO_FEED_EN);
+}
+
+esp_err_t bootloader_init(void)
+{
+    esp_err_t ret = ESP_OK;
+    bootloader_super_wdt_auto_feed();
+    // protect memory region
+
+    bootloader_init_mem();
+
+    /* check that static RAM is after the stack */
+#ifndef NDEBUG
+    {
+        assert(&_bss_start <= &_bss_end);
+        assert(&_data_start <= &_data_end);
+    }
+#endif
+    // clear bss section
+    bootloader_clear_bss_section();
+    // reset MMU
+    bootloader_reset_mmu();
+    // config clock
+    bootloader_clock_configure();
+    // initialize uart console, from now on, we can use esp_log
+    bootloader_init_uart_console();
+    /* print 2nd bootloader banner */
+    bootloader_print_banner();
+    // update flash ID
+    bootloader_flash_update_id();
+    // read bootloader header
+    if ((ret = bootloader_read_bootloader_header()) != ESP_OK) {
+        goto err;
+    }
+    // read chip revision and check if it's compatible to bootloader
+    if ((ret = bootloader_check_bootloader_validity()) != ESP_OK) {
+        goto err;
+    }
+    // initialize spi flash
+    if ((ret = bootloader_init_spi_flash()) != ESP_OK) {
+        goto err;
+    }
+    // check whether a WDT reset happend
+    bootloader_check_wdt_reset();
+    // config WDT
+    bootloader_config_wdt();
+    // enable RNG early entropy source
+    bootloader_enable_random();
+err:
+    return ret;
+}

--- a/components/bootloader_support/src/esp32s2/bootloader_sha.c
+++ b/components/bootloader_support/src/esp32s2/bootloader_sha.c
@@ -1,0 +1,53 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "bootloader_sha.h"
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/param.h>
+
+#include "esp32s2/rom/sha.h"
+
+static SHA_CTX ctx;
+
+// Words per SHA256 block
+// static const size_t BLOCK_WORDS = (64/sizeof(uint32_t));
+// Words in final SHA256 digest
+// static const size_t DIGEST_WORDS = (32/sizeof(uint32_t));
+
+bootloader_sha256_handle_t bootloader_sha256_start()
+{
+    // Enable SHA hardware
+    ets_sha_enable();
+    ets_sha_init(&ctx, SHA2_256);
+    return &ctx; // Meaningless non-NULL value
+}
+
+void bootloader_sha256_data(bootloader_sha256_handle_t handle, const void *data, size_t data_len)
+{
+    assert(handle != NULL);
+    assert(data_len % 4 == 0);
+    ets_sha_update(&ctx, data, data_len, false);
+}
+
+void bootloader_sha256_finish(bootloader_sha256_handle_t handle, uint8_t *digest)
+{
+    assert(handle != NULL);
+
+    if (digest == NULL) {
+        bzero(&ctx, sizeof(ctx));
+        return;
+    }
+    ets_sha_finish(&ctx, digest);
+}

--- a/components/bootloader_support/src/esp32s2/flash_encrypt.c
+++ b/components/bootloader_support/src/esp32s2/flash_encrypt.c
@@ -1,0 +1,410 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <strings.h>
+
+#include "bootloader_flash.h"
+#include "bootloader_random.h"
+#include "bootloader_utility.h"
+#include "esp_image_format.h"
+#include "esp_flash_encrypt.h"
+#include "esp_flash_partitions.h"
+#include "esp_secure_boot.h"
+#include "esp_log.h"
+#include "esp32s2/rom/secure_boot.h"
+#include "esp32s2/rom/cache.h"
+#include "esp32s2/rom/efuse.h"
+#include "esp_efuse.h"
+#include "esp_efuse_table.h"
+#include "hal/wdt_hal.h"
+
+static const char *TAG = "flash_encrypt";
+
+/* Static functions for stages of flash encryption */
+static esp_err_t initialise_flash_encryption(void);
+static esp_err_t encrypt_flash_contents(uint32_t flash_crypt_cnt, bool flash_crypt_wr_dis) __attribute__((unused));
+static esp_err_t encrypt_bootloader(void);
+static esp_err_t encrypt_and_load_partition_table(esp_partition_info_t *partition_table, int *num_partitions);
+static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partition);
+
+esp_err_t esp_flash_encrypt_check_and_update(void)
+{
+    uint8_t flash_crypt_wr_dis = 0;
+    uint32_t flash_crypt_cnt = 0;
+
+    esp_efuse_read_field_blob(ESP_EFUSE_SPI_BOOT_CRYPT_CNT, &flash_crypt_cnt, 3);
+    esp_efuse_read_field_blob(ESP_EFUSE_WR_DIS_SPI_BOOT_CRYPT_CNT, &flash_crypt_wr_dis, 1);
+
+    ESP_LOGV(TAG, "SPI_BOOT_CRYPT_CNT 0x%x", flash_crypt_cnt);
+    ESP_LOGV(TAG, "EFUSE_WR_DIS_SPI_BOOT_CRYPT_CNT 0x%x", flash_crypt_wr_dis);
+
+    _Static_assert(EFUSE_SPI_BOOT_CRYPT_CNT == 0x7, "assuming CRYPT_CNT is only 3 bits wide");
+
+    if (__builtin_parity(flash_crypt_cnt) == 1) {
+        /* Flash is already encrypted */
+        int left = (flash_crypt_cnt == 1) ? 1 : 0;
+        if (flash_crypt_wr_dis) {
+            left = 0; /* can't update FLASH_CRYPT_CNT, no more flashes */
+        }
+        ESP_LOGI(TAG, "flash encryption is enabled (%d plaintext flashes left)", left);
+        return ESP_OK;
+    } else {
+
+#ifndef CONFIG_SECURE_FLASH_REQUIRE_ALREADY_ENABLED
+        /* Flash is not encrypted, so encrypt it! */
+        return encrypt_flash_contents(flash_crypt_cnt, flash_crypt_wr_dis);
+#else
+        ESP_LOGE(TAG, "flash encryption is not enabled, and SECURE_FLASH_REQUIRE_ALREADY_ENABLED "
+                      "is set, refusing to boot.");
+        return ESP_ERR_INVALID_STATE;
+#endif // CONFIG_SECURE_FLASH_REQUIRE_ALREADY_ENABLED
+
+    }
+}
+
+static bool s_key_dis_read(ets_efuse_block_t block)
+{
+    unsigned key_num = block - ETS_EFUSE_BLOCK_KEY0;
+    return REG_GET_FIELD(EFUSE_RD_REPEAT_DATA0_REG, EFUSE_RD_DIS) & (EFUSE_RD_DIS_KEY0 << key_num);
+}
+
+static bool s_key_dis_write(ets_efuse_block_t block)
+{
+    unsigned key_num = block - ETS_EFUSE_BLOCK_KEY0;
+    return REG_GET_FIELD(EFUSE_RD_WR_DIS_REG, EFUSE_WR_DIS) & (EFUSE_WR_DIS_KEY0 << key_num);
+}
+
+static esp_err_t check_and_generate_encryption_keys(void)
+{
+    esp_err_t err = ESP_ERR_INVALID_STATE;
+    ets_efuse_block_t aes_128_key_block;
+    ets_efuse_block_t aes_256_key_block_1;
+    ets_efuse_block_t aes_256_key_block_2;
+
+    bool has_aes128 = ets_efuse_find_purpose(ETS_EFUSE_KEY_PURPOSE_XTS_AES_128_KEY, &aes_128_key_block);
+    bool has_aes256_1 = ets_efuse_find_purpose(ETS_EFUSE_KEY_PURPOSE_XTS_AES_256_KEY_1, &aes_256_key_block_1);
+    bool has_aes256_2 = ets_efuse_find_purpose(ETS_EFUSE_KEY_PURPOSE_XTS_AES_256_KEY_2, &aes_256_key_block_2);
+    bool has_key = has_aes128 || (has_aes256_1 && has_aes256_2);
+    bool dis_write = false;
+    bool dis_read = false;
+
+    // If there are keys set, they must be write and read protected!
+    if(has_key && has_aes128) {
+        dis_write = s_key_dis_write(aes_128_key_block);
+        dis_read = s_key_dis_read(aes_128_key_block);
+    } else if (has_key && has_aes256_1 && has_aes256_2) {
+        dis_write = s_key_dis_write(aes_256_key_block_1) && s_key_dis_write(aes_256_key_block_2);
+        dis_read = s_key_dis_read(aes_256_key_block_1) && s_key_dis_read(aes_256_key_block_2);
+    }
+
+    if (!has_key && (has_aes256_1 || has_aes256_2)) {
+        ESP_LOGE(TAG, "Invalid efuse key blocks: Both AES-256 key blocks must be set.");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if(has_key && (!dis_read || !dis_write)) {
+        ESP_LOGE(TAG, "Invalid key state, a key was set but not read and write protected.");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if(!has_key && !dis_write && !dis_read) {
+        ESP_LOGI(TAG, "Generating new flash encryption key...");
+#ifdef CONFIG_SECURE_FLASH_ENCRYPTION_AES256
+        const unsigned BLOCKS_NEEDED = 2;
+        const ets_efuse_purpose_t PURPOSE_START = ETS_EFUSE_KEY_PURPOSE_XTS_AES_256_KEY_1;
+        const ets_efuse_purpose_t PURPOSE_END = ETS_EFUSE_KEY_PURPOSE_XTS_AES_256_KEY_2;
+#else
+        const unsigned BLOCKS_NEEDED = 1;
+        const ets_efuse_purpose_t PURPOSE_START = ETS_EFUSE_KEY_PURPOSE_XTS_AES_128_KEY;
+        const ets_efuse_purpose_t PURPOSE_END = ETS_EFUSE_KEY_PURPOSE_XTS_AES_128_KEY;
+#endif
+
+        if (ets_efuse_count_unused_key_blocks() < BLOCKS_NEEDED) {
+            ESP_LOGE(TAG, "Not enough free efuse key blocks (need %d) to continue", BLOCKS_NEEDED);
+            return ESP_ERR_INVALID_STATE;
+        }
+
+        for(ets_efuse_purpose_t purpose = PURPOSE_START; purpose <= PURPOSE_END; purpose++) {
+            uint32_t buf[8] = {0};
+            bootloader_fill_random(buf, sizeof(buf));
+            ets_efuse_block_t block = ets_efuse_find_unused_key_block();
+            ESP_LOGD(TAG, "Writing ETS_EFUSE_BLOCK_KEY%d with purpose %d",
+                     block - ETS_EFUSE_BLOCK_KEY0, purpose);
+
+            /* Note: everything else in this function is deferred as a batch write, but we write the
+               key (and write protect it) immediately as it's too fiddly to manage unused key blocks, etc.
+               in bootloader size footprint otherwise. */
+            int r = ets_efuse_write_key(block, purpose, buf, sizeof(buf));
+            if (r != 0) {
+                ESP_LOGE(TAG, "Failed to write efuse block %d with purpose %d. Can't continue.",
+                        block, purpose);
+                return ESP_FAIL;
+            }
+
+            /* assuming numbering of esp_efuse_block_t matches ets_efuse_block_t */
+            _Static_assert((int)EFUSE_BLK_KEY0 == (int)ETS_EFUSE_BLOCK_KEY0, "esp_efuse_block_t doesn't match ets_efuse_block_t");
+            _Static_assert((int)EFUSE_BLK_KEY1 == (int)ETS_EFUSE_BLOCK_KEY1, "esp_efuse_block_t doesn't match ets_efuse_block_t");
+            _Static_assert((int)EFUSE_BLK_KEY2 == (int)ETS_EFUSE_BLOCK_KEY2, "esp_efuse_block_t doesn't match ets_efuse_block_t");
+            _Static_assert((int)EFUSE_BLK_KEY3 == (int)ETS_EFUSE_BLOCK_KEY3, "esp_efuse_block_t doesn't match ets_efuse_block_t");
+            _Static_assert((int)EFUSE_BLK_KEY4 == (int)ETS_EFUSE_BLOCK_KEY4, "esp_efuse_block_t doesn't match ets_efuse_block_t");
+            _Static_assert((int)EFUSE_BLK_KEY5 == (int)ETS_EFUSE_BLOCK_KEY5, "esp_efuse_block_t doesn't match ets_efuse_block_t");
+
+            // protect this block against reading after key is set (writing is done by ets_efuse_write_key)
+            err = esp_efuse_set_read_protect(block);
+            if(err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to set read protect to efuse block %d. Can't continue.", block);
+                return err;
+            }
+        }
+        ESP_LOGD(TAG, "Key generation complete");
+        return ESP_OK;
+
+    } else {
+        ESP_LOGI(TAG, "Using pre-existing key in efuse");
+        return ESP_OK;
+    }
+}
+
+static esp_err_t initialise_flash_encryption(void)
+{
+    esp_efuse_batch_write_begin(); /* Batch all efuse writes at the end of this function */
+
+    esp_err_t key_state = check_and_generate_encryption_keys();
+    if(key_state != ESP_OK) {
+        esp_efuse_batch_write_cancel();
+        return key_state;
+    }
+
+#ifndef CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_ENC
+    ESP_LOGI(TAG, "Disable UART bootloader encryption...");
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_DOWNLOAD_MANUAL_ENCRYPT);
+#else
+    ESP_LOGW(TAG, "Not disabling UART bootloader encryption");
+#endif
+
+#ifndef CONFIG_SECURE_FLASH_UART_BOOTLOADER_ALLOW_CACHE
+    ESP_LOGI(TAG, "Disable UART bootloader cache...");
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_DOWNLOAD_DCACHE);
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_DOWNLOAD_ICACHE);
+#else
+    ESP_LOGW(TAG, "Not disabling UART bootloader cache - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_JTAG
+    ESP_LOGI(TAG, "Disable JTAG...");
+    esp_efuse_write_field_bit(ESP_EFUSE_HARD_DIS_JTAG);
+#else
+    ESP_LOGW(TAG, "Not disabling JTAG - SECURITY COMPROMISED");
+#endif
+
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_BOOT_REMAP);
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_LEGACY_SPI_BOOT);
+
+    esp_err_t err = esp_efuse_batch_write_commit();
+
+    return err;
+}
+
+/* Encrypt all flash data that should be encrypted */
+static esp_err_t encrypt_flash_contents(uint32_t spi_boot_crypt_cnt, bool flash_crypt_wr_dis)
+{
+    esp_err_t err;
+    esp_partition_info_t partition_table[ESP_PARTITION_TABLE_MAX_ENTRIES];
+    int num_partitions;
+
+    /* If the last spi_boot_crypt_cnt bit is burned or write-disabled, the
+       device can't re-encrypt itself. */
+    if (flash_crypt_wr_dis || spi_boot_crypt_cnt == EFUSE_SPI_BOOT_CRYPT_CNT) {
+        ESP_LOGE(TAG, "Cannot re-encrypt data SPI_BOOT_CRYPT_CNT 0x%02x write disabled %d", spi_boot_crypt_cnt, flash_crypt_wr_dis);
+        return ESP_FAIL;
+    }
+
+    if (spi_boot_crypt_cnt == 0) {
+        /* Very first flash of encrypted data: generate keys, etc. */
+        err = initialise_flash_encryption();
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    err = encrypt_bootloader();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = encrypt_and_load_partition_table(partition_table, &num_partitions);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    /* Now iterate the just-loaded partition table, looking for entries to encrypt */
+    for (int i = 0; i < num_partitions; i++) {
+        err = encrypt_partition(i, &partition_table[i]);
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+
+    ESP_LOGD(TAG, "All flash regions checked for encryption pass");
+
+    /* Set least significant 0-bit in spi_boot_crypt_cnt */
+    int ffs_inv = __builtin_ffs((~spi_boot_crypt_cnt) & 0x7);
+    /* ffs_inv shouldn't be zero, as zero implies spi_boot_crypt_cnt == 0xFF */
+    uint32_t new_spi_boot_crypt_cnt = (1 << (ffs_inv - 1));
+    ESP_LOGD(TAG, "SPI_BOOT_CRYPT_CNT 0x%x -> 0x%x", spi_boot_crypt_cnt, new_spi_boot_crypt_cnt + spi_boot_crypt_cnt);
+
+    esp_efuse_write_field_blob(ESP_EFUSE_SPI_BOOT_CRYPT_CNT, &new_spi_boot_crypt_cnt, 3);
+
+#ifdef CONFIG_SECURE_FLASH_ENCRYPTION_MODE_RELEASE
+    //Secure SPI boot cnt after its update if needed.
+    const uint32_t spi_boot_cnt_wr_dis = 1;
+    ESP_LOGI(TAG, "Write protecting SPI_CRYPT_CNT eFuse");
+    esp_efuse_write_field_blob(ESP_EFUSE_WR_DIS_SPI_BOOT_CRYPT_CNT, &spi_boot_cnt_wr_dis, 1);
+#endif
+    ESP_LOGI(TAG, "Flash encryption completed");
+
+    return ESP_OK;
+}
+
+static esp_err_t encrypt_bootloader(void)
+{
+    esp_err_t err;
+    uint32_t image_length;
+    /* Check for plaintext bootloader (verification will fail if it's already encrypted) */
+    if (esp_image_verify_bootloader(&image_length) == ESP_OK) {
+        ESP_LOGD(TAG, "bootloader is plaintext. Encrypting...");
+
+#if CONFIG_SECURE_BOOT_V2_ENABLED
+        /* The image length obtained from esp_image_verify_bootloader includes the sector boundary padding and the signature block lengths */
+        if (ESP_BOOTLOADER_OFFSET + image_length > ESP_PARTITION_TABLE_OFFSET) {
+            ESP_LOGE(TAG, "Bootloader is too large to fit Secure Boot V2 signature sector and partition table (configured offset 0x%x)", ESP_PARTITION_TABLE_OFFSET);
+            return ESP_ERR_INVALID_SIZE;
+        }
+#endif // CONFIG_SECURE_BOOT_V2_ENABLED
+
+        err = esp_flash_encrypt_region(ESP_BOOTLOADER_OFFSET, image_length);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt bootloader in place: 0x%x", err);
+            return err;
+        } 
+        
+        ESP_LOGI(TAG, "bootloader encrypted successfully");
+        return err;
+    }
+    else {
+        ESP_LOGW(TAG, "no valid bootloader was found");
+        return ESP_ERR_NOT_FOUND;
+    }
+}
+
+static esp_err_t encrypt_and_load_partition_table(esp_partition_info_t *partition_table, int *num_partitions)
+{
+    esp_err_t err;
+    /* Check for plaintext partition table */
+    err = bootloader_flash_read(ESP_PARTITION_TABLE_OFFSET, partition_table, ESP_PARTITION_TABLE_MAX_LEN, false);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read partition table data");
+        return err;
+    }
+    if (esp_partition_table_verify(partition_table, false, num_partitions) == ESP_OK) {
+        ESP_LOGD(TAG, "partition table is plaintext. Encrypting...");
+        esp_err_t err = esp_flash_encrypt_region(ESP_PARTITION_TABLE_OFFSET,
+                                                 FLASH_SECTOR_SIZE);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt partition table in place. %x", err);
+            return err;
+        }
+    }
+    else {
+        ESP_LOGE(TAG, "Failed to read partition table data - not plaintext?");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Valid partition table loded */
+    ESP_LOGI(TAG, "partition table encrypted and loaded successfully");
+    return ESP_OK;
+}
+
+
+static esp_err_t encrypt_partition(int index, const esp_partition_info_t *partition)
+{
+    esp_err_t err;
+    bool should_encrypt = (partition->flags & PART_FLAG_ENCRYPTED);
+
+    if (partition->type == PART_TYPE_APP) {
+      /* check if the partition holds a valid unencrypted app */
+      esp_image_metadata_t data_ignored;
+      err = esp_image_verify(ESP_IMAGE_VERIFY,
+                           &partition->pos,
+                           &data_ignored);
+      should_encrypt = (err == ESP_OK);
+    } else if (partition->type == PART_TYPE_DATA && partition->subtype == PART_SUBTYPE_DATA_OTA) {
+        /* check if we have ota data partition and the partition should be encrypted unconditionally */
+        should_encrypt = true;
+    }
+
+    if (!should_encrypt) {
+        return ESP_OK;
+    }
+    else {
+        /* should_encrypt */
+        ESP_LOGI(TAG, "Encrypting partition %d at offset 0x%x (length 0x%x)...", index, partition->pos.offset, partition->pos.size);
+
+        err = esp_flash_encrypt_region(partition->pos.offset, partition->pos.size);
+        ESP_LOGI(TAG, "Done encrypting");
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to encrypt partition %d", index);
+        }
+        return err;
+    }
+}
+
+
+esp_err_t esp_flash_encrypt_region(uint32_t src_addr, size_t data_length)
+{
+    esp_err_t err;
+    uint32_t buf[FLASH_SECTOR_SIZE / sizeof(uint32_t)];
+
+    if (src_addr % FLASH_SECTOR_SIZE != 0) {
+        ESP_LOGE(TAG, "esp_flash_encrypt_region bad src_addr 0x%x",src_addr);
+        return ESP_FAIL;
+    }
+
+    wdt_hal_context_t rtc_wdt_ctx = {.inst = WDT_RWDT, .rwdt_dev = &RTCCNTL};
+    for (size_t i = 0; i < data_length; i += FLASH_SECTOR_SIZE) {
+
+        wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+        wdt_hal_feed(&rtc_wdt_ctx);
+        wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+
+        uint32_t sec_start = i + src_addr;
+        err = bootloader_flash_read(sec_start, buf, FLASH_SECTOR_SIZE, false);
+        if (err != ESP_OK) {
+            goto flash_failed;
+        }
+        err = bootloader_flash_erase_sector(sec_start / FLASH_SECTOR_SIZE);
+        if (err != ESP_OK) {
+            goto flash_failed;
+        }
+        err = bootloader_flash_write(sec_start, buf, FLASH_SECTOR_SIZE, true);
+        if (err != ESP_OK) {
+            goto flash_failed;
+        }
+    }
+    return ESP_OK;
+
+ flash_failed:
+    ESP_LOGE(TAG, "flash operation failed: 0x%x", err);
+    return err;
+}

--- a/components/bootloader_support/src/esp32s2/secure_boot.c
+++ b/components/bootloader_support/src/esp32s2/secure_boot.c
@@ -1,0 +1,325 @@
+// Copyright 2015-2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string.h>
+
+#include "esp_log.h"
+#include "esp_secure_boot.h"
+#include "soc/efuse_reg.h"
+
+#include "bootloader_flash.h"
+#include "bootloader_sha.h"
+#include "bootloader_utility.h"
+
+#include "esp32s2/rom/crc.h"
+#include "esp_efuse.h"
+#include "esp_efuse_table.h"
+
+#include "esp32s2/rom/efuse.h"
+#include "esp32s2/rom/secure_boot.h"
+
+static const char *TAG = "secure_boot_v2";
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
+#define SIG_BLOCK_MAGIC_BYTE 0xe7
+#define CRC_SIGN_BLOCK_LEN 1196
+#define SIG_BLOCK_PADDING 4096
+
+#define DIGEST_LEN 32
+
+/* A signature block is valid when it has correct magic byte, crc and image digest. */
+static esp_err_t validate_signature_block(const ets_secure_boot_sig_block_t *block, int block_num, const uint8_t *image_digest)
+{
+    uint32_t crc = crc32_le(0, (uint8_t *)block, CRC_SIGN_BLOCK_LEN);
+    if (block->magic_byte != SIG_BLOCK_MAGIC_BYTE) {
+        // All signature blocks have been parsed, no new signature block present.
+        ESP_LOGD(TAG, "Signature block(%d) invalid/absent.", block_num);
+        return ESP_FAIL;
+    }
+    if (block->block_crc != crc) {
+        ESP_LOGE(TAG, "Magic byte correct but incorrect crc.");
+        return ESP_FAIL;
+    }
+    if (memcmp(image_digest, block->image_digest, DIGEST_LEN)) {
+        ESP_LOGE(TAG, "Magic byte & CRC correct but incorrect image digest.");
+        return ESP_FAIL;
+    } else {
+        ESP_LOGD(TAG, "valid signature block(%d) found", block_num);
+        return ESP_OK;
+    }
+
+    return ESP_FAIL;
+}
+
+/* Structure to hold public key digests calculated from the signature blocks of a single image.
+
+   Each image can have one or more signature blocks (up to SECURE_BOOT_NUM_BLOCKS). Each signature block
+   includes a public key.
+
+   Different to the ROM ets_secure_boot_key_digests_t structure which holds pointers to eFuse data with digests,
+   in this data structure the digest data is included.
+*/
+typedef struct {
+    uint8_t key_digests[SECURE_BOOT_NUM_BLOCKS][DIGEST_LEN];
+    unsigned num_digests; /* Number of valid digests, starting at index 0 */
+} image_sig_public_key_digests_t;
+
+/* Generates the public key digests of the valid public keys in an image's
+   signature block, verifies each signature, and stores the key digests in the
+   public_key_digests structure.
+
+   @param flash_offset Image offset in flash
+   @param flash_size Image size in flash (not including signature block)
+   @param[out] public_key_digests Pointer to structure to hold the key digests for valid sig blocks
+
+
+   Note that this function doesn't read any eFuses, so it doesn't know if the
+   keys are ultimately trusted by the hardware or not
+
+   @return - ESP_OK if no signatures failed to verify, or if no valid signature blocks are found at all.
+           - ESP_FAIL if there's a valid signature block that doesn't verify using the included public key (unexpected!)
+*/
+static esp_err_t s_calculate_image_public_key_digests(uint32_t flash_offset, uint32_t flash_size, image_sig_public_key_digests_t *public_key_digests)
+{
+    esp_err_t ret;
+    uint8_t image_digest[DIGEST_LEN] = {0};
+    uint8_t __attribute__((aligned(4))) key_digest[DIGEST_LEN] = {0};
+    size_t sig_block_addr = flash_offset + ALIGN_UP(flash_size, FLASH_SECTOR_SIZE);
+
+    ESP_LOGD(TAG, "calculating public key digests for sig blocks of image offset 0x%x (sig block offset 0x%x)", flash_offset, sig_block_addr);
+
+    bzero(public_key_digests, sizeof(image_sig_public_key_digests_t));
+
+    ret = bootloader_sha256_flash_contents(flash_offset, sig_block_addr - flash_offset, image_digest);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "error generating image digest, %d", ret);
+        return ret;
+    }
+
+    ESP_LOGD(TAG, "reading signatures");
+    const ets_secure_boot_signature_t *signatures = bootloader_mmap(sig_block_addr, sizeof(ets_secure_boot_signature_t));
+    if (signatures == NULL) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", sig_block_addr, sizeof(ets_secure_boot_signature_t));
+        return ESP_FAIL;
+    }
+
+    for (int i = 0; i < SECURE_BOOT_NUM_BLOCKS; i++) {
+        const ets_secure_boot_sig_block_t *block = &signatures->block[i];
+
+        ret = validate_signature_block(block, i, image_digest);
+        if (ret != ESP_OK) {
+            ret = ESP_OK;  // past the last valid signature block
+            break;
+        }
+
+        /* Generating the SHA of the public key components in the signature block */
+        bootloader_sha256_handle_t sig_block_sha;
+        sig_block_sha = bootloader_sha256_start();
+        bootloader_sha256_data(sig_block_sha, &block->key, sizeof(block->key));
+        bootloader_sha256_finish(sig_block_sha, key_digest);
+
+        // Check we can verify the image using this signature and this key
+        uint8_t temp_verified_digest[DIGEST_LEN];
+        bool verified = ets_rsa_pss_verify(&block->key, block->signature, image_digest, temp_verified_digest);
+
+        if (!verified) {
+            /* We don't expect this: the signature blocks before we enable secure boot should all be verifiable or invalid,
+               so this is a fatal error
+            */
+            ret = ESP_FAIL;
+            ESP_LOGE(TAG, "Secure boot key (%d) verification failed.", i);
+            break;
+        }
+        ESP_LOGD(TAG, "Signature block (%d) is verified", i);
+        /* Copy the key digest to the buffer provided by the caller */
+        memcpy((void *)public_key_digests->key_digests[i], key_digest, DIGEST_LEN);
+        public_key_digests->num_digests++;
+    }
+
+    if (ret == ESP_OK && public_key_digests->num_digests > 0) {
+        ESP_LOGI(TAG, "Digests successfully calculated, %d valid signatures (image offset 0x%x)",
+                 public_key_digests->num_digests, flash_offset);
+    }
+
+    bootloader_munmap(signatures);
+    return ret;
+}
+
+esp_err_t esp_secure_boot_v2_permanently_enable(const esp_image_metadata_t *image_data)
+{
+    ESP_LOGI(TAG, "enabling secure boot v2 - ESP32-S2...");
+
+    if (esp_secure_boot_enabled()) {
+        ESP_LOGI(TAG, "secure boot v2 is already enabled, continuing..");
+        return ESP_OK;
+    }
+
+    esp_err_t ret;
+    /* Verify the bootloader */
+    esp_image_metadata_t bootloader_data = { 0 };
+    ret = esp_image_verify_bootloader_data(&bootloader_data);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "bootloader image appears invalid! error %d", ret);
+        return ret;
+    }
+
+    /* Check if secure boot digests are present */
+    bool has_secure_boot_digest = ets_efuse_find_purpose(ETS_EFUSE_KEY_PURPOSE_SECURE_BOOT_DIGEST0, NULL);
+    has_secure_boot_digest |= ets_efuse_find_purpose(ETS_EFUSE_KEY_PURPOSE_SECURE_BOOT_DIGEST1, NULL);
+    has_secure_boot_digest |= ets_efuse_find_purpose(ETS_EFUSE_KEY_PURPOSE_SECURE_BOOT_DIGEST2, NULL);
+    ESP_LOGI(TAG, "Secure boot digests %s", has_secure_boot_digest ? "already present":"absent, generating..");
+
+    ets_efuse_clear_program_registers();
+    if (!has_secure_boot_digest) {
+        image_sig_public_key_digests_t boot_key_digests = {0};
+        image_sig_public_key_digests_t app_key_digests = {0};
+
+        /* Generate the bootloader public key digests */
+        ret = s_calculate_image_public_key_digests(bootloader_data.start_addr, bootloader_data.image_len - SIG_BLOCK_PADDING, &boot_key_digests);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Bootloader signature block is invalid");
+            return ret;
+        }
+
+        if (boot_key_digests.num_digests == 0) {
+            ESP_LOGE(TAG, "No valid bootloader signature blocks found.");
+            return ESP_FAIL;
+        }
+        ESP_LOGI(TAG, "%d signature block(s) found appended to the bootloader.", boot_key_digests.num_digests);
+
+        int unused_key_slots = ets_efuse_count_unused_key_blocks();
+        if (boot_key_digests.num_digests > unused_key_slots) {
+            ESP_LOGE(TAG, "Bootloader signatures(%d) more than available key slots(%d).", boot_key_digests.num_digests, unused_key_slots);
+            return ESP_FAIL;
+        }
+
+        for (int i = 0; i < boot_key_digests.num_digests; i++) {
+            ets_efuse_block_t block;
+            const uint32_t secure_boot_key_purpose[SECURE_BOOT_NUM_BLOCKS] = { ETS_EFUSE_KEY_PURPOSE_SECURE_BOOT_DIGEST0,
+                                ETS_EFUSE_KEY_PURPOSE_SECURE_BOOT_DIGEST1, ETS_EFUSE_KEY_PURPOSE_SECURE_BOOT_DIGEST2 };
+
+            block = ets_efuse_find_unused_key_block();
+            if (block == ETS_EFUSE_BLOCK_MAX) {
+                ESP_LOGE(TAG, "No more unused key blocks available.");
+                return ESP_FAIL;
+            }
+
+            int r = ets_efuse_write_key(block, secure_boot_key_purpose[i], boot_key_digests.key_digests[i], DIGEST_LEN);
+            if (r != 0) {
+                ESP_LOGE(TAG, "Failed to write efuse block %d with purpose %d. Can't continue.", block, secure_boot_key_purpose[i]);
+                return ESP_FAIL;
+            }
+
+            // Note: write key will write protect both the block and the purpose eFuse, always
+        }
+
+        /* Generate the application public key digests */
+        ret = s_calculate_image_public_key_digests(image_data->start_addr, image_data->image_len - SIG_BLOCK_PADDING, &app_key_digests);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "App signature block is invalid.");
+            return ret;
+        }
+
+        if (app_key_digests.num_digests == 0) {
+            ESP_LOGE(TAG, "No valid applications signature blocks found.");
+            return ESP_FAIL;
+        }
+
+        ESP_LOGI(TAG, "%d signature block(s) found appended to the app.", app_key_digests.num_digests);
+        if (app_key_digests.num_digests > boot_key_digests.num_digests) {
+            ESP_LOGW(TAG, "App has %d signature blocks but bootloader only has %d. Some keys missing from bootloader?");
+        }
+
+        /* Confirm if at least one public key from the application matches a public key in the bootloader
+           (Also, ensure if that public revoke bit is not set for the matched key) */
+        bool match = false;
+        const uint32_t revoke_bits[SECURE_BOOT_NUM_BLOCKS] = { EFUSE_SECURE_BOOT_KEY_REVOKE0,
+                                EFUSE_SECURE_BOOT_KEY_REVOKE1, EFUSE_SECURE_BOOT_KEY_REVOKE2 };
+
+        for (int i = 0; i < boot_key_digests.num_digests; i++) {
+
+            if (REG_GET_BIT(EFUSE_RD_REPEAT_DATA1_REG, revoke_bits[i])) {
+                ESP_LOGI(TAG, "Key block(%d) has been revoked.", i);
+                continue; // skip if the key block is revoked
+            }
+
+            for (int j = 0; j < app_key_digests.num_digests; j++) {
+                if (!memcmp(boot_key_digests.key_digests[i], app_key_digests.key_digests[j], DIGEST_LEN)) {
+                    ESP_LOGI(TAG, "Application key(%d) matches with bootloader key(%d).", j, i);
+                    match = true;
+                }
+            }
+        }
+
+        if (match == false) {
+            ESP_LOGE(TAG, "No application key digest matches the bootloader key digest.");
+            return ESP_FAIL;
+        }
+
+        /* Revoke the empty signature blocks */
+        if (boot_key_digests.num_digests < SECURE_BOOT_NUM_BLOCKS) {
+            /* The revocation index can be 0, 1, 2. Bootloader count can be 1,2,3. */
+            for (uint8_t i = boot_key_digests.num_digests; i < SECURE_BOOT_NUM_BLOCKS; i++) {
+                ESP_LOGI(TAG, "Revoking empty key digest slot (%d)...", i);
+                ets_secure_boot_revoke_public_key_digest(i);
+            }
+        }
+    }
+
+    esp_err_t err = esp_efuse_batch_write_begin();
+    if (err != ESP_OK) {
+        ESP_LOGI(TAG, "Error batch programming security eFuses.");
+        return err;
+    }
+
+    __attribute__((unused)) static const uint8_t enable = 1;
+
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_BOOT_REMAP);
+    esp_efuse_write_field_bit(ESP_EFUSE_DIS_LEGACY_SPI_BOOT);
+
+#ifdef CONFIG_SECURE_ENABLE_SECURE_ROM_DL_MODE
+    ESP_LOGI(TAG, "Enabling Security download mode...");
+    esp_efuse_write_field_bit(ESP_EFUSE_ENABLE_SECURITY_DOWNLOAD);
+#else
+    ESP_LOGW(TAG, "Not enabling Security download mode - SECURITY COMPROMISED");
+#endif
+
+#ifndef CONFIG_SECURE_BOOT_ALLOW_JTAG
+    ESP_LOGI(TAG, "Disable hardware & software JTAG...");
+    esp_efuse_write_field_bit(ESP_EFUSE_HARD_DIS_JTAG);
+    esp_efuse_write_field_bit(ESP_EFUSE_SOFT_DIS_JTAG);
+#else
+    ESP_LOGW(TAG, "Not disabling JTAG - SECURITY COMPROMISED");
+#endif
+
+#ifdef CONFIG_SECURE_BOOT_ENABLE_AGGRESSIVE_KEY_REVOKE
+    esp_efuse_write_field_bit(ESP_EFUSE_SECURE_BOOT_AGGRESSIVE_REVOKE);
+#endif
+
+    esp_efuse_write_field_bit(ESP_EFUSE_SECURE_BOOT_EN);
+
+    err = esp_efuse_batch_write_commit();
+    if (err != ESP_OK) {
+        ESP_LOGI(TAG, "Error programming security eFuses.");
+        return err;
+    }
+
+#ifdef CONFIG_SECURE_BOOT_ENABLE_AGGRESSIVE_KEY_REVOKE
+    assert(ets_efuse_secure_boot_aggressive_revoke_enabled());
+#endif
+
+    assert(ets_efuse_secure_boot_enabled());
+    ESP_LOGI(TAG, "Secure boot permanently enabled");
+
+    return ESP_OK;
+}

--- a/components/bootloader_support/src/esp32s2/secure_boot_signatures.c
+++ b/components/bootloader_support/src/esp32s2/secure_boot_signatures.c
@@ -1,0 +1,93 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+
+#include <string.h>
+#include "esp_fault.h"
+#include "bootloader_flash.h"
+#include "bootloader_sha.h"
+#include "bootloader_utility.h"
+#include "esp_log.h"
+#include "esp_image_format.h"
+#include "esp_secure_boot.h"
+#include "esp32s2/rom/secure_boot.h"
+
+static const char* TAG = "secure_boot";
+
+#define DIGEST_LEN 32
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+
+esp_err_t esp_secure_boot_verify_signature(uint32_t src_addr, uint32_t length)
+{
+    uint8_t digest[DIGEST_LEN];
+    uint8_t verified_digest[DIGEST_LEN] = { 0 }; /* Note: this function doesn't do any anti-FI checks on this buffer */
+    const uint8_t *data;
+
+    ESP_LOGD(TAG, "verifying signature src_addr 0x%x length 0x%x", src_addr, length);
+
+    /* Padding to round off the input to the nearest 4k boundary */
+    int padded_length = ALIGN_UP(length, FLASH_SECTOR_SIZE);
+    ESP_LOGD(TAG, "verifying src_addr 0x%x length", src_addr, padded_length);
+
+    data = bootloader_mmap(src_addr, length + sizeof(struct ets_secure_boot_sig_block));
+    if (data == NULL) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", src_addr, length+sizeof(ets_secure_boot_signature_t));
+        return ESP_FAIL;
+    }
+
+    /* Calculate digest of main image */
+    esp_err_t err = bootloader_sha256_flash_contents(src_addr, padded_length, digest);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Digest calculation failed 0x%x, 0x%x", src_addr, padded_length);
+        bootloader_munmap(data);
+        return err;
+    }
+
+    const ets_secure_boot_signature_t *sig = (const ets_secure_boot_signature_t *)(data + length);
+    int r = esp_secure_boot_verify_rsa_signature_block(sig, digest, verified_digest);
+    bootloader_munmap(data);
+
+    return (r == ETS_OK) ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t esp_secure_boot_verify_rsa_signature_block(const ets_secure_boot_signature_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest)
+{
+    ets_secure_boot_key_digests_t trusted_keys;
+    ets_secure_boot_key_digests_t trusted_key_copies[2];
+    ETS_STATUS r;
+    ets_secure_boot_status_t sb_result;
+
+    memset(&trusted_keys, 0, sizeof(ets_secure_boot_key_digests_t));
+    memset(trusted_key_copies, 0, 2 * sizeof(ets_secure_boot_key_digests_t));
+
+    if (!esp_secure_boot_enabled()) {
+        return ESP_OK;
+    }
+
+    r = ets_secure_boot_read_key_digests(&trusted_keys);
+    if (r != ETS_OK) {
+        ESP_LOGI(TAG, "Could not read secure boot digests!");
+        return ESP_FAIL;
+    }
+
+    // Create the copies for FI checks (assuming result is ETS_OK, if it's not then it'll fail the fault check anyhow)
+    ets_secure_boot_read_key_digests(&trusted_key_copies[0]);
+    ets_secure_boot_read_key_digests(&trusted_key_copies[1]);
+    ESP_FAULT_ASSERT(memcmp(&trusted_keys, &trusted_key_copies[0], sizeof(ets_secure_boot_key_digests_t)) == 0);
+    ESP_FAULT_ASSERT(memcmp(&trusted_keys, &trusted_key_copies[1], sizeof(ets_secure_boot_key_digests_t)) == 0);
+
+    ESP_LOGI(TAG, "Verifying with RSA-PSS boot...");
+    sb_result = ets_secure_boot_verify_signature(sig_block, image_digest, &trusted_keys, verified_digest);
+    return (sb_result == SB_SUCCESS) ? ESP_OK : ESP_FAIL;
+}

--- a/components/bootloader_support/src/esp_image_format.c
+++ b/components/bootloader_support/src/esp_image_format.c
@@ -1,0 +1,871 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string.h>
+#include <sys/param.h>
+#include <soc/cpu.h>
+#include <bootloader_utility.h>
+#include <esp_secure_boot.h>
+#include <esp_fault.h>
+#include <esp_log.h>
+#include <esp_attr.h>
+#include <esp_spi_flash.h>
+#include <bootloader_flash.h>
+#include <bootloader_random.h>
+#include <bootloader_sha.h>
+#include "bootloader_util.h"
+#include "bootloader_common.h"
+#include "soc/soc_memory_layout.h"
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/rtc.h"
+#include "esp32/rom/secure_boot.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/rtc.h"
+#include "esp32s2/rom/secure_boot.h"
+#endif
+
+/* Checking signatures as part of verifying images is necessary:
+   - Always if secure boot is enabled
+   - Differently in bootloader and/or app, depending on kconfig
+*/
+#ifdef BOOTLOADER_BUILD
+#ifdef CONFIG_SECURE_SIGNED_ON_BOOT
+#define SECURE_BOOT_CHECK_SIGNATURE 1
+#endif
+#else /* !BOOTLOADER_BUILD */
+#ifdef CONFIG_SECURE_SIGNED_ON_UPDATE
+#define SECURE_BOOT_CHECK_SIGNATURE 1
+#endif
+#endif
+
+static const char *TAG = "esp_image";
+
+#define HASH_LEN ESP_IMAGE_HASH_LEN
+
+#define SIXTEEN_MB 0x1000000
+#define ESP_ROM_CHECKSUM_INITIAL 0xEF
+
+/* Headroom to ensure between stack SP (at time of checking) and data loaded from flash */
+#define STACK_LOAD_HEADROOM 32768
+
+#ifdef BOOTLOADER_BUILD
+/* 64 bits of random data to obfuscate loaded RAM with, until verification is complete
+   (Means loaded code isn't executable until after the secure boot check.)
+*/
+static uint32_t ram_obfs_value[2];
+
+#endif
+
+/* Return true if load_addr is an address the bootloader should load into */
+static bool should_load(uint32_t load_addr);
+/* Return true if load_addr is an address the bootloader should map via flash cache */
+static bool should_map(uint32_t load_addr);
+
+/* Load or verify a segment */
+static esp_err_t process_segment(int index, uint32_t flash_addr, esp_image_segment_header_t *header, bool silent, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum);
+
+/* split segment and verify if data_len is too long */
+static esp_err_t process_segment_data(intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum);
+
+/* Verify the main image header */
+static esp_err_t verify_image_header(uint32_t src_addr, const esp_image_header_t *image, bool silent);
+
+/* Verify a segment header */
+static esp_err_t verify_segment_header(int index, const esp_image_segment_header_t *segment, uint32_t segment_data_offs, bool silent);
+
+/* Log-and-fail macro for use in esp_image_load */
+#define FAIL_LOAD(...) do {                         \
+        if (!silent) {                              \
+            ESP_LOGE(TAG, __VA_ARGS__);             \
+        }                                           \
+        goto err;                                   \
+    }                                               \
+    while(0)
+
+static esp_err_t verify_checksum(bootloader_sha256_handle_t sha_handle, uint32_t checksum_word, esp_image_metadata_t *data);
+
+static esp_err_t __attribute__((unused)) verify_secure_boot_signature(bootloader_sha256_handle_t sha_handle, esp_image_metadata_t *data, uint8_t *image_digest, uint8_t *verified_digest);
+static esp_err_t __attribute__((unused)) verify_simple_hash(bootloader_sha256_handle_t sha_handle, esp_image_metadata_t *data);
+
+static esp_err_t image_load(esp_image_load_mode_t mode, const esp_partition_pos_t *part, esp_image_metadata_t *data)
+{
+#ifdef BOOTLOADER_BUILD
+    bool do_load   = (mode == ESP_IMAGE_LOAD) || (mode == ESP_IMAGE_LOAD_NO_VALIDATE);
+    bool do_verify = (mode == ESP_IMAGE_LOAD) || (mode == ESP_IMAGE_VERIFY) || (mode == ESP_IMAGE_VERIFY_SILENT);
+#else
+    bool do_load   = false; // Can't load the image in app mode
+    bool do_verify = true;  // In app mode is available only verify mode
+#endif
+    bool silent    = (mode == ESP_IMAGE_VERIFY_SILENT);
+    esp_err_t err = ESP_OK;
+    // checksum the image a word at a time. This shaves 30-40ms per MB of image size
+    uint32_t checksum_word = ESP_ROM_CHECKSUM_INITIAL;
+    uint32_t *checksum = NULL;
+    bootloader_sha256_handle_t sha_handle = NULL;
+#if SECURE_BOOT_CHECK_SIGNATURE
+     /* used for anti-FI checks */
+    uint8_t image_digest[HASH_LEN] = { [ 0 ... 31] = 0xEE };
+    uint8_t verified_digest[HASH_LEN] = { [ 0 ... 31 ] = 0x01 };
+#endif
+
+    if (data == NULL || part == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (part->size > SIXTEEN_MB) {
+        err = ESP_ERR_INVALID_ARG;
+        FAIL_LOAD("partition size 0x%x invalid, larger than 16MB", part->size);
+    }
+
+    bzero(data, sizeof(esp_image_metadata_t));
+    data->start_addr = part->offset;
+
+    ESP_LOGD(TAG, "reading image header @ 0x%x", data->start_addr);
+    err = bootloader_flash_read(data->start_addr, &data->image, sizeof(esp_image_header_t), true);
+    if (err != ESP_OK) {
+        goto err;
+    }
+
+    if (do_verify) {
+        checksum = &checksum_word;
+
+        // Calculate SHA-256 of image if secure boot is on, or if image has a hash appended
+#ifdef SECURE_BOOT_CHECK_SIGNATURE
+        if (1) {
+#else
+        if (data->image.hash_appended) {
+#endif
+            sha_handle = bootloader_sha256_start();
+            if (sha_handle == NULL) {
+                return ESP_ERR_NO_MEM;
+            }
+            bootloader_sha256_data(sha_handle, &data->image, sizeof(esp_image_header_t));
+        }
+
+        ESP_LOGD(TAG, "image header: 0x%02x 0x%02x 0x%02x 0x%02x %08x",
+                 data->image.magic,
+                 data->image.segment_count,
+                 data->image.spi_mode,
+                 data->image.spi_size,
+                 data->image.entry_addr);
+
+        err = verify_image_header(data->start_addr, &data->image, silent);
+        if (err != ESP_OK) {
+            goto err;
+        }
+
+        if (data->image.segment_count > ESP_IMAGE_MAX_SEGMENTS) {
+            FAIL_LOAD("image at 0x%x segment count %d exceeds max %d",
+                      data->start_addr, data->image.segment_count, ESP_IMAGE_MAX_SEGMENTS);
+        }
+    } // if (do_verify)
+
+    uint32_t next_addr = data->start_addr + sizeof(esp_image_header_t);
+    for (int i = 0; i < data->image.segment_count; i++) {
+        esp_image_segment_header_t *header = &data->segments[i];
+        ESP_LOGV(TAG, "loading segment header %d at offset 0x%x", i, next_addr);
+
+        err = process_segment(i, next_addr, header, silent, do_load, sha_handle, checksum);
+        if (err != ESP_OK) {
+            goto err;
+        }
+        next_addr += sizeof(esp_image_segment_header_t);
+        data->segment_data[i] = next_addr;
+        next_addr += header->data_len;
+    }
+
+    if (do_verify) {
+        // Segments all loaded, verify length
+        uint32_t end_addr = next_addr;
+        if (end_addr < data->start_addr) {
+            FAIL_LOAD("image offset has wrapped");
+        }
+
+        data->image_len = end_addr - data->start_addr;
+        ESP_LOGV(TAG, "image start 0x%08x end of last section 0x%08x", data->start_addr, end_addr);
+        if (NULL != checksum && !esp_cpu_in_ocd_debug_mode()) {
+            err = verify_checksum(sha_handle, checksum_word, data);
+            if (err != ESP_OK) {
+                goto err;
+            }
+        }
+
+        /* For secure boot V1 on ESP32, we don't calculate SHA or verify signature on bootloaders.
+           For Secure Boot V2, we do verify signature on bootloader which includes the SHA calculation.
+
+           (For non-secure boot, we don't verify any SHA-256 hash appended to the bootloader because
+           esptool.py may have rewritten the header - rely on esptool.py having verified the bootloader at flashing time, instead.)
+        */
+        bool verify_sha;
+#if CONFIG_SECURE_BOOT_V2_ENABLED
+        verify_sha = true;
+#else // ESP32, or ESP32S2 without secure boot enabled
+        verify_sha = (data->start_addr != ESP_BOOTLOADER_OFFSET);
+#endif
+
+        if (verify_sha) {
+            if (data->image_len > part->size) {
+                FAIL_LOAD("Image length %d doesn't fit in partition length %d", data->image_len, part->size);
+            }
+
+#ifdef SECURE_BOOT_CHECK_SIGNATURE
+            // secure boot images have a signature appended
+#if defined(BOOTLOADER_BUILD) && !defined(CONFIG_SECURE_BOOT)
+            // If secure boot is not enabled in hardware, then
+            // skip the signature check in bootloader when the debugger is attached.
+            // This is done to allow for breakpoints in Flash.
+            if (!esp_cpu_in_ocd_debug_mode()) {
+#else // CONFIG_SECURE_BOOT
+            if (true) {
+#endif // end checking for JTAG
+                err = verify_secure_boot_signature(sha_handle, data, image_digest, verified_digest);
+                sha_handle = NULL; // verify_secure_boot_signature finishes sha_handle
+            }
+#else // SECURE_BOOT_CHECK_SIGNATURE
+            // No secure boot, but SHA-256 can be appended for basic corruption detection
+            if (sha_handle != NULL && !esp_cpu_in_ocd_debug_mode()) {
+                err = verify_simple_hash(sha_handle, data);
+                sha_handle = NULL; // calling verify_simple_hash finishes sha_handle
+            }
+#endif // SECURE_BOOT_CHECK_SIGNATURE
+        } else { // verify_sha
+            // bootloader may still have a sha256 digest handle open
+            if (sha_handle != NULL) {
+                bootloader_sha256_finish(sha_handle, NULL);
+            }
+            sha_handle = NULL;
+        } //verify_sha
+
+        // Separately, if there's a hash appended to the image then copy it out to the data->image_digest field
+        if (data->image.hash_appended) {
+            const void *hash = bootloader_mmap(data->start_addr + data->image_len - HASH_LEN, HASH_LEN);
+            if (hash == NULL) {
+                err = ESP_FAIL;
+                goto err;
+            }
+            memcpy(data->image_digest, hash, HASH_LEN);
+            bootloader_munmap(hash);
+        }
+    } // do_verify
+
+    if (err != ESP_OK) {
+        goto err;
+    }
+
+#ifdef BOOTLOADER_BUILD
+
+#ifdef SECURE_BOOT_CHECK_SIGNATURE
+    /* If signature was checked in bootloader build, verified_digest should equal image_digest
+
+       This is to detect any fault injection that caused signature verification to not complete normally.
+
+       Any attack which bypasses this check should be of limited use as the RAM contents are still obfuscated, therefore we do the check
+       immediately before we deobfuscate.
+
+       Note: the conditions for making this check are the same as for setting verify_sha above, but on ESP32 SB V1 we move the test for
+       "only verify signature in bootloader" into the macro so it's tested multiple times.
+     */
+#if CONFIG_SECURE_BOOT_V2_ENABLED
+    ESP_FAULT_ASSERT(!esp_secure_boot_enabled() || memcmp(image_digest, verified_digest, HASH_LEN) == 0);
+#else // Secure Boot V1 on ESP32, only verify signatures for apps not bootloaders
+    ESP_FAULT_ASSERT(data->start_addr == ESP_BOOTLOADER_OFFSET || memcmp(image_digest, verified_digest, HASH_LEN) == 0);
+#endif
+
+#endif // SECURE_BOOT_CHECK_SIGNATURE
+
+    // Deobfuscate RAM
+    if (do_load && ram_obfs_value[0] != 0 && ram_obfs_value[1] != 0) {
+        for (int i = 0; i < data->image.segment_count; i++) {
+            uint32_t load_addr = data->segments[i].load_addr;
+            if (should_load(load_addr)) {
+                uint32_t *loaded = (uint32_t *)load_addr;
+                for (int j = 0; j < data->segments[i].data_len / sizeof(uint32_t); j++) {
+                    loaded[j] ^= (j & 1) ? ram_obfs_value[0] : ram_obfs_value[1];
+                }
+            }
+        }
+    }
+#endif
+
+    // Success!
+    return ESP_OK;
+
+err:
+    if (err == ESP_OK) {
+        err = ESP_ERR_IMAGE_INVALID;
+    }
+    if (sha_handle != NULL) {
+        // Need to finish the hash process to free the handle
+        bootloader_sha256_finish(sha_handle, NULL);
+    }
+    // Prevent invalid/incomplete data leaking out
+    bzero(data, sizeof(esp_image_metadata_t));
+    return err;
+}
+
+esp_err_t bootloader_load_image(const esp_partition_pos_t *part, esp_image_metadata_t *data)
+{
+#ifdef BOOTLOADER_BUILD
+    return image_load(ESP_IMAGE_LOAD, part, data);
+#else
+    return ESP_FAIL;
+#endif
+}
+
+esp_err_t bootloader_load_image_no_verify(const esp_partition_pos_t *part, esp_image_metadata_t *data)
+{
+#ifdef BOOTLOADER_BUILD
+    return image_load(ESP_IMAGE_LOAD_NO_VALIDATE, part, data);
+#else
+    return ESP_FAIL;
+#endif
+}
+
+esp_err_t esp_image_verify(esp_image_load_mode_t mode, const esp_partition_pos_t *part, esp_image_metadata_t *data)
+{
+    return image_load(mode, part, data);
+}
+
+static esp_err_t verify_image_header(uint32_t src_addr, const esp_image_header_t *image, bool silent)
+{
+    esp_err_t err = ESP_OK;
+
+    if (image->magic != ESP_IMAGE_HEADER_MAGIC) {
+        if (!silent) {
+            ESP_LOGE(TAG, "image at 0x%x has invalid magic byte", src_addr);
+        }
+        err = ESP_ERR_IMAGE_INVALID;
+    }
+    if (!silent) {
+        if (image->spi_mode > ESP_IMAGE_SPI_MODE_SLOW_READ) {
+            ESP_LOGW(TAG, "image at 0x%x has invalid SPI mode %d", src_addr, image->spi_mode);
+        }
+        if (image->spi_speed > ESP_IMAGE_SPI_SPEED_80M) {
+            ESP_LOGW(TAG, "image at 0x%x has invalid SPI speed %d", src_addr, image->spi_speed);
+        }
+        if (image->spi_size > ESP_IMAGE_FLASH_SIZE_MAX) {
+            ESP_LOGW(TAG, "image at 0x%x has invalid SPI size %d", src_addr, image->spi_size);
+        }
+    }
+
+    if (err == ESP_OK) {
+        // Checking the chip revision header *will* print a bunch of other info
+        // regardless of silent setting as this may be important, but don't bother checking it
+        // if it looks like the app partition is erased or otherwise garbage
+        if (bootloader_common_check_chip_validity(image, ESP_IMAGE_APPLICATION) != ESP_OK) {
+            err = ESP_ERR_IMAGE_INVALID;
+        }
+    }
+
+    return err;
+}
+
+#ifdef BOOTLOADER_BUILD
+/* Check the region load_addr - load_end doesn't overlap any memory used by the bootloader, registers, or other invalid memory
+ */
+static bool verify_load_addresses(int segment_index, intptr_t load_addr, intptr_t load_end, bool print_error, bool no_recurse)
+{
+    /* Addresses of static data and the "loader" section of bootloader IRAM, all defined in ld script */
+    const char *reason = NULL;
+    extern int _dram_start, _dram_end, _loader_text_start, _loader_text_end;
+    void *load_addr_p = (void *)load_addr;
+    void *load_end_p = (void *)load_end;
+
+    if (load_end == load_addr) {
+        return true; // zero-length segments are fine
+    }
+    assert(load_end > load_addr); // data_len<16MB is checked in verify_segment_header() which is called before this, so this should always be true
+
+    if (esp_ptr_in_dram(load_addr_p) && esp_ptr_in_dram(load_end_p)) { /* Writing to DRAM */
+        /* Check if we're clobbering the stack */
+        intptr_t sp = (intptr_t)get_sp();
+        if (bootloader_util_regions_overlap(sp - STACK_LOAD_HEADROOM, SOC_ROM_STACK_START,
+                                           load_addr, load_end)) {
+            reason = "overlaps bootloader stack";
+            goto invalid;
+        }
+
+        /* Check if we're clobbering static data
+
+           (_dram_start.._dram_end includes bss, data, rodata sections in DRAM)
+         */
+        if (bootloader_util_regions_overlap((intptr_t)&_dram_start, (intptr_t)&_dram_end, load_addr, load_end)) {
+            reason = "overlaps bootloader data";
+            goto invalid;
+        }
+
+        /* LAST DRAM CHECK (recursive): for D/IRAM, check the equivalent IRAM addresses if needed
+
+           Allow for the possibility that even though both pointers are IRAM, only part of the region is in a D/IRAM
+           section. In which case we recurse to check the part which falls in D/IRAM.
+
+           Note: We start with SOC_DIRAM_DRAM_LOW/HIGH and convert that address to IRAM to account for any reversing of word order
+           (chip-specific).
+         */
+        if (!no_recurse && bootloader_util_regions_overlap(SOC_DIRAM_DRAM_LOW, SOC_DIRAM_DRAM_HIGH, load_addr, load_end)) {
+            intptr_t iram_load_addr, iram_load_end;
+
+            if (esp_ptr_in_diram_dram(load_addr_p)) {
+                iram_load_addr = (intptr_t)esp_ptr_diram_dram_to_iram(load_addr_p);
+            } else {
+                iram_load_addr = (intptr_t)esp_ptr_diram_dram_to_iram((void *)SOC_DIRAM_DRAM_LOW);
+            }
+
+            if (esp_ptr_in_diram_dram(load_end_p)) {
+                iram_load_end = (intptr_t)esp_ptr_diram_dram_to_iram(load_end_p);
+            } else {
+                iram_load_end = (intptr_t)esp_ptr_diram_dram_to_iram((void *)SOC_DIRAM_DRAM_HIGH);
+            }
+
+            if (iram_load_end < iram_load_addr) {
+                return verify_load_addresses(segment_index, iram_load_end, iram_load_addr, print_error, true);
+            } else {
+                return verify_load_addresses(segment_index, iram_load_addr, iram_load_end, print_error, true);
+            }
+        }
+    }
+    else if (esp_ptr_in_iram(load_addr_p) && esp_ptr_in_iram(load_end_p)) { /* Writing to IRAM */
+        /* Check for overlap of 'loader' section of IRAM */
+        if (bootloader_util_regions_overlap((intptr_t)&_loader_text_start, (intptr_t)&_loader_text_end,
+                                            load_addr, load_end)) {
+            reason = "overlaps loader IRAM";
+            goto invalid;
+        }
+
+        /* LAST IRAM CHECK (recursive): for D/IRAM, check the equivalent DRAM address if needed
+
+           Allow for the possibility that even though both pointers are IRAM, only part of the region is in a D/IRAM
+           section. In which case we recurse to check the part which falls in D/IRAM.
+           Note: We start with SOC_DIRAM_IRAM_LOW/HIGH and convert that address to DRAM to account for any reversing of word order
+           (chip-specific).
+         */
+        if (!no_recurse && bootloader_util_regions_overlap(SOC_DIRAM_IRAM_LOW, SOC_DIRAM_IRAM_HIGH, load_addr, load_end)) {
+            intptr_t dram_load_addr, dram_load_end;
+
+            if (esp_ptr_in_diram_iram(load_addr_p)) {
+                dram_load_addr = (intptr_t)esp_ptr_diram_iram_to_dram(load_addr_p);
+            } else {
+                dram_load_addr = (intptr_t)esp_ptr_diram_iram_to_dram((void *)SOC_DIRAM_IRAM_LOW);
+            }
+
+            if (esp_ptr_in_diram_iram(load_end_p)) {
+                dram_load_end = (intptr_t)esp_ptr_diram_iram_to_dram(load_end_p);
+            } else {
+                dram_load_end = (intptr_t)esp_ptr_diram_iram_to_dram((void *)SOC_DIRAM_IRAM_HIGH);
+            }
+
+            if (dram_load_end < dram_load_addr) {
+                return verify_load_addresses(segment_index, dram_load_end, dram_load_addr, print_error, true);
+            } else {
+                return verify_load_addresses(segment_index, dram_load_addr, dram_load_end, print_error, true);
+            }
+        }
+    /* Sections entirely in RTC memory won't overlap with a vanilla bootloader but are valid load addresses, thus skipping them from the check */
+    } else if (esp_ptr_in_rtc_iram_fast(load_addr_p) && esp_ptr_in_rtc_iram_fast(load_end_p)){
+        return true;
+    } else if (esp_ptr_in_rtc_dram_fast(load_addr_p) && esp_ptr_in_rtc_dram_fast(load_end_p)){
+        return true;
+    } else if (esp_ptr_in_rtc_slow(load_addr_p) && esp_ptr_in_rtc_slow(load_end_p)) {
+        return true;
+    } else { /* Not a DRAM or an IRAM or RTC Fast IRAM, RTC Fast DRAM or RTC Slow address */
+        reason = "bad load address range";
+        goto invalid;
+    }
+    return true;
+
+ invalid:
+    if (print_error) {
+        ESP_LOGE(TAG, "Segment %d 0x%08x-0x%08x invalid: %s", segment_index, load_addr, load_end, reason);
+    }
+    return false;
+}
+#endif // BOOTLOADER_BUILD
+
+static esp_err_t process_segment(int index, uint32_t flash_addr, esp_image_segment_header_t *header, bool silent, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum)
+{
+    esp_err_t err;
+
+    /* read segment header */
+    err = bootloader_flash_read(flash_addr, header, sizeof(esp_image_segment_header_t), true);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "bootloader_flash_read failed at 0x%08x", flash_addr);
+        return err;
+    }
+    if (sha_handle != NULL) {
+        bootloader_sha256_data(sha_handle, header, sizeof(esp_image_segment_header_t));
+    }
+
+    intptr_t load_addr = header->load_addr;
+    uint32_t data_len = header->data_len;
+    uint32_t data_addr = flash_addr + sizeof(esp_image_segment_header_t);
+
+    ESP_LOGV(TAG, "segment data length 0x%x data starts 0x%x", data_len, data_addr);
+
+    err = verify_segment_header(index, header, data_addr, silent);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (data_len % 4 != 0) {
+        FAIL_LOAD("unaligned segment length 0x%x", data_len);
+    }
+
+    bool is_mapping = should_map(load_addr);
+    do_load = do_load && should_load(load_addr);
+
+    if (!silent) {
+        ESP_LOGI(TAG, "segment %d: paddr=0x%08x vaddr=0x%08x size=0x%05x (%6d) %s",
+                 index, data_addr, load_addr,
+                 data_len, data_len,
+                 (do_load) ? "load" : (is_mapping) ? "map" : "");
+    }
+
+
+#ifdef BOOTLOADER_BUILD
+    /* Before loading segment, check it doesn't clobber bootloader RAM. */
+    if (do_load && data_len > 0) {
+        if (!verify_load_addresses(index, load_addr, load_addr + data_len, true, false)) {
+            return ESP_ERR_IMAGE_INVALID;
+        }
+    }
+#endif // BOOTLOADER_BUILD
+
+    uint32_t free_page_count = bootloader_mmap_get_free_pages();
+    ESP_LOGD(TAG, "free data page_count 0x%08x", free_page_count);
+
+    int32_t data_len_remain = data_len;
+    while (data_len_remain > 0) {
+#if SECURE_BOOT_CHECK_SIGNATURE && defined(BOOTLOADER_BUILD)
+        /* Double check the address verification done above */
+        ESP_FAULT_ASSERT(!do_load || verify_load_addresses(0, load_addr, load_addr + data_len_remain, false, false));
+#endif
+        uint32_t offset_page = ((data_addr & MMAP_ALIGNED_MASK) != 0) ? 1 : 0;
+        /* Data we could map in case we are not aligned to PAGE boundary is one page size lesser. */
+        data_len = MIN(data_len_remain, ((free_page_count - offset_page) * SPI_FLASH_MMU_PAGE_SIZE));
+        err = process_segment_data(load_addr, data_addr, data_len, do_load, sha_handle, checksum);
+        if (err != ESP_OK) {
+            return err;
+        }
+        data_addr += data_len;
+        data_len_remain -= data_len;
+    }
+
+    return ESP_OK;
+
+err:
+    if (err == ESP_OK) {
+        err = ESP_ERR_IMAGE_INVALID;
+    }
+
+    return err;
+}
+
+static esp_err_t process_segment_data(intptr_t load_addr, uint32_t data_addr, uint32_t data_len, bool do_load, bootloader_sha256_handle_t sha_handle, uint32_t *checksum)
+{
+    // If we are not loading, and the checksum is empty, skip processing this
+    // segment for data
+    if (!do_load && checksum == NULL) {
+        ESP_LOGD(TAG, "skipping checksum for segment");
+        return ESP_OK;
+    }
+
+    const uint32_t *data = (const uint32_t *)bootloader_mmap(data_addr, data_len);
+    if (!data) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed",
+                 data_addr, data_len);
+        return ESP_FAIL;
+    }
+
+    if (checksum == NULL && sha_handle == NULL) {
+        memcpy((void *)load_addr, data, data_len);
+        bootloader_munmap(data);
+        return ESP_OK;
+    }
+
+#ifdef BOOTLOADER_BUILD
+    // Set up the obfuscation value to use for loading
+    while (ram_obfs_value[0] == 0 || ram_obfs_value[1] == 0) {
+        bootloader_fill_random(ram_obfs_value, sizeof(ram_obfs_value));
+    }
+    uint32_t *dest = (uint32_t *)load_addr;
+#endif
+
+    const uint32_t *src = data;
+
+    for (int i = 0; i < data_len; i += 4) {
+        int w_i = i / 4; // Word index
+        uint32_t w = src[w_i];
+        if (checksum != NULL) {
+            *checksum ^= w;
+        }
+#ifdef BOOTLOADER_BUILD
+        if (do_load) {
+            dest[w_i] = w ^ ((w_i & 1) ? ram_obfs_value[0] : ram_obfs_value[1]);
+        }
+#endif
+        // SHA_CHUNK determined experimentally as the optimum size
+        // to call bootloader_sha256_data() with. This is a bit
+        // counter-intuitive, but it's ~3ms better than using the
+        // SHA256 block size.
+        const size_t SHA_CHUNK = 1024;
+        if (sha_handle != NULL && i % SHA_CHUNK == 0) {
+            bootloader_sha256_data(sha_handle, &src[w_i],
+                                   MIN(SHA_CHUNK, data_len - i));
+        }
+    }
+
+    bootloader_munmap(data);
+
+    return ESP_OK;
+}
+
+static esp_err_t verify_segment_header(int index, const esp_image_segment_header_t *segment, uint32_t segment_data_offs, bool silent)
+{
+    if ((segment->data_len & 3) != 0
+            || segment->data_len >= SIXTEEN_MB) {
+        if (!silent) {
+            ESP_LOGE(TAG, "invalid segment length 0x%x", segment->data_len);
+        }
+        return ESP_ERR_IMAGE_INVALID;
+    }
+
+    uint32_t load_addr = segment->load_addr;
+    bool map_segment = should_map(load_addr);
+
+    /* Check that flash cache mapped segment aligns correctly from flash to its mapped address,
+       relative to the 64KB page mapping size.
+    */
+    ESP_LOGV(TAG, "segment %d map_segment %d segment_data_offs 0x%x load_addr 0x%x",
+             index, map_segment, segment_data_offs, load_addr);
+    if (map_segment
+            && ((segment_data_offs % SPI_FLASH_MMU_PAGE_SIZE) != (load_addr % SPI_FLASH_MMU_PAGE_SIZE))) {
+        if (!silent) {
+            ESP_LOGE(TAG, "Segment %d load address 0x%08x, doesn't match data 0x%08x",
+                     index, load_addr, segment_data_offs);
+        }
+        return ESP_ERR_IMAGE_INVALID;
+    }
+
+    return ESP_OK;
+}
+
+static bool should_map(uint32_t load_addr)
+{
+    return (load_addr >= SOC_IROM_LOW && load_addr < SOC_IROM_HIGH)
+           || (load_addr >= SOC_DROM_LOW && load_addr < SOC_DROM_HIGH);
+}
+
+static bool should_load(uint32_t load_addr)
+{
+    /* Reload the RTC memory segments whenever a non-deepsleep reset
+       is occurring */
+    bool load_rtc_memory = rtc_get_reset_reason(0) != DEEPSLEEP_RESET;
+
+    if (should_map(load_addr)) {
+        return false;
+    }
+
+    if (load_addr < 0x10000000) {
+        // Reserved for non-loaded addresses.
+        // Current reserved values are
+        // 0x0 (padding block)
+        // 0x4 (unused, but reserved for an MD5 block)
+        return false;
+    }
+
+    if (!load_rtc_memory) {
+        if (load_addr >= SOC_RTC_IRAM_LOW && load_addr < SOC_RTC_IRAM_HIGH) {
+            ESP_LOGD(TAG, "Skipping RTC fast memory segment at 0x%08x", load_addr);
+            return false;
+        }
+        if (load_addr >= SOC_RTC_DRAM_LOW && load_addr < SOC_RTC_DRAM_HIGH) {
+            ESP_LOGD(TAG, "Skipping RTC fast memory segment at 0x%08x", load_addr);
+            return false;
+        }
+        if (load_addr >= SOC_RTC_DATA_LOW && load_addr < SOC_RTC_DATA_HIGH) {
+            ESP_LOGD(TAG, "Skipping RTC slow memory segment at 0x%08x", load_addr);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+esp_err_t esp_image_verify_bootloader(uint32_t *length)
+{
+    esp_image_metadata_t data;
+    esp_err_t err = esp_image_verify_bootloader_data(&data);
+    if (length != NULL) {
+        *length = (err == ESP_OK) ? data.image_len : 0;
+    }
+    return err;
+}
+
+esp_err_t esp_image_verify_bootloader_data(esp_image_metadata_t *data)
+{
+    if (data == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    const esp_partition_pos_t bootloader_part = {
+        .offset = ESP_BOOTLOADER_OFFSET,
+        .size = ESP_PARTITION_TABLE_OFFSET - ESP_BOOTLOADER_OFFSET,
+    };
+    return esp_image_verify(ESP_IMAGE_VERIFY,
+                            &bootloader_part,
+                            data);
+}
+
+
+static esp_err_t verify_checksum(bootloader_sha256_handle_t sha_handle, uint32_t checksum_word, esp_image_metadata_t *data)
+{
+    uint32_t unpadded_length = data->image_len;
+    uint32_t length = unpadded_length + 1; // Add a byte for the checksum
+    length = (length + 15) & ~15; // Pad to next full 16 byte block
+
+    // Verify checksum
+    WORD_ALIGNED_ATTR uint8_t buf[16];
+    esp_err_t err = bootloader_flash_read(data->start_addr + unpadded_length, buf, length - unpadded_length, true);
+    uint8_t calc = buf[length - unpadded_length - 1];
+    uint8_t checksum = (checksum_word >> 24)
+                       ^ (checksum_word >> 16)
+                       ^ (checksum_word >> 8)
+                       ^ (checksum_word >> 0);
+    if (err != ESP_OK || checksum != calc) {
+        ESP_LOGE(TAG, "Checksum failed. Calculated 0x%x read 0x%x", checksum, calc);
+        return ESP_ERR_IMAGE_INVALID;
+    }
+    if (sha_handle != NULL) {
+        bootloader_sha256_data(sha_handle, buf, length - unpadded_length);
+    }
+
+    if (data->image.hash_appended) {
+        // Account for the hash in the total image length
+        length += HASH_LEN;
+    }
+    data->image_len = length;
+
+    return ESP_OK;
+}
+
+static esp_err_t verify_secure_boot_signature(bootloader_sha256_handle_t sha_handle, esp_image_metadata_t *data, uint8_t *image_digest, uint8_t *verified_digest)
+{
+#ifdef SECURE_BOOT_CHECK_SIGNATURE
+    uint32_t end = data->start_addr + data->image_len;
+
+    ESP_LOGI(TAG, "Verifying image signature...");
+
+    // For secure boot, we calculate the signature hash over the whole file, which includes any "simple" hash
+    // appended to the image for corruption detection
+    if (data->image.hash_appended) {
+        const void *simple_hash = bootloader_mmap(end - HASH_LEN, HASH_LEN);
+        bootloader_sha256_data(sha_handle, simple_hash, HASH_LEN);
+        bootloader_munmap(simple_hash);
+    }
+
+#if CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME
+    // End of the image needs to be padded all the way to a 4KB boundary, after the simple hash
+    // (for apps they are usually already padded due to --secure-pad-v2, only a problem if this option was not used.)
+    uint32_t padded_end = (end + FLASH_SECTOR_SIZE - 1) & ~(FLASH_SECTOR_SIZE-1);
+    if (padded_end > end) {
+        const void *padding = bootloader_mmap(end, padded_end - end);
+        bootloader_sha256_data(sha_handle, padding, padded_end - end);
+        bootloader_munmap(padding);
+        end = padded_end;
+    }
+#endif
+
+    bootloader_sha256_finish(sha_handle, image_digest);
+
+    // Log the hash for debugging
+    bootloader_debug_buffer(image_digest, HASH_LEN, "Calculated secure boot hash");
+
+    // Use hash to verify signature block
+    esp_err_t err = ESP_ERR_IMAGE_INVALID;
+    const void *sig_block;
+#ifdef CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
+    ESP_FAULT_ASSERT(memcmp(image_digest, verified_digest, HASH_LEN) != 0); /* sanity check that these values start differently */
+    sig_block = bootloader_mmap(data->start_addr + data->image_len, sizeof(esp_secure_boot_sig_block_t));
+    err = esp_secure_boot_verify_ecdsa_signature_block(sig_block, image_digest, verified_digest);
+#elif CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME
+    ESP_FAULT_ASSERT(memcmp(image_digest, verified_digest, HASH_LEN) != 0);  /* sanity check that these values start differently */
+    sig_block = bootloader_mmap(end, sizeof(ets_secure_boot_signature_t));
+    err = esp_secure_boot_verify_rsa_signature_block(sig_block, image_digest, verified_digest);
+#endif
+
+    bootloader_munmap(sig_block);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Secure boot signature verification failed");
+
+        // Go back and check if the simple hash matches or not (we're off the fast path so we can re-hash the whole image now)
+        ESP_LOGI(TAG, "Calculating simple hash to check for corruption...");
+        const void *whole_image = bootloader_mmap(data->start_addr, data->image_len - HASH_LEN);
+        if (whole_image != NULL) {
+            sha_handle = bootloader_sha256_start();
+            bootloader_sha256_data(sha_handle, whole_image, data->image_len - HASH_LEN);
+            bootloader_munmap(whole_image);
+            if (verify_simple_hash(sha_handle, data) != ESP_OK) {
+                ESP_LOGW(TAG, "image corrupted on flash");
+            } else {
+                ESP_LOGW(TAG, "image valid, signature bad");
+            }
+        }
+        return ESP_ERR_IMAGE_INVALID;
+    }
+
+#if CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME
+    // Adjust image length result to include the appended signature
+    data->image_len = end - data->start_addr + sizeof(ets_secure_boot_signature_t);
+#endif
+
+#endif // SECURE_BOOT_CHECK_SIGNATURE
+    return ESP_OK;
+}
+
+static esp_err_t verify_simple_hash(bootloader_sha256_handle_t sha_handle, esp_image_metadata_t *data)
+{
+    uint8_t image_hash[HASH_LEN] = { 0 };
+    bootloader_sha256_finish(sha_handle, image_hash);
+
+    // Log the hash for debugging
+    bootloader_debug_buffer(image_hash, HASH_LEN, "Calculated hash");
+
+    // Simple hash for verification only
+    const void *hash = bootloader_mmap(data->start_addr + data->image_len - HASH_LEN, HASH_LEN);
+    if (memcmp(hash, image_hash, HASH_LEN) != 0) {
+        ESP_LOGE(TAG, "Image hash failed - image is corrupt");
+        bootloader_debug_buffer(hash, HASH_LEN, "Expected hash");
+        bootloader_munmap(hash);
+        return ESP_ERR_IMAGE_INVALID;
+    }
+
+    bootloader_munmap(hash);
+    return ESP_OK;
+}
+
+int esp_image_get_flash_size(esp_image_flash_size_t app_flash_size)
+{
+    switch (app_flash_size) {
+    case ESP_IMAGE_FLASH_SIZE_1MB:
+        return 1 * 1024 * 1024;
+    case ESP_IMAGE_FLASH_SIZE_2MB:
+        return 2 * 1024 * 1024;
+    case ESP_IMAGE_FLASH_SIZE_4MB:
+        return 4 * 1024 * 1024;
+    case ESP_IMAGE_FLASH_SIZE_8MB:
+        return 8 * 1024 * 1024;
+    case ESP_IMAGE_FLASH_SIZE_16MB:
+        return 16 * 1024 * 1024;
+    default:
+        return 0;
+    }
+}

--- a/components/bootloader_support/src/flash_encrypt.c
+++ b/components/bootloader_support/src/flash_encrypt.c
@@ -1,0 +1,132 @@
+// Copyright 2015-2019 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <strings.h>
+#include "sdkconfig.h"
+#include "esp_log.h"
+#include "esp_efuse.h"
+#include "esp_efuse_table.h"
+#include "esp_flash_encrypt.h"
+#include "esp_secure_boot.h"
+
+#if CONFIG_IDF_TARGET_ESP32
+#define CRYPT_CNT ESP_EFUSE_FLASH_CRYPT_CNT
+#define WR_DIS_CRYPT_CNT ESP_EFUSE_WR_DIS_FLASH_CRYPT_CNT
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define CRYPT_CNT ESP_EFUSE_SPI_BOOT_CRYPT_CNT
+#define WR_DIS_CRYPT_CNT ESP_EFUSE_WR_DIS_SPI_BOOT_CRYPT_CNT
+#endif
+
+#ifndef BOOTLOADER_BUILD
+static const char *TAG = "flash_encrypt";
+
+void esp_flash_encryption_init_checks()
+{
+    esp_flash_enc_mode_t mode;
+
+    // First check is: if Release mode flash encryption & secure boot are enabled then
+    // FLASH_CRYPT_CNT *must* be write protected. This will have happened automatically
+    // if bootloader is IDF V4.0 or newer but may not have happened for previous ESP-IDF bootloaders.
+#ifdef CONFIG_SECURE_FLASH_ENCRYPTION_MODE_RELEASE
+#ifdef CONFIG_SECURE_BOOT
+    if (esp_secure_boot_enabled() && esp_flash_encryption_enabled()) {
+        bool flash_crypt_cnt_wr_dis = esp_efuse_read_field_bit(WR_DIS_CRYPT_CNT);
+        if (!flash_crypt_cnt_wr_dis) {
+            uint8_t flash_crypt_cnt = 0;
+            esp_efuse_read_field_blob(CRYPT_CNT, &flash_crypt_cnt,  CRYPT_CNT[0]->bit_count);
+            if (flash_crypt_cnt == (1<<(CRYPT_CNT[0]->bit_count))-1) {
+                // If encryption counter is already max, no need to write protect it
+                // (this distinction is important on ESP32 ECO3 where write-procted FLASH_CRYPT_CNT also write-protects UART_DL_DIS)
+                return;
+            }
+            ESP_LOGE(TAG, "Flash encryption & Secure Boot together requires FLASH_CRYPT_CNT efuse to be write protected. Fixing now...");
+            esp_flash_write_protect_crypt_cnt();
+        }
+    }
+#endif // CONFIG_SECURE_BOOT
+#endif // CONFIG_SECURE_FLASH_ENCRYPTION_MODE_RELEASE
+
+    // Second check is to print a warning or error if the current running flash encryption mode
+    // doesn't match the expectation from project config (due to mismatched bootloader and app, probably)
+    mode = esp_get_flash_encryption_mode();
+    if (mode == ESP_FLASH_ENC_MODE_DEVELOPMENT) {
+#ifdef CONFIG_SECURE_FLASH_ENCRYPTION_MODE_RELEASE
+        ESP_LOGE(TAG, "Flash encryption settings error: app is configured for RELEASE but efuses are set for DEVELOPMENT");
+        ESP_LOGE(TAG, "Mismatch found in security options in bootloader menuconfig and efuse settings. Device is not secure.");
+#else
+        ESP_LOGW(TAG, "Flash encryption mode is DEVELOPMENT (not secure)");
+#endif
+    } else if (mode == ESP_FLASH_ENC_MODE_RELEASE) {
+        ESP_LOGI(TAG, "Flash encryption mode is RELEASE");
+    }
+}
+#endif
+
+void esp_flash_write_protect_crypt_cnt(void)
+{
+    esp_efuse_write_field_bit(WR_DIS_CRYPT_CNT);
+}
+
+esp_flash_enc_mode_t esp_get_flash_encryption_mode(void)
+{
+    bool flash_crypt_cnt_wr_dis = false;
+#if CONFIG_IDF_TARGET_ESP32   
+    uint8_t dis_dl_enc = 0, dis_dl_dec = 0, dis_dl_cache = 0;
+#elif CONFIG_IDF_TARGET_ESP32S2
+    uint8_t  dis_dl_enc = 0; 
+    uint8_t dis_dl_icache = 0; 
+    uint8_t dis_dl_dcache = 0; 
+
+#endif
+
+    esp_flash_enc_mode_t mode = ESP_FLASH_ENC_MODE_DEVELOPMENT;
+
+    if (esp_flash_encryption_enabled()) {
+        /* Check if FLASH CRYPT CNT is write protected */
+
+        flash_crypt_cnt_wr_dis = esp_efuse_read_field_bit(WR_DIS_CRYPT_CNT);
+        if (!flash_crypt_cnt_wr_dis) {
+            uint8_t flash_crypt_cnt = 0;
+            esp_efuse_read_field_blob(CRYPT_CNT, &flash_crypt_cnt, CRYPT_CNT[0]->bit_count);
+            if (flash_crypt_cnt == (1 << (CRYPT_CNT[0]->bit_count)) - 1) {
+                flash_crypt_cnt_wr_dis = true;
+            }
+        }
+
+        if (flash_crypt_cnt_wr_dis) {
+
+#if CONFIG_IDF_TARGET_ESP32
+            dis_dl_cache = esp_efuse_read_field_bit(ESP_EFUSE_DISABLE_DL_CACHE);
+            dis_dl_enc = esp_efuse_read_field_bit(ESP_EFUSE_DISABLE_DL_ENCRYPT);
+            dis_dl_dec = esp_efuse_read_field_bit(ESP_EFUSE_DISABLE_DL_DECRYPT);
+            /* Check if DISABLE_DL_DECRYPT, DISABLE_DL_ENCRYPT & DISABLE_DL_CACHE are set */
+            if ( dis_dl_cache && dis_dl_enc && dis_dl_dec ) {
+                mode = ESP_FLASH_ENC_MODE_RELEASE;
+            }
+#elif CONFIG_IDF_TARGET_ESP32S2
+            dis_dl_enc = esp_efuse_read_field_bit(ESP_EFUSE_DIS_DOWNLOAD_MANUAL_ENCRYPT);
+            dis_dl_icache = esp_efuse_read_field_bit(ESP_EFUSE_DIS_DOWNLOAD_ICACHE);
+            dis_dl_dcache = esp_efuse_read_field_bit(ESP_EFUSE_DIS_DOWNLOAD_DCACHE);
+
+            if (dis_dl_enc && dis_dl_icache && dis_dl_dcache) {
+                mode = ESP_FLASH_ENC_MODE_RELEASE;
+            }
+#endif
+        }
+    } else {
+        mode = ESP_FLASH_ENC_MODE_DISABLED;
+    }
+
+    return mode;
+}

--- a/components/bootloader_support/src/flash_partitions.c
+++ b/components/bootloader_support/src/flash_partitions.c
@@ -1,0 +1,85 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <string.h>
+#include "esp_flash_partitions.h"
+#include "esp_log.h"
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/md5_hash.h"
+
+static const char *TAG = "flash_parts";
+
+esp_err_t esp_partition_table_verify(const esp_partition_info_t *partition_table, bool log_errors, int *num_partitions)
+{
+    int md5_found = 0;
+    int num_parts;
+    uint32_t chip_size = g_rom_flashchip.chip_size;
+    *num_partitions = 0;
+
+    for (num_parts = 0; num_parts < ESP_PARTITION_TABLE_MAX_ENTRIES; num_parts++) {
+        const esp_partition_info_t *part = &partition_table[num_parts];
+
+        if (part->magic == ESP_PARTITION_MAGIC) {
+            const esp_partition_pos_t *pos = &part->pos;
+            if (pos->offset > chip_size || pos->offset + pos->size > chip_size) {
+                if (log_errors) {
+                    ESP_LOGE(TAG, "partition %d invalid - offset 0x%x size 0x%x exceeds flash chip size 0x%x",
+                             num_parts, pos->offset, pos->size, chip_size);
+                }
+                return ESP_ERR_INVALID_SIZE;
+            }
+        } else if (part->magic == ESP_PARTITION_MAGIC_MD5) {
+            if (md5_found) {
+                if (log_errors) {
+                    ESP_LOGE(TAG, "Only one MD5 checksum is allowed");
+                }
+                return ESP_ERR_INVALID_STATE;
+            }
+
+            struct MD5Context context;
+            unsigned char digest[16];
+            MD5Init(&context);
+            MD5Update(&context, (unsigned char *) partition_table, num_parts * sizeof(esp_partition_info_t));
+            MD5Final(digest, &context);
+
+            unsigned char *md5sum = ((unsigned char *) part) + ESP_PARTITION_MD5_OFFSET;
+
+            if (memcmp(md5sum, digest, sizeof(digest)) != 0) {
+                if (log_errors) {
+                    ESP_LOGE(TAG, "Incorrect MD5 checksum");
+                }
+                return ESP_ERR_INVALID_STATE;
+            }
+            //MD5 checksum matches and we continue with the next interation in
+            //order to detect the end of the partition table
+            md5_found = 1;
+        } else if (part->magic == 0xFFFF
+                   && part->type == PART_TYPE_END
+                   && part->subtype == PART_SUBTYPE_END) {
+            ESP_LOGD(TAG, "partition table verified, %d entries", num_parts);
+            *num_partitions = num_parts - md5_found; //do not count the partition where the MD5 checksum is held
+            return ESP_OK;
+        } else {
+            if (log_errors) {
+                ESP_LOGE(TAG, "partition %d invalid magic number 0x%x", num_parts, part->magic);
+            }
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+
+    if (log_errors) {
+        ESP_LOGE(TAG, "partition table has no terminating entry, not valid");
+    }
+    return ESP_ERR_INVALID_STATE;
+}
+

--- a/components/bootloader_support/src/flash_qio_mode.c
+++ b/components/bootloader_support/src/flash_qio_mode.c
@@ -1,0 +1,357 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stddef.h>
+#include <stdint.h>
+#include "bootloader_flash_config.h"
+#include "flash_qio_mode.h"
+#include "esp_log.h"
+#include "esp_err.h"
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/efuse.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/spi_flash.h"
+#include "esp32s2/rom/efuse.h"
+#include "soc/spi_mem_struct.h"
+#endif
+#include "soc/spi_struct.h"
+#include "soc/spi_reg.h"
+#include "soc/efuse_periph.h"
+#include "soc/io_mux_reg.h"
+#include "sdkconfig.h"
+
+/* SPI flash controller */
+#if CONFIG_IDF_TARGET_ESP32
+#define SPIFLASH SPI1
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define SPIFLASH SPIMEM1
+#endif
+
+/* SPI commands (actual on-wire commands not SPI controller bitmasks)
+   Suitable for use with the execute_flash_command static function.
+*/
+#define CMD_RDID       0x9F
+#define CMD_WRSR       0x01
+#define CMD_WRSR2      0x31 /* Not all SPI flash uses this command */
+#define CMD_WREN       0x06
+#define CMD_WRDI       0x04
+#define CMD_RDSR       0x05
+#define CMD_RDSR2      0x35 /* Not all SPI flash uses this command */
+#define CMD_OTPEN      0x3A /* Enable OTP mode, not all SPI flash uses this command */
+
+static const char *TAG = "qio_mode";
+
+typedef unsigned (*read_status_fn_t)(void);
+typedef void (*write_status_fn_t)(unsigned);
+
+typedef struct __attribute__((packed))
+{
+    const char *manufacturer;
+    uint8_t mfg_id; /* 8-bit JEDEC manufacturer ID */
+    uint16_t flash_id; /* 16-bit JEDEC flash chip ID */
+    uint16_t id_mask; /* Bits to match on in flash chip ID */
+    read_status_fn_t read_status_fn;
+    write_status_fn_t write_status_fn;
+    uint8_t status_qio_bit;
+} qio_info_t;
+
+/* Read 8 bit status using RDSR command */
+static unsigned read_status_8b_rdsr(void);
+/* Read 8 bit status (second byte) using RDSR2 command */
+static unsigned read_status_8b_rdsr2(void);
+/* read 16 bit status using RDSR & RDSR2 (low and high bytes) */
+static unsigned read_status_16b_rdsr_rdsr2(void);
+
+/* Write 8 bit status using WRSR */
+static void write_status_8b_wrsr(unsigned new_status);
+/* Write 8 bit status (second byte) using WRSR2 */
+static void write_status_8b_wrsr2(unsigned new_status);
+/* Write 16 bit status using WRSR */
+static void write_status_16b_wrsr(unsigned new_status);
+
+/* Read 8 bit status of XM25QU64A  */
+static unsigned read_status_8b_xmc25qu64a(void);
+/* Write 8 bit status of XM25QU64A */
+static void write_status_8b_xmc25qu64a(unsigned new_status);
+
+/* Array of known flash chips and data to enable Quad I/O mode
+
+   Manufacturer & flash ID can be tested by running "esptool.py
+   flash_id"
+
+   If manufacturer ID matches, and flash ID ORed with flash ID mask
+   matches, enable_qio_mode() will execute "Read Cmd", test if bit
+   number "QIE Bit" is set, and if not set it will call "Write Cmd"
+   with this bit set.
+
+   Searching of this table stops when the first match is found.
+ */
+const static qio_info_t chip_data[] = {
+    /*   Manufacturer,   mfg_id, flash_id, id mask, Read Status,                Write Status,               QIE Bit */
+    { "MXIC",        0xC2,   0x2000, 0xFF00,    read_status_8b_rdsr,        write_status_8b_wrsr,       6 },
+    { "ISSI",        0x9D,   0x4000, 0xCF00,    read_status_8b_rdsr,        write_status_8b_wrsr,       6 }, /* IDs 0x40xx, 0x70xx */
+    { "WinBond",     0xEF,   0x4000, 0xFF00,    read_status_16b_rdsr_rdsr2, write_status_16b_wrsr,      9 },
+    { "GD",          0xC8,   0x6000, 0xFF00,    read_status_16b_rdsr_rdsr2, write_status_16b_wrsr,      9 },
+    { "XM25QU64A",   0x20,   0x3817, 0xFFFF,    read_status_8b_xmc25qu64a,  write_status_8b_xmc25qu64a, 6 },
+
+    /* Final entry is default entry, if no other IDs have matched.
+
+       This approach works for chips including:
+       GigaDevice (mfg ID 0xC8, flash IDs including 4016),
+       FM25Q32 (QOUT mode only, mfg ID 0xA1, flash IDs including 4016)
+    */
+    { NULL,          0xFF,    0xFFFF, 0xFFFF,   read_status_8b_rdsr2,       write_status_8b_wrsr2,      1 },
+};
+
+#define NUM_CHIPS (sizeof(chip_data) / sizeof(qio_info_t))
+
+static esp_err_t enable_qio_mode(read_status_fn_t read_status_fn,
+                                 write_status_fn_t write_status_fn,
+                                 uint8_t status_qio_bit);
+
+/* Generic function to use the "user command" SPI controller functionality
+   to send commands to the SPI flash and read the respopnse.
+
+   The command passed here is always the on-the-wire command given to the SPI flash unit.
+*/
+static uint32_t execute_flash_command(uint8_t command, uint32_t mosi_data, uint8_t mosi_len, uint8_t miso_len);
+
+/* dummy_len_plus values defined in ROM for SPI flash configuration */
+extern uint8_t g_rom_spiflash_dummy_len_plus[];
+uint32_t bootloader_read_flash_id(void)
+{
+    uint32_t id = execute_flash_command(CMD_RDID, 0, 0, 24);
+    id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
+    return id;
+}
+
+#if CONFIG_IDF_TARGET_ESP32S2
+#define FLASH_WRAP_CMD   0x77
+typedef enum {
+    FLASH_WRAP_MODE_8B  = 0,
+    FLASH_WRAP_MODE_16B = 2,
+    FLASH_WRAP_MODE_32B = 4,
+    FLASH_WRAP_MODE_64B = 6,
+    FLASH_WRAP_MODE_DISABLE = 1
+} spi_flash_wrap_mode_t;
+static esp_err_t spi_flash_wrap_set(spi_flash_wrap_mode_t mode)
+{
+    uint32_t reg_bkp_ctrl = SPIFLASH.ctrl.val;
+    uint32_t reg_bkp_usr  = SPIFLASH.user.val;
+    SPIFLASH.user.fwrite_dio = 0;
+    SPIFLASH.user.fwrite_dual = 0;
+    SPIFLASH.user.fwrite_qio = 1;
+    SPIFLASH.user.fwrite_quad = 0;
+    SPIFLASH.ctrl.fcmd_dual = 0;
+    SPIFLASH.ctrl.fcmd_quad = 0;
+    SPIFLASH.user.usr_dummy = 0;
+    SPIFLASH.user.usr_addr = 1;
+    SPIFLASH.user.usr_command = 1;
+    SPIFLASH.user2.usr_command_bitlen = 7;
+    SPIFLASH.user2.usr_command_value = FLASH_WRAP_CMD;
+    SPIFLASH.user1.usr_addr_bitlen = 23;
+    SPIFLASH.addr = 0;
+    SPIFLASH.user.usr_miso = 0;
+    SPIFLASH.user.usr_mosi = 1;
+    SPIFLASH.mosi_dlen.usr_mosi_bit_len = 7;
+    SPIFLASH.data_buf[0] = (uint32_t) mode << 4;;
+    SPIFLASH.cmd.usr = 1;
+    while (SPIFLASH.cmd.usr != 0) {
+    }
+
+    SPIFLASH.ctrl.val = reg_bkp_ctrl;
+    SPIFLASH.user.val = reg_bkp_usr;
+    return ESP_OK;
+}
+#endif
+
+void bootloader_enable_qio_mode(void)
+{
+    uint32_t raw_flash_id;
+    uint8_t mfg_id;
+    uint16_t flash_id;
+    int i;
+
+    ESP_LOGD(TAG, "Probing for QIO mode enable...");
+    esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+
+    raw_flash_id = g_rom_flashchip.device_id;
+    ESP_LOGD(TAG, "Raw SPI flash chip id 0x%x", raw_flash_id);
+
+    mfg_id = (raw_flash_id >> 16) & 0xFF;
+    flash_id = raw_flash_id & 0xFFFF;
+    ESP_LOGD(TAG, "Manufacturer ID 0x%02x chip ID 0x%04x", mfg_id, flash_id);
+
+    for (i = 0; i < NUM_CHIPS - 1; i++) {
+        const qio_info_t *chip = &chip_data[i];
+        if (mfg_id == chip->mfg_id && (flash_id & chip->id_mask) == (chip->flash_id & chip->id_mask)) {
+            ESP_LOGI(TAG, "Enabling QIO for flash chip %s", chip_data[i].manufacturer);
+            break;
+        }
+    }
+
+    if (i == NUM_CHIPS - 1) {
+        ESP_LOGI(TAG, "Enabling default flash chip QIO");
+    }
+    enable_qio_mode(chip_data[i].read_status_fn,
+                    chip_data[i].write_status_fn,
+                    chip_data[i].status_qio_bit);
+#if CONFIG_IDF_TARGET_ESP32S2
+    spi_flash_wrap_set(FLASH_WRAP_MODE_DISABLE);
+#endif
+}
+
+static esp_err_t enable_qio_mode(read_status_fn_t read_status_fn,
+                                 write_status_fn_t write_status_fn,
+                                 uint8_t status_qio_bit)
+{
+    uint32_t status;
+    const uint32_t spiconfig = ets_efuse_get_spiconfig();
+
+    esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+
+    status = read_status_fn();
+    ESP_LOGD(TAG, "Initial flash chip status 0x%x", status);
+
+    if ((status & (1 << status_qio_bit)) == 0) {
+        execute_flash_command(CMD_WREN, 0, 0, 0);
+        write_status_fn(status | (1 << status_qio_bit));
+
+        esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+
+        status = read_status_fn();
+        ESP_LOGD(TAG, "Updated flash chip status 0x%x", status);
+        if ((status & (1 << status_qio_bit)) == 0) {
+            ESP_LOGE(TAG, "Failed to set QIE bit, not enabling QIO mode");
+            return ESP_FAIL;
+        }
+
+    } else {
+        ESP_LOGD(TAG, "QIO mode already enabled in flash");
+    }
+
+    ESP_LOGD(TAG, "Enabling QIO mode...");
+
+    esp_rom_spiflash_read_mode_t mode;
+#if CONFIG_ESPTOOLPY_FLASHMODE_QOUT
+    mode = ESP_ROM_SPIFLASH_QOUT_MODE;
+#else
+    mode = ESP_ROM_SPIFLASH_QIO_MODE;
+#endif
+
+    esp_rom_spiflash_config_readmode(mode);
+
+#if CONFIG_IDF_TARGET_ESP32
+    int wp_pin = bootloader_flash_get_wp_pin();
+    esp_rom_spiflash_select_qio_pins(wp_pin, spiconfig);
+#elif CONFIG_IDF_TARGET_ESP32S2
+    esp_rom_spiflash_select_qio_pins(ets_efuse_get_wp_pad(), spiconfig);
+#endif
+    return ESP_OK;
+}
+
+static unsigned read_status_8b_rdsr(void)
+{
+    return execute_flash_command(CMD_RDSR, 0, 0, 8);
+}
+
+static unsigned read_status_8b_rdsr2(void)
+{
+    return execute_flash_command(CMD_RDSR2, 0, 0, 8);
+}
+
+static unsigned read_status_16b_rdsr_rdsr2(void)
+{
+    return execute_flash_command(CMD_RDSR, 0, 0, 8) | (execute_flash_command(CMD_RDSR2, 0, 0, 8) << 8);
+}
+
+static void write_status_8b_wrsr(unsigned new_status)
+{
+    execute_flash_command(CMD_WRSR, new_status, 8, 0);
+}
+
+static void write_status_8b_wrsr2(unsigned new_status)
+{
+    execute_flash_command(CMD_WRSR2, new_status, 8, 0);
+}
+
+static void write_status_16b_wrsr(unsigned new_status)
+{
+    execute_flash_command(CMD_WRSR, new_status, 16, 0);
+}
+
+static unsigned read_status_8b_xmc25qu64a(void)
+{
+    execute_flash_command(CMD_OTPEN, 0, 0, 0);  /* Enter OTP mode */
+    esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+    uint32_t read_status = execute_flash_command(CMD_RDSR, 0, 0, 8);
+    execute_flash_command(CMD_WRDI, 0, 0, 0);   /* Exit OTP mode */
+    return read_status;
+}
+
+static void write_status_8b_xmc25qu64a(unsigned new_status)
+{
+    execute_flash_command(CMD_OTPEN, 0, 0, 0);  /* Enter OTP mode */
+    esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+    execute_flash_command(CMD_WRSR, new_status, 8, 0);
+    esp_rom_spiflash_wait_idle(&g_rom_flashchip);
+    execute_flash_command(CMD_WRDI, 0, 0, 0);   /* Exit OTP mode */
+}
+
+static uint32_t execute_flash_command(uint8_t command, uint32_t mosi_data, uint8_t mosi_len, uint8_t miso_len)
+{
+    uint32_t old_ctrl_reg = SPIFLASH.ctrl.val;
+#if CONFIG_IDF_TARGET_ESP32
+    SPIFLASH.ctrl.val = SPI_WP_REG_M; // keep WP high while idle, otherwise leave DIO mode
+#elif CONFIG_IDF_TARGET_ESP32S2
+    SPIFLASH.ctrl.val = SPI_MEM_WP_REG_M; // keep WP high while idle, otherwise leave DIO mode
+#endif
+    SPIFLASH.user.usr_dummy = 0;
+    SPIFLASH.user.usr_addr = 0;
+    SPIFLASH.user.usr_command = 1;
+    SPIFLASH.user2.usr_command_bitlen = 7;
+
+    SPIFLASH.user2.usr_command_value = command;
+    SPIFLASH.user.usr_miso = miso_len > 0;
+#if CONFIG_IDF_TARGET_ESP32
+    SPIFLASH.miso_dlen.usr_miso_dbitlen = miso_len ? (miso_len - 1) : 0;
+#elif CONFIG_IDF_TARGET_ESP32S2
+    SPIFLASH.miso_dlen.usr_miso_bit_len = miso_len ? (miso_len - 1) : 0;
+#endif
+    SPIFLASH.user.usr_mosi = mosi_len > 0;
+#if CONFIG_IDF_TARGET_ESP32
+    SPIFLASH.mosi_dlen.usr_mosi_dbitlen = mosi_len ? (mosi_len - 1) : 0;
+#elif CONFIG_IDF_TARGET_ESP32S2
+    SPIFLASH.mosi_dlen.usr_mosi_bit_len = mosi_len ? (mosi_len - 1) : 0;
+#endif
+    SPIFLASH.data_buf[0] = mosi_data;
+
+    if (g_rom_spiflash_dummy_len_plus[1]) {
+        /* When flash pins are mapped via GPIO matrix, need a dummy cycle before reading via MISO */
+        if (miso_len > 0) {
+            SPIFLASH.user.usr_dummy = 1;
+            SPIFLASH.user1.usr_dummy_cyclelen = g_rom_spiflash_dummy_len_plus[1] - 1;
+        } else {
+            SPIFLASH.user.usr_dummy = 0;
+            SPIFLASH.user1.usr_dummy_cyclelen = 0;
+        }
+    }
+
+    SPIFLASH.cmd.usr = 1;
+    while (SPIFLASH.cmd.usr != 0) {
+    }
+
+    SPIFLASH.ctrl.val = old_ctrl_reg;
+    return SPIFLASH.data_buf[0];
+}

--- a/components/bootloader_support/src/idf/bootloader_sha.c
+++ b/components/bootloader_support/src/idf/bootloader_sha.c
@@ -1,0 +1,55 @@
+// Copyright 2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "bootloader_sha.h"
+#include "bootloader_flash.h"
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/param.h>
+#include <mbedtls/sha256.h>
+
+bootloader_sha256_handle_t bootloader_sha256_start(void)
+{
+    mbedtls_sha256_context *ctx = (mbedtls_sha256_context *)malloc(sizeof(mbedtls_sha256_context));
+    if (!ctx) {
+        return NULL;
+    }
+    mbedtls_sha256_init(ctx);
+    int ret = mbedtls_sha256_starts_ret(ctx, false);
+    if (ret != 0) {
+        return NULL;
+    }
+    return ctx;
+}
+
+void bootloader_sha256_data(bootloader_sha256_handle_t handle, const void *data, size_t data_len)
+{
+    assert(handle != NULL);
+    mbedtls_sha256_context *ctx = (mbedtls_sha256_context *)handle;
+    int ret = mbedtls_sha256_update_ret(ctx, data, data_len);
+    assert(ret == 0);
+}
+
+void bootloader_sha256_finish(bootloader_sha256_handle_t handle, uint8_t *digest)
+{
+    assert(handle != NULL);
+    mbedtls_sha256_context *ctx = (mbedtls_sha256_context *)handle;
+    if (digest != NULL) {
+        int ret = mbedtls_sha256_finish_ret(ctx, digest);
+        assert(ret == 0);
+    }
+    mbedtls_sha256_free(ctx);
+    free(handle);
+    handle = NULL;
+}

--- a/components/bootloader_support/src/idf/secure_boot_signatures.c
+++ b/components/bootloader_support/src/idf/secure_boot_signatures.c
@@ -1,0 +1,377 @@
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "sdkconfig.h"
+
+#include "bootloader_flash.h"
+#include "bootloader_sha.h"
+#include "bootloader_utility.h"
+#include "esp_log.h"
+#include "esp_image_format.h"
+#include "esp_secure_boot.h"
+#include "mbedtls/rsa.h"
+#include "mbedtls/version.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/x509.h"
+#include "mbedtls/md.h"
+#include "mbedtls/platform.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/ctr_drbg.h"
+#include <string.h>
+#include <sys/param.h>
+#include "esp_secure_boot.h"
+
+#ifdef CONFIG_IDF_TARGET_ESP32S2
+#include <esp32s2/rom/secure_boot.h>
+#endif
+
+#define DIGEST_LEN 32
+
+#ifdef CONFIG_SECURE_SIGNED_APPS_ECDSA_SCHEME
+static const char *TAG = "secure_boot_v1";
+
+extern const uint8_t signature_verification_key_start[] asm("_binary_signature_verification_key_bin_start");
+extern const uint8_t signature_verification_key_end[] asm("_binary_signature_verification_key_bin_end");
+
+#define SIGNATURE_VERIFICATION_KEYLEN 64
+
+esp_err_t esp_secure_boot_verify_signature(uint32_t src_addr, uint32_t length)
+{
+    uint8_t digest[DIGEST_LEN];
+    uint8_t verified_digest[DIGEST_LEN];
+    const esp_secure_boot_sig_block_t *sigblock;
+
+    ESP_LOGD(TAG, "verifying signature src_addr 0x%x length 0x%x", src_addr, length);
+
+    esp_err_t err = bootloader_sha256_flash_contents(src_addr, length, digest);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Digest calculation failed 0x%x, 0x%x", src_addr, length);
+        return err;
+    }
+
+    // Map the signature block and verify the signature
+    sigblock = (const esp_secure_boot_sig_block_t *)bootloader_mmap(src_addr + length, sizeof(esp_secure_boot_sig_block_t));
+    if (sigblock == NULL) {
+        ESP_LOGE(TAG, "bootloader_mmap(0x%x, 0x%x) failed", src_addr + length, sizeof(esp_secure_boot_sig_block_t));
+        return ESP_FAIL;
+    }
+    err = esp_secure_boot_verify_ecdsa_signature_block(sigblock, digest, verified_digest);
+    bootloader_munmap(sigblock);
+    return err;
+}
+
+esp_err_t esp_secure_boot_verify_ecdsa_signature_block(const esp_secure_boot_sig_block_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest)
+{
+#if !(defined(CONFIG_MBEDTLS_ECDSA_C) && defined(CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED))
+    ESP_LOGE(TAG, "Signature verification requires ECDSA & SECP256R1 curve enabled");
+    return ESP_ERR_NOT_SUPPORTED;
+#else
+    ptrdiff_t keylen;
+
+    /* Note: in IDF app image verification we don't add any fault injection resistance, boot-time checks only */
+    memset(verified_digest, 0, DIGEST_LEN);
+
+    keylen = signature_verification_key_end - signature_verification_key_start;
+    if (keylen != SIGNATURE_VERIFICATION_KEYLEN) {
+        ESP_LOGE(TAG, "Embedded public verification key has wrong length %d", keylen);
+        return ESP_FAIL;
+    }
+
+    if (sig_block->version != 0) {
+        ESP_LOGE(TAG, "image has invalid signature version field 0x%08x", sig_block->version);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, "Verifying secure boot signature");
+
+    int ret;
+    mbedtls_mpi r, s;
+
+    mbedtls_mpi_init(&r);
+    mbedtls_mpi_init(&s);
+
+    /* Extract r and s components from RAW ECDSA signature of 64 bytes */
+#define ECDSA_INTEGER_LEN 32
+    ret = mbedtls_mpi_read_binary(&r, &sig_block->signature[0], ECDSA_INTEGER_LEN);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Failed mbedtls_mpi_read_binary(1), err:%d", ret);
+        return ESP_FAIL;
+    }
+
+    ret = mbedtls_mpi_read_binary(&s, &sig_block->signature[ECDSA_INTEGER_LEN], ECDSA_INTEGER_LEN);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Failed mbedtls_mpi_read_binary(2), err:%d", ret);
+        mbedtls_mpi_free(&r);
+        return ESP_FAIL;
+    }
+
+    /* Initialise ECDSA context */
+    mbedtls_ecdsa_context ecdsa_context;
+    mbedtls_ecdsa_init(&ecdsa_context);
+
+    mbedtls_ecp_group_load(&ecdsa_context.grp, MBEDTLS_ECP_DP_SECP256R1);
+    size_t plen = mbedtls_mpi_size(&ecdsa_context.grp.P);
+    if (keylen != 2 * plen) {
+        ESP_LOGE(TAG, "Incorrect ECDSA key length %d", keylen);
+        ret = ESP_FAIL;
+        goto cleanup;
+    }
+
+    /* Extract X and Y components from ECDSA public key */
+    MBEDTLS_MPI_CHK(mbedtls_mpi_read_binary(&ecdsa_context.Q.X, signature_verification_key_start, plen));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_read_binary(&ecdsa_context.Q.Y, signature_verification_key_start + plen, plen));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_lset(&ecdsa_context.Q.Z, 1));
+
+    ret = mbedtls_ecdsa_verify(&ecdsa_context.grp, image_digest, DIGEST_LEN, &ecdsa_context.Q, &r, &s);
+    ESP_LOGD(TAG, "Verification result %d", ret);
+
+cleanup:
+    mbedtls_mpi_free(&r);
+    mbedtls_mpi_free(&s);
+    mbedtls_ecdsa_free(&ecdsa_context);
+    return ret == 0 ? ESP_OK : ESP_ERR_IMAGE_INVALID;
+#endif // CONFIG_MBEDTLS_ECDSA_C && CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED
+}
+
+#elif CONFIG_SECURE_SIGNED_APPS_RSA_SCHEME
+
+static const char *TAG = "secure_boot_v2";
+#define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+#define RSA_KEY_SIZE 384 /* RSA 3072 Bits */
+
+#if CONFIG_IDF_TARGET_ESP32S2
+inline static bool digest_matches(const void *trusted, const void *computed)
+{
+    if (trusted == NULL) {
+        return false;
+    }
+
+    // 'trusted' is probably a pointer to read-only efuse registers,
+    // which only support word reads. memcmp() cannot be guaranteed
+    // to do word reads, so we make a local copy here (we know that
+    // memcpy() will do word operations if it can).
+    uint8_t __attribute__((aligned(4))) trusted_local[ETS_DIGEST_LEN];
+    uint8_t __attribute__((aligned(4))) computed_local[ETS_DIGEST_LEN];
+
+    memcpy(trusted_local, trusted, ETS_DIGEST_LEN);
+    memcpy(computed_local, computed, ETS_DIGEST_LEN);
+    return memcmp(trusted_local, computed_local, ETS_DIGEST_LEN) == 0;
+}
+#endif /* CONFIG_IDF_TARGET_ESP32S2 */
+
+esp_err_t esp_secure_boot_verify_signature(uint32_t src_addr, uint32_t length)
+{
+    uint8_t digest[DIGEST_LEN] = {0};
+    uint8_t verified_digest[DIGEST_LEN] = {0};
+
+    /* Rounding off length to the upper 4k boundary */
+    uint32_t padded_length = ALIGN_UP(length, FLASH_SECTOR_SIZE);
+    ESP_LOGD(TAG, "verifying signature src_addr 0x%x length 0x%x", src_addr, length);
+
+    esp_err_t err = bootloader_sha256_flash_contents(src_addr, padded_length, digest);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Digest calculation failed 0x%x, 0x%x", src_addr, padded_length);
+        return err;
+    }
+
+    const ets_secure_boot_signature_t *sig_block = bootloader_mmap(src_addr + padded_length, sizeof(ets_secure_boot_signature_t));
+    if (sig_block == NULL) {
+        ESP_LOGE(TAG, "Failed to mmap data at offset 0x%x", src_addr + padded_length);
+        return ESP_FAIL;
+    }
+
+    err = esp_secure_boot_verify_rsa_signature_block(sig_block, digest, verified_digest);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Secure Boot V2 verification failed.");
+    }
+    bootloader_munmap(sig_block);
+    return err;
+}
+
+typedef struct verify_rsa_sig_block_mem_t {
+    uint8_t sig_block_key_digest[SECURE_BOOT_NUM_BLOCKS][DIGEST_LEN];
+    uint8_t efuse_trusted_digest[DIGEST_LEN];
+    uint8_t zeroes[DIGEST_LEN];
+    mbedtls_rsa_context pk;
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context ctr_drbg;
+} verify_rsa_sig_block_mem_t;
+
+static esp_err_t esp_secure_boot_verify_rsa_signature_block_internal(
+    const ets_secure_boot_signature_t *sig_block,
+    const uint8_t *image_digest,
+    uint8_t *verified_digest,
+    verify_rsa_sig_block_mem_t* const p_mem)
+{
+    uint8_t i = 0;
+#if CONFIG_SECURE_BOOT_V2_ENABLED /* Verify key against efuse block */
+    /* Note: in IDF verification we don't add any fault injection resistance, as we don't expect this to be called
+       during boot-time verification. */
+    memset(verified_digest, 0, DIGEST_LEN);
+
+    /* Generating the SHA of the public key components in the signature block */
+    for (i = 0; i < SECURE_BOOT_NUM_BLOCKS; i++) {
+        bootloader_sha256_handle_t sig_block_sha;
+        sig_block_sha = bootloader_sha256_start();
+        bootloader_sha256_data(sig_block_sha, &sig_block->block[i].key, sizeof(sig_block->block[i].key));
+        bootloader_sha256_finish(sig_block_sha, (unsigned char *)p_mem->sig_block_key_digest[i]);
+    }
+
+#if CONFIG_IDF_TARGET_ESP32
+    memcpy(p_mem->efuse_trusted_digest, (uint8_t *) EFUSE_BLK2_RDATA0_REG, sizeof(p_mem->efuse_trusted_digest));
+
+    if (memcmp(p_mem->efuse_trusted_digest, p_mem->sig_block_key_digest[0], DIGEST_LEN) != 0) {
+        /* Can't continue if secure boot is enabled, OR if a different digest is already written in efuse BLK2
+
+           (If BLK2 is empty and Secure Boot is disabled then we assume that it will be enabled later.)
+         */
+        if (esp_secure_boot_enabled() || memcmp(p_mem->efuse_trusted_digest, p_mem->zeroes, DIGEST_LEN) != 0) {
+            ESP_LOGE(TAG, "Public key digest in eFuse BLK2 and the signature block don't match.");
+            return ESP_FAIL;
+        }
+    }
+#elif CONFIG_IDF_TARGET_ESP32S2
+    bool match = false;
+    ETS_STATUS r;
+    r = ets_secure_boot_read_key_digests(&p_mem->efuse_trusted_digest);
+    if (r != 0) {
+        ESP_LOGI(TAG, "Could not read secure boot digests!");
+        return ESP_FAIL;
+    }
+#endif /* CONFIG_IDF_TARGET_ESP32 */
+#endif /* CONFIG_SECURE_BOOT_V2_ENABLED */
+
+    ESP_LOGI(TAG, "Verifying with RSA-PSS...");
+    int ret = 0;
+    unsigned char *sig_be = calloc(1, RSA_KEY_SIZE);
+    unsigned char *buf = calloc(1, RSA_KEY_SIZE);
+    if (sig_be == NULL || buf == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    mbedtls_entropy_init(&p_mem->entropy);
+    mbedtls_ctr_drbg_init(&p_mem->ctr_drbg);
+    ret = mbedtls_ctr_drbg_seed(&p_mem->ctr_drbg, mbedtls_entropy_func, &p_mem->entropy, NULL, 0);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "mbedtls_ctr_drbg_seed returned -0x%04x\n", ret);
+        goto exit;
+    }
+
+    for (i = 0; i < SECURE_BOOT_NUM_BLOCKS; i++) {
+#if CONFIG_IDF_TARGET_ESP32S2
+        for (uint8_t j = 0; j < SECURE_BOOT_NUM_BLOCKS; j++) {
+            if (digest_matches(p_mem->efuse_trusted_digest.key_digests[j], p_mem->sig_block_key_digest[i])) {
+                ESP_LOGI(TAG, "eFuse key matches(%d) matches the application key(%d).", j, i);
+                match = true;
+                break;
+            }
+        }
+        if (match == false) {
+            continue; // Skip the public keys whose digests don't match.
+        }
+# endif
+
+        const mbedtls_mpi N = { .s = 1,
+                                .n = sizeof(sig_block->block[i].key.n)/sizeof(mbedtls_mpi_uint),
+                                .p = (void *)sig_block->block[i].key.n,
+        };
+        const mbedtls_mpi e = { .s = 1,
+                                .n = sizeof(sig_block->block[i].key.e)/sizeof(mbedtls_mpi_uint), // 1
+                                .p = (void *)&sig_block->block[i].key.e,
+        };
+        /* Mbed TLS 2.x vs 3.x API differences */
+#if defined(MBEDTLS_VERSION_MAJOR) && (MBEDTLS_VERSION_MAJOR >= 3)
+        mbedtls_rsa_init(&p_mem->pk);
+        mbedtls_rsa_set_padding(&p_mem->pk, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+#else
+        mbedtls_rsa_init(&p_mem->pk, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+#endif
+        ret = mbedtls_rsa_import(&p_mem->pk, &N, NULL, NULL, NULL, &e);
+        if (ret != 0) {
+            ESP_LOGE(TAG, "Failed mbedtls_rsa_import, err: %d", ret);
+            goto exit;
+        }
+
+        ret = mbedtls_rsa_complete(&p_mem->pk);
+        if (ret != 0) {
+            ESP_LOGE(TAG, "Failed mbedtls_rsa_complete, err: %d", ret);
+            goto exit;
+        }
+
+        ret = mbedtls_rsa_check_pubkey(&p_mem->pk);
+        if (ret != 0) {
+            ESP_LOGI(TAG, "Key is not an RSA key -%0x", -ret);
+            goto exit;
+        }
+
+        /* Signature needs to be byte swapped into BE representation */
+        for (int j = 0; j < RSA_KEY_SIZE; j++) {
+            sig_be[RSA_KEY_SIZE- j - 1] = sig_block->block[i].signature[j];
+        }
+
+        ret = mbedtls_rsa_public( &p_mem->pk, sig_be, buf);
+        if (ret != 0) {
+            ESP_LOGE(TAG, "mbedtls_rsa_public failed, err: %d", ret);
+            goto exit;
+        }
+
+        /* Verify RSA-PSS signature: function signature changed in Mbed TLS 3.x */
+#if defined(MBEDTLS_VERSION_MAJOR) && (MBEDTLS_VERSION_MAJOR >= 3)
+        ret = mbedtls_rsa_rsassa_pss_verify(&p_mem->pk,
+                                            MBEDTLS_MD_SHA256,
+                                            DIGEST_LEN,
+                                            image_digest,
+                                            sig_be);
+#else
+        ret = mbedtls_rsa_rsassa_pss_verify(&p_mem->pk,
+                                            mbedtls_ctr_drbg_random,
+                                            &p_mem->ctr_drbg,
+                                            MBEDTLS_RSA_PUBLIC,
+                                            MBEDTLS_MD_SHA256,
+                                            DIGEST_LEN,
+                                            image_digest,
+                                            sig_be);
+#endif
+        if (ret != 0) {
+            ESP_LOGE(TAG, "Failed mbedtls_rsa_rsassa_pss_verify, err: %d", ret);
+        } else {
+            ESP_LOGI(TAG, "Signature verified successfully!");
+        }
+        exit:
+            mbedtls_rsa_free(&p_mem->pk);
+            if (ret == 0) {
+                break;
+            }
+    }
+    
+    free(sig_be);
+    free(buf);
+#if CONFIG_IDF_TARGET_ESP32
+    return (ret != 0) ? ESP_ERR_IMAGE_INVALID: ESP_OK;
+#elif CONFIG_IDF_TARGET_ESP32S2
+    return (ret != 0 || match == false) ? ESP_ERR_IMAGE_INVALID: ESP_OK;
+#endif /* CONFIG_IDF_TARGET_ESP32 */
+}
+
+esp_err_t esp_secure_boot_verify_rsa_signature_block(
+    const ets_secure_boot_signature_t *sig_block, const uint8_t *image_digest, uint8_t *verified_digest)
+{
+    verify_rsa_sig_block_mem_t* p_mem = calloc(1, sizeof(verify_rsa_sig_block_mem_t));
+    if (NULL == p_mem) {
+        return ESP_ERR_NO_MEM;
+    }
+    const esp_err_t res = esp_secure_boot_verify_rsa_signature_block_internal(sig_block, image_digest, verified_digest, p_mem);
+    free(p_mem);
+    return res;
+}
+#endif

--- a/components/bootloader_support/test/CMakeLists.txt
+++ b/components/bootloader_support/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRC_DIRS "."
+                    PRIV_INCLUDE_DIRS "."
+                    PRIV_REQUIRES unity bootloader_support app_update)

--- a/components/bootloader_support/test/component.mk
+++ b/components/bootloader_support/test/component.mk
@@ -1,0 +1,4 @@
+#
+#Component Makefile
+#
+COMPONENT_ADD_LDFLAGS = -Wl,--whole-archive -l$(COMPONENT_NAME) -Wl,--no-whole-archive

--- a/components/bootloader_support/test/test_verify_image.c
+++ b/components/bootloader_support/test/test_verify_image.c
@@ -1,0 +1,116 @@
+/*
+ * Tests for bootloader_support esp_load(ESP_IMAGE_VERIFY, ...)
+ */
+
+#include <esp_types.h>
+#include <stdio.h>
+#include "string.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "freertos/queue.h"
+#include "freertos/xtensa_api.h"
+#include "unity.h"
+#include "bootloader_common.h"
+#include "bootloader_util.h"
+#include "esp_partition.h"
+#include "esp_ota_ops.h"
+#include "esp_image_format.h"
+
+TEST_CASE("Verify bootloader image in flash", "[bootloader_support]")
+{
+    const esp_partition_pos_t fake_bootloader_partition = {
+        .offset = ESP_BOOTLOADER_OFFSET,
+        .size = ESP_PARTITION_TABLE_OFFSET - ESP_BOOTLOADER_OFFSET,
+    };
+    esp_image_metadata_t data = { 0 };
+    TEST_ASSERT_EQUAL_HEX(ESP_OK, esp_image_verify(ESP_IMAGE_VERIFY, &fake_bootloader_partition, &data));
+    TEST_ASSERT_NOT_EQUAL(0, data.image_len);
+
+    uint32_t bootloader_length = 0;
+    TEST_ASSERT_EQUAL_HEX(ESP_OK, esp_image_verify_bootloader(&bootloader_length));
+    TEST_ASSERT_EQUAL(data.image_len, bootloader_length);
+}
+
+#if !TEMPORARY_DISABLED_FOR_TARGETS(ESP32S2)
+TEST_CASE("Verify unit test app image", "[bootloader_support]")
+{
+    esp_image_metadata_t data = { 0 };
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    TEST_ASSERT_NOT_EQUAL(NULL, running);
+    const esp_partition_pos_t running_pos  = {
+        .offset = running->address,
+        .size = running->size,
+    };
+
+    TEST_ASSERT_EQUAL_HEX(ESP_OK, esp_image_verify(ESP_IMAGE_VERIFY, &running_pos, &data));
+    TEST_ASSERT_NOT_EQUAL(0, data.image_len);
+    TEST_ASSERT_TRUE(data.image_len <= running->size);
+}
+#endif
+
+void check_label_search (int num_test, const char *list, const char *t_label, bool result)
+{
+    // gen_esp32part.py trims up to 16 characters
+    // and the string may not have a null terminal symbol.
+    // below is cutting as it does the generator.
+    char label[16 + 1] = {0};
+    strncpy(label, t_label, sizeof(label) - 1);
+
+    bool ret = bootloader_common_label_search(list, label);
+    if (ret != result) {
+        printf("%d) %s  |  %s \n", num_test, list, label);
+    }
+    TEST_ASSERT_MESSAGE(ret == result, "Test failed");
+}
+
+TEST_CASE("Test label_search", "[bootloader_support]")
+{
+    TEST_ASSERT_FALSE(bootloader_common_label_search(NULL, NULL));
+    TEST_ASSERT_FALSE(bootloader_common_label_search("nvs", NULL));
+
+    check_label_search(1,   "nvs",                   "nvs",      true);
+    check_label_search(2,   "nvs, ",                 "nvs",      true);
+    check_label_search(3,   "nvs1",                  "nvs",      false);
+    check_label_search(3,   "nvs1, ",                "nvs",      false);
+    check_label_search(4,   "nvs1nvs1, phy",         "nvs1",     false);
+    check_label_search(5,   "nvs1, nvs1, phy",       "nvs1",     true);
+    check_label_search(6,   "nvs12, nvs12, phy",     "nvs1",     false);
+    check_label_search(7,   "nvs12, nvs1, phy",      "nvs1",     true);
+    check_label_search(8,   "nvs12, nvs3, phy, nvs1","nvs1",     true);
+    check_label_search(9,   "nvs1nvs1, phy, nvs",    "nvs",      true);
+    check_label_search(10,  "nvs1nvs1, phy, nvs1",   "nvs",      false);
+    check_label_search(11,  "nvs1,  nvs, phy, nvs1", "nvs",      true);
+    check_label_search(12,  "nvs1, nvs2,  phy,  nvs","nvs",      true);
+    check_label_search(13,  "ota_data, backup_nvs",  "nvs",      false);
+    check_label_search(14,  "nvs1, nvs2, ota, nvs",  "vs1",      false);
+
+    check_label_search(20,  "12345678901234, phy, nvs1",    "12345678901234",       true);
+    check_label_search(21,  "123456789012345, phy, nvs1",   "123456789012345",      true);
+    check_label_search(22,  "1234567890123456, phy, nvs1",  "1234567890123456",     true);
+    check_label_search(23,  "12345678901234567, phy, nvs1", "12345678901234567",    false);
+    check_label_search(24,  "1234567890123456, phy, nvs1",  "12345678901234567",    true);
+    check_label_search(25,  "phy, 1234567890123456, nvs1",  "12345678901234567",    true);
+
+}
+
+
+TEST_CASE("Test regions_overlap", "[bootloader_support]")
+{
+    TEST_ASSERT( bootloader_util_regions_overlap(1, 2, 1, 2) );
+
+    TEST_ASSERT( bootloader_util_regions_overlap(1, 2, 0, 2) );
+    TEST_ASSERT( bootloader_util_regions_overlap(1, 2, 1, 3) );
+    TEST_ASSERT( bootloader_util_regions_overlap(1, 2, 0, 3) );
+
+    TEST_ASSERT( bootloader_util_regions_overlap(0, 2, 1, 2) );
+    TEST_ASSERT( bootloader_util_regions_overlap(1, 3, 1, 2) );
+    TEST_ASSERT( bootloader_util_regions_overlap(0, 3, 1, 2) );
+
+    TEST_ASSERT( !bootloader_util_regions_overlap(2, 3, 1, 2) );
+    TEST_ASSERT( !bootloader_util_regions_overlap(1, 2, 2, 3) );
+
+    TEST_ASSERT( !bootloader_util_regions_overlap(3, 4, 1, 2) );
+    TEST_ASSERT( !bootloader_util_regions_overlap(1, 2, 3, 4) );
+}


### PR DESCRIPTION
## Summary

Back-port the patched `components/bootloader_support` from the `v1.17.x`
branch of `ruuvi.gateway_esp.c` into `v1.16.x`. The component is a fork
of the ESP-IDF v4.2.2 `components/bootloader_support` with a minimal,
targeted set of changes required by the Ruuvi Gateway firmware:

* enable signature verification of OTA images from non-bootloader
  (application) code,
* allow inclusion of `esp_app_format.h` from C++ translation units,
* avoid a stack overflow during RSA-PSS signature verification of OTA
  images, and
* stay source-compatible with Mbed TLS 3.x in addition to the 2.x API
  that ships with ESP-IDF v4.2.2.

The component is otherwise a verbatim copy of the upstream ESP-IDF
v4.2.2 sources, so the diff against upstream is intentionally small and
easy to audit.

## Motivation

Ruuvi Gateway verifies the digital signature of OTA images from
application code (see #1094 / #1103). The stock IDF v4.2.2
`bootloader_support` component:

1. Exposes `esp_secure_boot_verify_rsa_signature_block()` only through
   the *private* `include_bootloader` directory, which is not visible
   outside the bootloader build.
2. Allocates the entire RSA verification working set (key digests,
   `mbedtls_rsa_context`, entropy and DRBG contexts) on the stack —
   roughly several hundred bytes — which overflows the stack of the
   task that performs OTA verification on the gateway.
3. Uses the Mbed TLS 2.x API only, which makes it impossible to build
   against newer Mbed TLS releases.
4. Declares `esp_app_format.h` without `extern "C"` guards and uses
   `_Static_assert`, which prevents inclusion from C++ sources.

Forking the component is the least invasive way to address all four
issues without modifying the in-tree ESP-IDF and without disabling the
upstream's CI / signing tooling.

## Changes vs. ESP-IDF v4.2.2 baseline

Diff is limited to three files:

### `components/bootloader_support/CMakeLists.txt`

* `include` *and* `include_bootloader` are now registered as **public**
  include directories regardless of whether the component is built as
  part of the bootloader or the application. Upstream marks
  `include_bootloader` as `priv_include_dirs` for the application
  build, which hides
  `esp_secure_boot_verify_rsa_signature_block()` from OTA code.

### `components/bootloader_support/include/esp_app_format.h`

* Added `extern "C" { ... }` guards.
* Wrapped the three `_Static_assert` declarations in
  `#ifndef __cplusplus` so the header can be included from C++
  translation units (where `_Static_assert` is not a keyword in the
  same way and the assertions are not needed for the C++ side).

### `components/bootloader_support/src/idf/secure_boot_signatures.c`

* Introduced `verify_rsa_sig_block_mem_t`, a single structure that
  groups all sizeable working buffers used during signature
  verification:
  * per-block SHA-256 digests of the signature-block public keys,
  * the trusted digest read back from eFuse,
  * the all-zero comparison buffer,
  * the `mbedtls_rsa_context`,
  * the `mbedtls_entropy_context`, and
  * the `mbedtls_ctr_drbg_context`.
* The existing logic was refactored into a static
  `esp_secure_boot_verify_rsa_signature_block_internal()` worker that
  takes a pointer to this structure.
* The public
  `esp_secure_boot_verify_rsa_signature_block()` now `calloc()`s the
  structure, delegates to the worker, and `free()`s the memory on
  return. This moves the verification working set from the caller's
  stack to the heap and prevents stack overflows in tasks with small
  stacks (e.g. the OTA / HTTPS worker tasks).
* Added Mbed TLS 3.x compatibility, gated on
  `MBEDTLS_VERSION_MAJOR >= 3`:
  * `mbedtls_rsa_init()` is called with the new single-argument
    signature and padding is configured separately via
    `mbedtls_rsa_set_padding()`.
  * `mbedtls_rsa_rsassa_pss_verify()` is called with the
    Mbed TLS 3.x signature (no RNG callback, no `MBEDTLS_RSA_PUBLIC`
    mode argument).
* Added the necessary `#include "mbedtls/rsa.h"` and
  `#include "mbedtls/version.h"` for the version detection above.

No other files were modified. The full list of changed files can be
reproduced with:

```sh
diff -rqN \
    $IDF_PATH/components/bootloader_support \
    components/bootloader_support
```

against an unmodified ESP-IDF v4.2.2 checkout.

## Risk / impact

* **Bootloader image is unchanged.** All edits are either build-system
  scope (header visibility), C++-only guards, or in the IDF-side
  `src/idf/secure_boot_signatures.c` which is only compiled into the
  application, not the bootloader.
* **Secure-boot algorithm is unchanged.** The cryptographic operations
  performed (SHA-256 of the public keys, eFuse comparison, RSA-PSS
  verification) are bit-for-bit identical to upstream; only the
  storage of intermediate values moves from the stack to the heap.
* **Mbed TLS 3.x branches are dead code** when building against the
  Mbed TLS 2.x that ships with ESP-IDF v4.2.2, so behaviour on the
  shipping toolchain is unaffected.

## Testing

* Builds with `idf.py build` against ESP-IDF v4.2.2 (the toolchain
  used by `v1.16.x`).
* Signed OTA flow verified end-to-end on hardware (signature accepted
  for a correctly signed image, rejected for a tampered image, no
  stack-overflow panic on the verifying task).
* Diff against upstream ESP-IDF v4.2.2 contains only the three files
  listed above.

## Related

* Issue: #1309
* Source branch: `v1.17.x` (the patched component is copied verbatim
  from there).
* Earlier related work: #1094 / #1095 (signed OTA), #1102 / #1103
  (public-key digest comparison on OTA).
