### PR TITLE
ci(workflows): #1321 support versioned release branches in build-fw-prod and build-fw-dev

### DIFF
--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -2,7 +2,9 @@ name: Build Firmware (dev)
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'v[0-9]*.[0-9]*.x'
     tags: [ '*' ]
   pull_request:
     branches: [ '*' ]

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -2,7 +2,9 @@ name: Build Firmware (prod)
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'v[0-9]*.[0-9]*.x'
     tags: [ '*' ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Closes #1321

> Forward-port from `v1.16.x` to `v1.17.x`. Filed as a new issue/PR on
> this branch.

## Summary

Extend the `build-fw-prod` and `build-fw-dev` GitHub Actions workflow so 
production firmware builds are produced for versioned release 
branches (e.g. `v1.16.x`, `v1.17.x`), not only for `master` and tags.

## Motivation

On the `v1.17.x` (and other long-lived release) branches, pushes currently
do not trigger the build workflow, so we cannot easily produce
official signed artifacts from a release-line branch without tagging.
The branch-name pattern in `build-fw-prod.yml` and  `build-fw-dev.yml` did not match the
`v<major>.<minor>.x` convention used for release branches.

## Changes

- `.github/workflows/build-fw-prod.yml` and `.github/workflows/build-fw-dev.yml`:
  add/adjust the `on.push.branches` pattern so `v*.*.x` release branches
  trigger the production build job, and fix the branch-pattern glob so
  versioned releases are picked up reliably.

## Acceptance criteria

- Pushing to `v1.17.x` (and similar versioned release branches) triggers
  the `build-fw-prod` and `build-fw-dev` workflows.
- Pushes to feature branches still do **not** trigger it.
- `master` and tag-based triggers continue to work as before.

## Related

- Forward-port of work originally tracked under issue #1309 on the
  `v1.16.x` branch.
