### PR TITLE
ci(build-fw-prod): #1317 publish GitHub Release on tag push (v1.16.x)

### DIFF
--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -121,3 +121,52 @@ jobs:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
 
+  release:
+    name: Publish GitHub Release (prod)
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write   # create GitHub Release and upload assets
+      actions: read     # download workflow artifact from the build job
+    env:
+      TAG: ${{ github.ref_name }}
+    steps:
+      - name: Download firmware artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ruuvi_gateway_fw
+          path: release_files
+
+      - name: Create release and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -xe
+          command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
+          RELEASE_DIR="$GITHUB_WORKSPACE/release_files"
+          if [ ! -d "$RELEASE_DIR" ]; then
+            echo "Release files directory not found at $RELEASE_DIR"
+            exit 1
+          fi
+          # Collect all files from the downloaded artifact. upload-artifact
+          # flattens to the common ancestor of the input paths (here: build/),
+          # so subdirectories like binaries_v1.9.2/ and partition_table/ are
+          # preserved but file basenames remain unique across the asset set.
+          mapfile -t ASSETS < <(find "$RELEASE_DIR" -type f | sort)
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "No release files found under $RELEASE_DIR"
+            exit 1
+          fi
+          # Create the release if it does not already exist.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
+              echo "Create failed; rechecking..."
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+                echo "Release still missing; aborting."
+                exit 1
+              fi
+            fi
+          fi
+          gh release upload "$TAG" "${ASSETS[@]}" --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
Closes #1317

# Pull Request: Publish GitHub Release from prod firmware workflow on tag push (v1.16.x)

## Target branch

`v1.16.x` (maintenance branch for the outdated v1.16 firmware line).
**Not** intended to be merged into `master` — `master` already has its own,
zip-based release flow with separate dev and prod assets.

## Summary

Extend `.github/workflows/build-fw-prod.yml` so that pushing a git tag on
`v1.16.x` automatically creates a prerelease GitHub Release and uploads the
prod firmware binaries to it as individual files, matching the asset layout
used by previous v1.16.x releases (e.g.
[v1.16.2](https://github.com/ruuvi/ruuvi.gateway_esp.c/releases/tag/v1.16.2)).

## Motivation

On `v1.16.x`, tag pushes currently build the firmware but do not publish a
release; release assets have to be uploaded manually. Master automates this
already but ships **two zip archives** (one per dev/prod workflow). For
v1.16.x we only need the prod build and we want the historical flat-file
asset layout, so the master workflow cannot be reused verbatim.

## Changes

`.github/workflows/build-fw-prod.yml`:

- Added a new `release` job, gated by `if: startsWith(github.ref, 'refs/tags/')`
  and `needs: build`, with `permissions: contents: write` /
  `actions: read`.
- The job downloads the existing `ruuvi_gateway_fw` workflow artifact
  produced by the build job and uploads every file inside it to the GitHub
  Release for the pushed tag, using the `gh` CLI:
  - `gh release create "$TAG" --prerelease` if the release is missing
    (re-checked after a failed create to tolerate concurrent runs).
  - `gh release upload "$TAG" "${ASSETS[@]}" --clobber` for the files.
- No changes to the existing build job, file list (`RELEASE_FILES`), ESP-IDF
  setup, signing-key handling, or branch/tag triggers.

## Why reuse the build artifact instead of staging a separate one?

`actions/upload-artifact` flattens inputs to their common ancestor (`build/`
here), so the existing `ruuvi_gateway_fw` artifact already contains exactly
the files we want to publish — with unique basenames suitable for flat
release assets. A separate staging step / helper artifact would just
duplicate that content.

## Resulting release assets

Uploaded individually (no zip), matching v1.16.2:

- `ruuvi_gateway_esp.bin`
- `bootloader.bin`
- `partition-table.bin`
- `ota_data_initial.bin`
- `fatfs_nrf52.bin`
- `fatfs_gwui.bin`
- `gw_cfg_def.bin`

## Differences vs. `master`

| Aspect | `master` | `v1.16.x` (this PR) |
| --- | --- | --- |
| Release assets | Two zip archives (`...-dev_<tag>.zip`, `...-prod_<tag>.zip`) | Individual files, no zip |
| Source workflows | Both dev and prod publish to the release | Only prod publishes |
| Staging step | Builds a sanitized zip in a dedicated step | None — reuses `ruuvi_gateway_fw` artifact directly |

## Testing / verification

- Branch pushes to `v1.16.x` and manual `workflow_dispatch` runs: build job
  runs as before; the `release` job is skipped by its `if:` guard.
- Tag pushes: build job runs as before; `release` job downloads
  `ruuvi_gateway_fw`, creates the prerelease if missing, and uploads the seven
  binaries listed above with `--clobber` (idempotent on re-runs).
- `gh` CLI is preinstalled on `ubuntu-22.04` runners; `GITHUB_TOKEN` with
  `contents: write` is sufficient — no extra secrets required.

## Risk

Low. The build job is unchanged, so existing branch/dispatch builds behave
identically. New behaviour is fully gated by `startsWith(github.ref, 'refs/tags/')`
and only adds release assets — it never deletes a release.

## Out of scope

- Any changes to `master` workflows.
- Adding release publishing to the dev workflow on `v1.16.x`.
- Generating release notes / changelogs (release is created with a fixed
  `"Automated release"` body, same as master).

