### PR TITLE
Close #1319: Harden Secure Boot signature handling and CI signing-key validation

### DIFF
--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -96,6 +96,10 @@ jobs:
           SECURE_BOOT_SIGNING_KEY: ${{ secrets.SECURE_BOOT_SIGNING_KEY }}
         run: |
           set +x # do not echo secrets
+          if [ -z "$SECURE_BOOT_SIGNING_KEY" ]; then
+            echo "SECURE_BOOT_SIGNING_KEY is not set"
+            exit 1
+          fi
           mkdir -p ~/.signing_keys
           install -m 600 /dev/null ~/.signing_keys/secure_boot_signing_key.pem
           printf "%s" "$SECURE_BOOT_SIGNING_KEY" > ~/.signing_keys/secure_boot_signing_key.pem

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -93,6 +93,10 @@ jobs:
           SECURE_BOOT_SIGNING_KEY: ${{ secrets.SECURE_BOOT_SIGNING_KEY }}
         run: |
           set +x # do not echo secrets
+          if [ -z "$SECURE_BOOT_SIGNING_KEY" ]; then
+            echo "SECURE_BOOT_SIGNING_KEY is not set"
+            exit 1
+          fi
           mkdir -p ~/.signing_keys
           install -m 600 /dev/null ~/.signing_keys/secure_boot_signing_key.pem
           printf "%s" "$SECURE_BOOT_SIGNING_KEY" > ~/.signing_keys/secure_boot_signing_key.pem

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -84,6 +84,10 @@ jobs:
           SECURE_BOOT_SIGNING_KEY: ${{ secrets.SECURE_BOOT_SIGNING_KEY }}
         run: |
           set +x # do not echo secrets
+          if [ -z "$SECURE_BOOT_SIGNING_KEY" ]; then
+            echo "SECURE_BOOT_SIGNING_KEY is not set"
+            exit 1
+          fi
           mkdir -p ~/.signing_keys
           install -m 600 /dev/null ~/.signing_keys/secure_boot_signing_key.pem
           printf "%s" "$SECURE_BOOT_SIGNING_KEY" > ~/.signing_keys/secure_boot_signing_key.pem
@@ -113,7 +117,7 @@ jobs:
           cd ../..
           gcovr -r . --sonarqube -o coverage.xml
 
-      - name: SonarQube Scan
+      - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/components/fatfs_gwui/CMakeLists.txt
+++ b/components/fatfs_gwui/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 if(NOT BOOTLOADER_BUILD AND CONFIG_SECURE_SIGNED_APPS AND CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES)
     add_custom_command(
             OUTPUT "${build_dir}/.signed_gwui_timestamp" "${GWUI_SIGNED}"
-            COMMAND ${ESPSECUREPY} sign_data --version ${secure_boot_version} --keyfile ${secure_boot_signing_key}
+            COMMAND ${ESPSECUREPY} sign_data --version ${secure_boot_version} --keyfile "${secure_boot_signing_key}"
             -o "${GWUI_SIGNED}" "${GWUI_UNSIGNED}"
             COMMAND ${CMAKE_COMMAND} -E echo "Generated signed binary image ${GWUI_SIGNED} from ${GWUI_UNSIGNED}"
             COMMAND ${CMAKE_COMMAND} -E md5sum "${GWUI_SIGNED}" > "${build_dir}/.signed_gwui_timestamp"

--- a/components/fatfs_nrf52/CMakeLists.txt
+++ b/components/fatfs_nrf52/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 if(NOT BOOTLOADER_BUILD AND CONFIG_SECURE_SIGNED_APPS AND CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES)
     add_custom_command(
             OUTPUT "${build_dir}/.signed_nrf52fw_timestamp" "${NRF52_SIGNED}"
-            COMMAND ${ESPSECUREPY} sign_data --version ${secure_boot_version} --keyfile ${secure_boot_signing_key}
+            COMMAND ${ESPSECUREPY} sign_data --version ${secure_boot_version} --keyfile "${secure_boot_signing_key}"
             -o "${NRF52_SIGNED}" "${NRF52_UNSIGNED}"
             COMMAND ${CMAKE_COMMAND} -E echo "Generated signed binary image ${NRF52_SIGNED} from ${NRF52_UNSIGNED}"
             COMMAND ${CMAKE_COMMAND} -E md5sum "${NRF52_SIGNED}" > "${build_dir}/.signed_nrf52fw_timestamp"

--- a/main/esp_ota_helpers.c
+++ b/main/esp_ota_helpers.c
@@ -212,6 +212,11 @@ esp_ota_helper_calc_pub_key_digest_for_signature_in_flash(
     const ets_secure_boot_signature_t* const p_sig_block = bootloader_mmap(
         signature_addr,
         sizeof(ets_secure_boot_signature_t));
+    if (NULL == p_sig_block)
+    {
+        LOG_ERR("bootloader_mmap failed for address 0x%08x", signature_addr);
+        return false;
+    }
     LOG_DUMP_DBG(
         (void*)&p_sig_block->block[0].key,
         sizeof(p_sig_block->block[0].key),

--- a/main/fw_update.c
+++ b/main/fw_update.c
@@ -407,6 +407,13 @@ fw_update_self_check_signature(ruuvi_flash_info_t* const p_flash_info)
     assert(
         ((uintptr_t)fatfs_gwui_signature_end - (uintptr_t)fatfs_gwui_signature_start)
         == sizeof(ets_secure_boot_signature_t));
+    if (((uintptr_t)fatfs_gwui_signature_end - (uintptr_t)fatfs_gwui_signature_start)
+        != sizeof(ets_secure_boot_signature_t))
+    {
+        LOG_ERR("Invalid size of embedded signature for fatfs_gwui partition");
+        gateway_restart("Invalid size of embedded signature for fatfs_gwui partition");
+        return false;
+    }
 
     if (!fw_update_check_fatfs_partition_signature(
             p_flash_info->p_cur_fatfs_gwui_partition,
@@ -431,6 +438,13 @@ fw_update_self_check_signature(ruuvi_flash_info_t* const p_flash_info)
     assert(
         ((uintptr_t)fatfs_nrf52_signature_end - (uintptr_t)fatfs_nrf52_signature_start)
         == sizeof(ets_secure_boot_signature_t));
+    if (((uintptr_t)fatfs_nrf52_signature_end - (uintptr_t)fatfs_nrf52_signature_start)
+        != sizeof(ets_secure_boot_signature_t))
+    {
+        LOG_ERR("Invalid size of embedded signature for fatfs_nrf52 partition");
+        gateway_restart("Invalid size of embedded signature for fatfs_nrf52 partition");
+        return false;
+    }
 
     if (!fw_update_check_fatfs_partition_signature(
             p_flash_info->p_cur_fatfs_nrf52_partition,

--- a/tests/test_adv_post_async_comm/include/esp32/rom/secure_boot.h
+++ b/tests/test_adv_post_async_comm/include/esp32/rom/secure_boot.h
@@ -18,6 +18,7 @@
 #define _ROM_SECURE_BOOT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/test_adv_post_signals/include/esp32/rom/secure_boot.h
+++ b/tests/test_adv_post_signals/include/esp32/rom/secure_boot.h
@@ -18,6 +18,7 @@
 #define _ROM_SECURE_BOOT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/test_adv_post_statistics/include/esp32/rom/secure_boot.h
+++ b/tests/test_adv_post_statistics/include/esp32/rom/secure_boot.h
@@ -18,6 +18,7 @@
 #define _ROM_SECURE_BOOT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/test_adv_post_task/include/esp32/rom/secure_boot.h
+++ b/tests/test_adv_post_task/include/esp32/rom/secure_boot.h
@@ -18,6 +18,7 @@
 #define _ROM_SECURE_BOOT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/test_http_json/include/esp32/rom/secure_boot.h
+++ b/tests/test_http_json/include/esp32/rom/secure_boot.h
@@ -18,6 +18,7 @@
 #define _ROM_SECURE_BOOT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/test_http_server_cb/include/esp32/rom/secure_boot.h
+++ b/tests/test_http_server_cb/include/esp32/rom/secure_boot.h
@@ -18,6 +18,7 @@
 #define _ROM_SECURE_BOOT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
> Forward-port from `v1.16.x` (issue #1309) to `v1.17.x`. Tracked on this
> branch as issue #1319.

## Summary

Strengthens the Secure Boot signing/verification flow and protects CI
from silently building unsigned artifacts.

## Motivation

While preparing signed builds on the `v1.17.x` line, several latent
issues were uncovered:

- `bootloader_mmap()` failures during OTA signature validation were not
  handled and could lead to a `NULL` dereference.
- The embedded `fatfs_gwui` / `fatfs_nrf52` signature blob size was only
  checked with `assert()`, so release builds (`NDEBUG`) would silently
  continue with a corrupt signature.
- The `espsecure.py sign_data --keyfile <path>` invocation was unquoted
  in CMake, breaking signing when the key path contains spaces.
- CI workflows would happily run without the `SECURE_BOOT_SIGNING_KEY`
  secret and produce unsigned artifacts that look like normal builds.

## Changes

### Runtime (OTA / fw_update)
- `main/esp_ota_helpers.c`:
  `esp_ota_helper_calc_pub_key_digest_for_signature_in_flash()` now logs
  an error and returns `false` when `bootloader_mmap()` returns `NULL`,
  instead of dereferencing it.
- `main/fw_update.c`:
  `fw_update_self_check_signature()` adds runtime size checks for the
  embedded `fatfs_gwui` and `fatfs_nrf52` signature blobs (previously
  only `assert()`-guarded). On mismatch it logs the error and triggers
  `gateway_restart()` instead of continuing with a corrupt signature.

### Build
- `components/fatfs_gwui/CMakeLists.txt`,
  `components/fatfs_nrf52/CMakeLists.txt`:
  quote `${secure_boot_signing_key}` in the
  `espsecure.py sign_data --keyfile` invocation so paths containing
  spaces work correctly.

### CI
- `.github/workflows/build-fw-dev.yml`,
  `.github/workflows/build-fw-prod.yml`:
  fail fast if the `SECURE_BOOT_SIGNING_KEY` secret is missing,
  preventing silent fallback to unsigned builds.

### Tests
- `tests/test_adv_post_async_comm/include/esp32/rom/secure_boot.h`,
  `tests/test_adv_post_signals/.../secure_boot.h`,
  `tests/test_adv_post_statistics/.../secure_boot.h`,
  `tests/test_adv_post_task/.../secure_boot.h`,
  `tests/test_http_json/.../secure_boot.h`,
  `tests/test_http_server_cb/.../secure_boot.h`:
  add `#include <stdbool.h>` so the per-test ROM shim headers compile
  after the secure-boot-related header changes.

## Commits (squashed on merge)

- `b30f45fa` fix(ota): handle bootloader_mmap failure in signature validation
- `2207292d` fix(ota): add runtime validation for embedded signature sizes
- `5f913975` fix(fatfs): wrap signing keyfile path in quotes for gwui and nrf52 components
- `76971479` ci(workflows): add validation for SECURE_BOOT_SIGNING_KEY in build jobs
- `ba48468d` fix(tests): include `<stdbool.h>` in secure boot headers

## Related

- Closes #1319.
- Forward-port of #1309 on the `v1.16.x` branch.

