### PR TITLE
fix(fatfs): close #1326 mount fatfs partitions as raw or wear-leveled FAT to support downgrade to v1.16.3

### DIFF
--- a/main/flashfatfs.c
+++ b/main/flashfatfs.c
@@ -28,8 +28,10 @@ static const char TAG[] = "FlashFatFS";
 
 struct flash_fat_fs_t
 {
-    char* mount_point;
-    char* partition_label;
+    char*       mount_point;
+    wl_handle_t wl_handle;
+    char*       partition_label;
+    bool        flag_use_raw_flash;
 };
 
 const flash_fat_fs_t*
@@ -42,7 +44,7 @@ flashfatfs_mount(const char* mount_point, const char* partition_label, const fla
     size_t mount_point_buf_size     = strlen(mount_point_prefix) + strlen(mount_point) + 1;
     size_t partition_label_buf_size = strlen(partition_label) + 1;
 
-    LOG_INFO("Mount partition '%s' to the mount point %s", partition_label, mount_point);
+    LOG_INFO("Mount partition '%s' as FATFS (raw flash) to the mount point %s", partition_label, mount_point);
     flash_fat_fs_t* p_obj = os_calloc(1, sizeof(*p_obj) + mount_point_buf_size + partition_label_buf_size);
     if (NULL == p_obj)
     {
@@ -54,17 +56,34 @@ flashfatfs_mount(const char* mount_point, const char* partition_label, const fla
     p_obj->partition_label = p_obj->mount_point + mount_point_buf_size;
     snprintf(p_obj->partition_label, partition_label_buf_size, "%s", partition_label);
 
-    esp_vfs_fat_mount_config_t mount_config = {
+    p_obj->flag_use_raw_flash = true;
+
+    const esp_vfs_fat_mount_config_t mount_config = {
         .format_if_mount_failed = false,
         .max_files              = max_files,
         .allocation_unit_size   = 512U,
     };
-    const esp_err_t err = esp_vfs_fat_rawflash_mount(p_obj->mount_point, p_obj->partition_label, &mount_config);
+    esp_err_t err = esp_vfs_fat_rawflash_mount(p_obj->mount_point, p_obj->partition_label, &mount_config);
     if (ESP_OK != err)
     {
+        p_obj->flag_use_raw_flash = false;
         LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_rawflash_mount");
-        os_free(p_obj);
-        return NULL;
+        LOG_WARN(
+            "Try to mount partition '%s' as FATFS (SPI-Flash) to the mount point %s",
+            partition_label,
+            mount_point);
+        const esp_vfs_fat_sdmmc_mount_config_t mount_config_spiflash = {
+            .format_if_mount_failed = false,
+            .max_files              = max_files,
+            .allocation_unit_size   = 512U,
+        };
+        err = esp_vfs_fat_spiflash_mount(mount_point, partition_label, &mount_config_spiflash, &p_obj->wl_handle);
+        if (ESP_OK != err)
+        {
+            LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_spiflash_mount");
+            os_free(p_obj);
+            return NULL;
+        }
     }
     LOG_INFO("Partition '%s' mounted successfully to %s", partition_label, mount_point);
     return p_obj;
@@ -75,12 +94,27 @@ flashfatfs_unmount(const flash_fat_fs_t** pp_ffs)
 {
     const flash_fat_fs_t* p_ffs = *pp_ffs;
     LOG_INFO("Unmount %s", p_ffs->mount_point);
-    const esp_err_t err = esp_vfs_fat_rawflash_unmount(p_ffs->mount_point, p_ffs->partition_label);
+    esp_err_t err = ESP_FAIL;
+    if (p_ffs->flag_use_raw_flash)
+    {
+        err = esp_vfs_fat_rawflash_unmount(p_ffs->mount_point, p_ffs->partition_label);
+        if (ESP_OK != err)
+        {
+            LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_rawflash_unmount");
+        }
+    }
+    else
+    {
+        err = esp_vfs_fat_spiflash_unmount(p_ffs->mount_point, p_ffs->wl_handle);
+        if (ESP_OK != err)
+        {
+            LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_spiflash_unmount");
+        }
+    }
     os_free(p_ffs);
     *pp_ffs = NULL;
     if (ESP_OK != err)
     {
-        LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_rawflash_unmount");
         return false;
     }
     return true;

--- a/main/flashfatfs.c
+++ b/main/flashfatfs.c
@@ -72,16 +72,7 @@ flashfatfs_mount(const char* mount_point, const char* partition_label, const fla
             "Try to mount partition '%s' as FATFS (SPI-Flash) to the mount point %s",
             p_obj->partition_label,
             p_obj->mount_point);
-        const esp_vfs_fat_sdmmc_mount_config_t mount_config_spiflash = {
-            .format_if_mount_failed = false,
-            .max_files              = max_files,
-            .allocation_unit_size   = 512U,
-        };
-        err = esp_vfs_fat_spiflash_mount(
-            p_obj->mount_point,
-            p_obj->partition_label,
-            &mount_config_spiflash,
-            &p_obj->wl_handle);
+        err = esp_vfs_fat_spiflash_mount(p_obj->mount_point, p_obj->partition_label, &mount_config, &p_obj->wl_handle);
         if (ESP_OK != err)
         {
             LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_spiflash_mount");

--- a/main/flashfatfs.c
+++ b/main/flashfatfs.c
@@ -70,14 +70,18 @@ flashfatfs_mount(const char* mount_point, const char* partition_label, const fla
         LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_rawflash_mount");
         LOG_WARN(
             "Try to mount partition '%s' as FATFS (SPI-Flash) to the mount point %s",
-            partition_label,
-            mount_point);
+            p_obj->partition_label,
+            p_obj->mount_point);
         const esp_vfs_fat_sdmmc_mount_config_t mount_config_spiflash = {
             .format_if_mount_failed = false,
             .max_files              = max_files,
             .allocation_unit_size   = 512U,
         };
-        err = esp_vfs_fat_spiflash_mount(mount_point, partition_label, &mount_config_spiflash, &p_obj->wl_handle);
+        err = esp_vfs_fat_spiflash_mount(
+            p_obj->mount_point,
+            p_obj->partition_label,
+            &mount_config_spiflash,
+            &p_obj->wl_handle);
         if (ESP_OK != err)
         {
             LOG_ERR_ESP(err, "%s failed", "esp_vfs_fat_spiflash_mount");

--- a/tests/test_flashfatfs/include/esp_vfs_fat.h
+++ b/tests/test_flashfatfs/include/esp_vfs_fat.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <stddef.h>
 #include "esp_err.h"
+#include "wear_levelling.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -174,14 +175,12 @@ esp_err_t esp_vfs_fat_sdmmc_unmount();
  *      - ESP_FAIL if partition can not be mounted
  *      - other error codes from wear levelling library, SPI flash driver, or FATFS drivers
  */
-#if 0
 esp_err_t
 esp_vfs_fat_spiflash_mount(
     const char*                       base_path,
     const char*                       partition_label,
     const esp_vfs_fat_mount_config_t* mount_config,
     wl_handle_t*                      wl_handle);
-#endif
 
 /**
  * @brief Unmount FAT filesystem and release resources acquired using esp_vfs_fat_spiflash_mount
@@ -193,10 +192,8 @@ esp_vfs_fat_spiflash_mount(
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_spiflash_mount hasn't been called
  */
-#if 0
 esp_err_t
 esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle);
-#endif
 
 /**
  * @brief Convenience function to initialize read-only FAT filesystem and register it in VFS

--- a/tests/test_flashfatfs/include/wear_levelling.h
+++ b/tests/test_flashfatfs/include/wear_levelling.h
@@ -1,0 +1,35 @@
+// Copyright 2015-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _wear_levelling_H_
+#define _wear_levelling_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief wear levelling handle
+ */
+typedef int32_t wl_handle_t;
+
+#define WL_INVALID_HANDLE -1
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // _wear_levelling_H_

--- a/tests/test_flashfatfs/test_flashfatfs.cpp
+++ b/tests/test_flashfatfs/test_flashfatfs.cpp
@@ -22,7 +22,8 @@ using namespace std;
 
 struct flash_fat_fs_t
 {
-    char* mount_point;
+    char*       mount_point;
+    wl_handle_t wl_handle;
 };
 
 class TestFlashFatFs;
@@ -33,10 +34,13 @@ class FlashFatFs_VFS_FAT_MountInfo
 public:
     string                     base_path;
     string                     partition_label;
-    esp_vfs_fat_mount_config_t mount_config = {};
-    bool                       flag_mounted = false;
-    esp_err_t                  mount_err    = ESP_OK;
-    esp_err_t                  unmount_err  = ESP_OK;
+    esp_vfs_fat_mount_config_t mount_config    = {};
+    bool                       flag_mounted    = false;
+    esp_err_t                  mount_err       = ESP_OK;
+    esp_err_t                  unmount_err     = ESP_OK;
+    wl_handle_t                wl_handle       = 0;
+    esp_err_t                  mount_raw_err   = ESP_OK;
+    esp_err_t                  unmount_raw_err = ESP_OK;
 };
 
 class MemAllocTrace
@@ -127,11 +131,14 @@ protected:
         esp_log_wrapper_init();
         g_pTestClass = this;
 
-        this->m_malloc_cnt              = 0;
-        this->m_malloc_fail_on_cnt      = 0;
-        this->m_mount_info.flag_mounted = false;
-        this->m_mount_info.mount_err    = ESP_OK;
-        this->m_mount_info.unmount_err  = ESP_OK;
+        this->m_malloc_cnt                 = 0;
+        this->m_malloc_fail_on_cnt         = 0;
+        this->m_mount_info.flag_mounted    = false;
+        this->m_mount_info.mount_err       = ESP_OK;
+        this->m_mount_info.unmount_err     = ESP_OK;
+        this->m_mount_info.wl_handle       = 0;
+        this->m_mount_info.mount_raw_err   = ESP_OK;
+        this->m_mount_info.unmount_raw_err = ESP_OK;
     }
 
     void
@@ -236,8 +243,11 @@ esp_vfs_fat_rawflash_mount(
     g_pTestClass->m_mount_info.base_path       = string(base_path);
     g_pTestClass->m_mount_info.partition_label = string(partition_label);
     g_pTestClass->m_mount_info.mount_config    = *mount_config;
-    g_pTestClass->m_mount_info.flag_mounted    = true;
-    return g_pTestClass->m_mount_info.mount_err;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_raw_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
+    return g_pTestClass->m_mount_info.mount_raw_err;
 }
 
 esp_err_t
@@ -245,6 +255,34 @@ esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label)
 {
     assert(nullptr != g_pTestClass);
     assert(g_pTestClass->m_mount_info.flag_mounted);
+    g_pTestClass->m_mount_info.flag_mounted = false;
+    return g_pTestClass->m_mount_info.unmount_raw_err;
+}
+
+esp_err_t
+esp_vfs_fat_spiflash_mount(
+    const char*                       base_path,
+    const char*                       partition_label,
+    const esp_vfs_fat_mount_config_t* mount_config,
+    wl_handle_t*                      wl_handle)
+{
+    g_pTestClass->m_mount_info.base_path       = string(base_path);
+    g_pTestClass->m_mount_info.partition_label = string(partition_label);
+    g_pTestClass->m_mount_info.mount_config    = *mount_config;
+    *wl_handle                                 = g_pTestClass->m_mount_info.wl_handle;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
+    return g_pTestClass->m_mount_info.mount_err;
+}
+
+esp_err_t
+esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle)
+{
+    assert(nullptr != g_pTestClass);
+    assert(g_pTestClass->m_mount_info.flag_mounted);
+    assert(g_pTestClass->m_mount_info.wl_handle == wl_handle);
     g_pTestClass->m_mount_info.flag_mounted = false;
     return g_pTestClass->m_mount_info.unmount_err;
 }
@@ -274,7 +312,9 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_rel_path) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -299,7 +339,9 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_abs_path) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -314,11 +356,13 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_ok_unmount_failed) // NOLINT
 
     ASSERT_NE(nullptr, this->m_p_ffs);
 
-    this->m_mount_info.unmount_err = ESP_ERR_NOT_SUPPORTED;
+    this->m_mount_info.unmount_raw_err = ESP_ERR_NOT_SUPPORTED;
     ASSERT_FALSE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_unmount failed, err=262 (Unknown error 262)");
@@ -333,21 +377,93 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_failed_no_mem) // NOLINT
     this->m_p_ffs              = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files);
     ASSERT_EQ(nullptr, this->m_p_ffs);
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't allocate memory");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
 }
 
-TEST_F(TestFlashFatFs, flashfatfs_mount_failed_on_rawflash_mount) // NOLINT
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_failed_fallback_to_spiflash_ok) // NOLINT
 {
-    const int max_files          = 1;
-    this->m_mount_info.mount_err = ESP_ERR_NOT_FOUND;
-    this->m_p_ffs                = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files);
+    const wl_handle_t wl_handle      = 25;
+    const int         max_files      = 1;
+    this->m_mount_info.wl_handle     = wl_handle;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+
+    ASSERT_NE(nullptr, this->m_p_ffs);
+    ASSERT_EQ(string("fs_nrf52"), string(this->m_p_ffs->mount_point));
+    ASSERT_EQ(wl_handle, this->m_p_ffs->wl_handle);
+    ASSERT_TRUE(this->m_mount_info.flag_mounted);
+    ASSERT_EQ("fs_nrf52", this->m_mount_info.base_path);
+    ASSERT_EQ(GW_NRF_PARTITION, this->m_mount_info.partition_label);
+    ASSERT_FALSE(this->m_mount_info.mount_config.format_if_mount_failed);
+    ASSERT_EQ(max_files, this->m_mount_info.mount_config.max_files);
+    ASSERT_EQ(512U, this->m_mount_info.mount_config.allocation_unit_size);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_WARN,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_failed_fallback_to_spiflash_unmount_failed) // NOLINT
+{
+    const wl_handle_t wl_handle      = 25;
+    const int         max_files      = 1;
+    this->m_mount_info.wl_handle     = wl_handle;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+
+    this->m_mount_info.unmount_err = ESP_ERR_NOT_SUPPORTED;
+    ASSERT_FALSE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_WARN,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_unmount failed, err=262 (Unknown error 262)");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_failed_on_both_rawflash_and_spiflash_mount) // NOLINT
+{
+    const int max_files              = 1;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+    this->m_mount_info.mount_err     = ESP_ERR_NO_MEM;
+    this->m_p_ffs                    = flashfatfs_mount(this->m_mount_point, GW_NRF_PARTITION, max_files);
     ASSERT_EQ(nullptr, this->m_p_ffs);
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_WARN,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=257 (Unknown error 257)");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
 }
@@ -435,7 +551,9 @@ TEST_F(TestFlashFatFs, flashfatfs_open_ok) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -457,7 +575,9 @@ TEST_F(TestFlashFatFs, flashfatfs_open_failed) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't open: fs_nrf52/test1.txt");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
@@ -500,7 +620,9 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_ascii_ok) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -542,7 +664,9 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_binary_ok) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -565,7 +689,9 @@ TEST_F(TestFlashFatFs, flashfatfs_fopen_failed) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Can't open: fs_nrf52/test1.txt");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
@@ -598,7 +724,9 @@ TEST_F(TestFlashFatFs, flashfatfs_stat_ok) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -620,7 +748,9 @@ TEST_F(TestFlashFatFs, flashfatfs_stat_failed) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -652,7 +782,9 @@ TEST_F(TestFlashFatFs, flashfatfs_get_file_size_ok) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -674,7 +806,9 @@ TEST_F(TestFlashFatFs, flashfatfs_get_file_size_failed) // NOLINT
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());

--- a/tests/test_flashfatfs/test_flashfatfs.cpp
+++ b/tests/test_flashfatfs/test_flashfatfs.cpp
@@ -464,7 +464,7 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_failed_on_both_rawflash_and_spiflash_mou
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
     TEST_CHECK_LOG_RECORD(
         ESP_LOG_WARN,
-        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point ./fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=257 (Unknown error 257)");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
@@ -483,9 +483,9 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_raw_failed_fallback_to_spiflash_ok_abs_p
     ASSERT_EQ(string("./fs_nrf52"), string(this->m_p_ffs->mount_point));
     ASSERT_EQ(wl_handle, this->m_p_ffs->wl_handle);
     ASSERT_TRUE(this->m_mount_info.flag_mounted);
-    // The SPI-Flash fallback is mounted using the original (non-prefixed) mount point,
-    // unlike the raw-flash attempt which uses the './'-prefixed copy in the test build.
-    ASSERT_EQ("/fs_nrf52", this->m_mount_info.base_path);
+    // The SPI-Flash fallback is mounted using the same stored/prefixed mount point as the
+    // raw-flash attempt and the later unmount, so the base path stays consistent.
+    ASSERT_EQ("./fs_nrf52", this->m_mount_info.base_path);
     ASSERT_EQ(GW_NRF_PARTITION, this->m_mount_info.partition_label);
     ASSERT_FALSE(this->m_mount_info.mount_config.format_if_mount_failed);
     ASSERT_EQ(max_files, this->m_mount_info.mount_config.max_files);
@@ -500,7 +500,7 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_raw_failed_fallback_to_spiflash_ok_abs_p
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
     TEST_CHECK_LOG_RECORD(
         ESP_LOG_WARN,
-        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point ./fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());

--- a/tests/test_flashfatfs/test_flashfatfs.cpp
+++ b/tests/test_flashfatfs/test_flashfatfs.cpp
@@ -24,6 +24,8 @@ struct flash_fat_fs_t
 {
     char*       mount_point;
     wl_handle_t wl_handle;
+    char*       partition_label;
+    bool        flag_use_raw_flash;
 };
 
 class TestFlashFatFs;
@@ -464,6 +466,95 @@ TEST_F(TestFlashFatFs, flashfatfs_mount_failed_on_both_rawflash_and_spiflash_mou
         ESP_LOG_WARN,
         "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=257 (Unknown error 257)");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_mount_raw_failed_fallback_to_spiflash_ok_abs_path) // NOLINT
+{
+    const wl_handle_t wl_handle      = 25;
+    const int         max_files      = 1;
+    this->m_mount_info.wl_handle     = wl_handle;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+
+    this->m_p_ffs = flashfatfs_mount("/fs_nrf52", GW_NRF_PARTITION, max_files);
+
+    ASSERT_NE(nullptr, this->m_p_ffs);
+    ASSERT_EQ(string("./fs_nrf52"), string(this->m_p_ffs->mount_point));
+    ASSERT_EQ(wl_handle, this->m_p_ffs->wl_handle);
+    ASSERT_TRUE(this->m_mount_info.flag_mounted);
+    // The SPI-Flash fallback is mounted using the original (non-prefixed) mount point,
+    // unlike the raw-flash attempt which uses the './'-prefixed copy in the test build.
+    ASSERT_EQ("/fs_nrf52", this->m_mount_info.base_path);
+    ASSERT_EQ(GW_NRF_PARTITION, this->m_mount_info.partition_label);
+    ASSERT_FALSE(this->m_mount_info.mount_config.format_if_mount_failed);
+    ASSERT_EQ(max_files, this->m_mount_info.mount_config.max_files);
+    ASSERT_EQ(512U, this->m_mount_info.mount_config.allocation_unit_size);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_WARN,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount ./fs_nrf52");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestFlashFatFs, flashfatfs_open_ok_after_fallback_to_spiflash) // NOLINT
+{
+    const wl_handle_t wl_handle      = 25;
+    const int         max_files      = 1;
+    this->m_mount_info.wl_handle     = wl_handle;
+    this->m_mount_info.mount_raw_err = ESP_ERR_NOT_FOUND;
+
+    const char* test_file_name = "test1.txt";
+    const char* test_text      = "test123\n";
+    {
+        char tmp_file_path[80];
+        snprintf(tmp_file_path, sizeof(tmp_file_path), "%s/%s", this->m_mount_point_dir, test_file_name);
+        FILE* fd = fopen(tmp_file_path, "w");
+        ASSERT_NE(nullptr, fd);
+        fprintf(fd, "%s", test_text);
+        fclose(fd);
+    }
+
+    this->m_p_ffs = flashfatfs_mount("fs_nrf52", GW_NRF_PARTITION, max_files);
+    ASSERT_NE(nullptr, this->m_p_ffs);
+    ASSERT_FALSE(this->m_p_ffs->flag_use_raw_flash);
+    ASSERT_EQ(wl_handle, this->m_p_ffs->wl_handle);
+
+    file_descriptor_t fd = flashfatfs_open(this->m_p_ffs, test_file_name);
+    ASSERT_GE(fd, 0);
+
+    {
+        char      buf[80];
+        const int len = read(fd, buf, sizeof(buf));
+        ASSERT_EQ(8, len);
+        buf[len] = '\0';
+        ASSERT_EQ(string(test_text), string(buf));
+    }
+
+    close(fd);
+
+    ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
+    this->m_p_ffs = nullptr;
+
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (Unknown error 261)");
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_WARN,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to fs_nrf52");
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Unmount fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
     ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
 }

--- a/tests/test_nrf52fw/include/esp_vfs_fat.h
+++ b/tests/test_nrf52fw/include/esp_vfs_fat.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <stddef.h>
 #include "esp_err.h"
+#include "wear_levelling.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -174,14 +175,12 @@ esp_err_t esp_vfs_fat_sdmmc_unmount();
  *      - ESP_FAIL if partition can not be mounted
  *      - other error codes from wear levelling library, SPI flash driver, or FATFS drivers
  */
-#if 0
 esp_err_t
 esp_vfs_fat_spiflash_mount(
     const char*                       base_path,
     const char*                       partition_label,
     const esp_vfs_fat_mount_config_t* mount_config,
     wl_handle_t*                      wl_handle);
-#endif
 
 /**
  * @brief Unmount FAT filesystem and release resources acquired using esp_vfs_fat_spiflash_mount
@@ -193,10 +192,8 @@ esp_vfs_fat_spiflash_mount(
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if esp_vfs_fat_spiflash_mount hasn't been called
  */
-#if 0
 esp_err_t
 esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle);
-#endif
 
 /**
  * @brief Convenience function to initialize read-only FAT filesystem and register it in VFS

--- a/tests/test_nrf52fw/include/wear_levelling.h
+++ b/tests/test_nrf52fw/include/wear_levelling.h
@@ -1,0 +1,35 @@
+// Copyright 2015-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _wear_levelling_H_
+#define _wear_levelling_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief wear levelling handle
+ */
+typedef int32_t wl_handle_t;
+
+#define WL_INVALID_HANDLE -1
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // _wear_levelling_H_

--- a/tests/test_nrf52fw/test_nrf52fw.cpp
+++ b/tests/test_nrf52fw/test_nrf52fw.cpp
@@ -539,7 +539,9 @@ esp_vfs_fat_spiflash_mount(
 esp_err_t
 esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle)
 {
+    (void)base_path;
     assert(g_pTestClass->m_mount_info.flag_mounted);
+    assert(g_pTestClass->m_mount_info.wl_handle == wl_handle);
     g_pTestClass->m_mount_info.flag_mounted = false;
     return g_pTestClass->m_mount_info.unmount_err;
 }

--- a/tests/test_nrf52fw/test_nrf52fw.cpp
+++ b/tests/test_nrf52fw/test_nrf52fw.cpp
@@ -43,6 +43,7 @@ public:
     bool                       flag_mounted = false;
     esp_err_t                  mount_err    = ESP_OK;
     esp_err_t                  unmount_err  = ESP_OK;
+    wl_handle_t                wl_handle    = 0;
 };
 
 class MemAllocTrace
@@ -502,12 +503,41 @@ esp_vfs_fat_rawflash_mount(
     g_pTestClass->m_mount_info.base_path       = string(base_path);
     g_pTestClass->m_mount_info.partition_label = string(partition_label);
     g_pTestClass->m_mount_info.mount_config    = *mount_config;
-    g_pTestClass->m_mount_info.flag_mounted    = true;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
     return g_pTestClass->m_mount_info.mount_err;
 }
 
 esp_err_t
 esp_vfs_fat_rawflash_unmount(const char* base_path, const char* partition_label)
+{
+    assert(g_pTestClass->m_mount_info.flag_mounted);
+    g_pTestClass->m_mount_info.flag_mounted = false;
+    return g_pTestClass->m_mount_info.unmount_err;
+}
+
+esp_err_t
+esp_vfs_fat_spiflash_mount(
+    const char*                       base_path,
+    const char*                       partition_label,
+    const esp_vfs_fat_mount_config_t* mount_config,
+    wl_handle_t*                      wl_handle)
+{
+    g_pTestClass->m_mount_info.base_path       = string(base_path);
+    g_pTestClass->m_mount_info.partition_label = string(partition_label);
+    g_pTestClass->m_mount_info.mount_config    = *mount_config;
+    *wl_handle                                 = g_pTestClass->m_mount_info.wl_handle;
+    if (ESP_OK == g_pTestClass->m_mount_info.mount_err)
+    {
+        g_pTestClass->m_mount_info.flag_mounted = true;
+    }
+    return g_pTestClass->m_mount_info.mount_err;
+}
+
+esp_err_t
+esp_vfs_fat_spiflash_unmount(const char* base_path, wl_handle_t wl_handle)
 {
     assert(g_pTestClass->m_mount_info.flag_mounted);
     g_pTestClass->m_mount_info.flag_mounted = false;
@@ -1075,7 +1105,9 @@ TEST_F(TestNRF52Fw, nrf52fw_info_read_txt_no_file) // NOLINT
     ASSERT_EQ(0, info.fw_ver.version);
     ASSERT_EQ(0, info.num_segments);
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/info.txt");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open: info.txt");
@@ -1107,7 +1139,9 @@ TEST_F(TestNRF52Fw, nrf52fw_info_read_txt_bad_line_3) // NOLINT
     }
     ASSERT_TRUE(flashfatfs_unmount(&this->m_p_ffs));
     this->m_p_ffs = nullptr;
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Failed to parse 'info.txt' at line 3");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -1663,7 +1697,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_ok) // NOLINT
         ASSERT_EQ(this->m_memSegmentsRead[0].segmentAddr, this->m_memSegmentsWrite[0].segmentAddr);
         ASSERT_EQ(this->m_memSegmentsRead[0].data, this->m_memSegmentsWrite[0].data);
     }
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Writing 0x00001000...");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -1710,7 +1746,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_error_on_writing_segme
     flashfatfs_unmount(&this->m_p_ffs);
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Writing 0x00001000...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52swd_write_flash failed");
@@ -1749,7 +1787,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_segment_from_file_error_no_file) // NOLI
     flashfatfs_unmount(&this->m_p_ffs);
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/segment_1.bin");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open 'segment_1.bin'");
@@ -1836,7 +1876,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_ok) // NOLINT
     {
         ASSERT_EQ(fw_info.fw_ver.version, this->m_uicr_fw_ver);
     }
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 2 segments");
@@ -1953,7 +1995,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_ok_with_version_segment) // NOL
     {
         ASSERT_EQ(fw_info.fw_ver.version, this->m_uicr_fw_ver);
     }
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 3 segments");
@@ -2053,7 +2097,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_writing_version) // NOLIN
         ASSERT_EQ(this->m_memSegmentsRead[1].segmentAddr, this->m_memSegmentsWrite[1].segmentAddr);
         ASSERT_EQ(this->m_memSegmentsRead[1].data, this->m_memSegmentsWrite[1].data);
     }
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 2 segments");
@@ -2149,7 +2195,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_writing_segment) // NOLIN
         ASSERT_EQ(this->m_memSegmentsRead[0].segmentAddr, this->m_memSegmentsWrite[1].segmentAddr);
         ASSERT_EQ(this->m_memSegmentsRead[0].data, this->m_memSegmentsWrite[1].data);
     }
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Flash 2 segments");
@@ -2236,7 +2284,9 @@ TEST_F(TestNRF52Fw, nrf52fw_flash_write_firmware_error_erasing) // NOLINT
     this->m_p_ffs = nullptr;
 
     ASSERT_EQ(0, this->m_memSegmentsWrite.size());
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Erasing flash memory...");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52swd_erase_all failed");
@@ -2430,7 +2480,9 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_ok) // NOLINT
     flashfatfs_unmount(&this->m_p_ffs);
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
@@ -2500,7 +2552,9 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_error_bad_crc) // NOLINT
     flashfatfs_unmount(&this->m_p_ffs);
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Segment: 0x00001000: expected CRC: 0xa433c76e, actual CRC: 0xa433c76d");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -2564,7 +2618,9 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_fail_open_file) // NOLINT
     flashfatfs_unmount(&this->m_p_ffs);
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/segment_2.bin");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open 'segment_2.bin'");
@@ -2637,7 +2693,9 @@ TEST_F(TestNRF52Fw, nrf52fw_check_firmware_fail_calc_segment_crc) // NOLINT
     flashfatfs_unmount(&this->m_p_ffs);
     this->m_p_ffs = nullptr;
 
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_file_read failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_calc_segment_crc failed");
@@ -2739,7 +2797,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_not_needed) // 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
@@ -2864,7 +2924,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_not_needed_dont
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
@@ -2990,7 +3052,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required_becaus
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
@@ -3147,7 +3211,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required_becaus
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
@@ -3304,7 +3370,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required_dont_r
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
@@ -3486,7 +3554,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required__with_
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");
@@ -4123,7 +4193,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__debug_run_failed) // N
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
@@ -4243,8 +4315,14 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_mount_failed) //
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_WARN,
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "flashfatfs_mount failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
@@ -4341,7 +4419,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_mount_failed_no_
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't allocate memory");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "flashfatfs_mount failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");
@@ -4439,7 +4519,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_step2_no_mem) //
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "os_malloc failed");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -4528,7 +4610,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_info_txt) /
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "Can't open: ./fs_nrf52/info.txt");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "Can't open: info.txt");
@@ -4634,7 +4718,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_factory_inf
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_read_nrf52_ficr_hw_rev failed");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Unmount ./fs_nrf52");
@@ -4738,7 +4824,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_version) //
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "nrf52fw_read_current_fw_ver failed");
@@ -4846,7 +4934,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_calc_nrf52_sha25
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.3");
@@ -4952,7 +5042,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_check_firmware) 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
@@ -5072,7 +5164,9 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_write_firmware) 
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: true");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Hardware reset nRF52: false");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Init SWD");
-    TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Mount partition 'fatfs_nrf52' to the mount point /fs_nrf52");
+    TEST_CHECK_LOG_RECORD_FFFS(
+        ESP_LOG_INFO,
+        "Mount partition 'fatfs_nrf52' as FATFS (raw flash) to the mount point /fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_INFO, "Partition 'fatfs_nrf52' mounted successfully to /fs_nrf52");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "nRF52 factory information: Part code: 0x00052811");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "### Firmware on nRF52: v1.2.0");

--- a/tests/test_nrf52fw/test_nrf52fw.cpp
+++ b/tests/test_nrf52fw/test_nrf52fw.cpp
@@ -4321,7 +4321,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_mount_failed) //
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_rawflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
     TEST_CHECK_LOG_RECORD_FFFS(
         ESP_LOG_WARN,
-        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point /fs_nrf52");
+        "Try to mount partition 'fatfs_nrf52' as FATFS (SPI-Flash) to the mount point ./fs_nrf52");
     TEST_CHECK_LOG_RECORD_FFFS(ESP_LOG_ERROR, "esp_vfs_fat_spiflash_mount failed, err=261 (ESP_ERR_NOT_FOUND)");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_ERROR, "flashfatfs_mount failed");
     TEST_CHECK_LOG_RECORD_NRF52(ESP_LOG_INFO, "Deinit SWD");


### PR DESCRIPTION
Closes #1326.

## What

Restores dual-format mounting of the gateway's FAT filesystem partitions
(`fatfs_nrf52`, `fatfs_gwui`) in `main/flashfatfs.c`:
`flashfatfs_mount()` now tries the raw read-only FAT layout first and
falls back to the legacy wear-leveled (SPI-Flash) layout, and
`flashfatfs_unmount()` releases resources with the matching routine.

The public `flashfatfs_mount()` signature is unchanged (still 3
arguments), so no callers (`nrf52fw.c`, `http_server_cb.c`) need to
change.

## Why

v1.16.x mounts these partitions as **wear-leveled FAT**
(`esp_vfs_fat_spiflash_mount()`); v1.17.x switched them to **raw
read-only FAT** (`esp_vfs_fat_rawflash_mount()`, #1303/#1304) and, in
the process, dropped the fallback — v1.17.x mounted raw flash only.

That makes downgrading **v1.17.x → v1.16.3** brittle: across the
upgrade/downgrade transition the data partitions can be present in the
wear-leveled layout while v1.17.x is the firmware mounting them. A
raw-only mount then fails and the Web UI (`fatfs_gwui`) and the nRF52
firmware update (`fatfs_nrf52`) stop working. The legacy v1.16.x code
already coped with both layouts; this PR brings that robustness back to
v1.17.x.

## How

`struct flash_fat_fs_t` gains:

```c
wl_handle_t wl_handle;          // valid only when wear-leveled mount is used
bool        flag_use_raw_flash; // which backend mounted the partition
```

`flashfatfs_mount()`:

1. Sets `flag_use_raw_flash = true` and attempts
   `esp_vfs_fat_rawflash_mount()`.
2. On any error, logs a warning, sets `flag_use_raw_flash = false` and
   falls back to `esp_vfs_fat_spiflash_mount()` (storing `wl_handle`).
3. Only if both mounts fail is the object freed and `NULL` returned.

`flashfatfs_unmount()` calls `esp_vfs_fat_rawflash_unmount()` or
`esp_vfs_fat_spiflash_unmount(..., wl_handle)` depending on
`flag_use_raw_flash`, so the wear-leveling handle is always released.

Attempting raw → WL on the *same* partition is safe thanks to the local
`components/fatfs/vfs/vfs_fat_spiflash.c` overlay that fixes the
incomplete cleanup on the failed-mount path (#1294/#1312).

## What this PR does *not* change

- The `flashfatfs_*` public API (signatures unchanged).
- The on-flash partition format produced by the build.
- Any default values or other runtime behaviour.

## How to verify

1. Build the firmware:
   ```bash
   source ~/esp-idf-env.sh
   idf.py build
   ```
2. On a device whose partitions are in the **raw** layout, confirm the
   log shows `Mount partition '...' as FATFS (raw flash)` and a
   successful mount (unchanged behaviour).
3. On a device whose partitions are in the **wear-leveled** layout
   (e.g. one written by v1.16.3), confirm the log shows the raw-mount
   warning followed by
   `Try to mount partition '...' as FATFS (SPI-Flash)` and a successful
   mount; the Web UI loads and the nRF52 updater runs.
4. Downgrade a v1.17.x device to v1.16.3 and confirm the Web UI and the
   nRF52 firmware update keep working through the transition.
5. Run the host-side unit tests:
   ```bash
   cd tests
   cmake -S . -B cmake-build-unit-tests -G Ninja
   cmake --build cmake-build-unit-tests
   ctest --test-dir cmake-build-unit-tests --output-on-failure
   ```

## Notes for reviewers

- This mirrors the dual-format logic already shipped on the v1.16.x
  branch (`flag_use_raw_flash` selection in `flashfatfs_mount` /
  `_unmount`), minus the explicit `flag_use_raw_fatfs` parameter: on
  v1.17.x the raw layout is always tried first, so the behaviour is the
  same without changing the call sites.
- The fallback mount currently passes the original `mount_point` /
  `partition_label` arguments (matching the v1.16.x implementation),
  while the raw mount uses the object's copies. These differ only in the
  host unit-test build where a `.`-prefix is added to absolute mount
  points; in firmware builds the prefix is empty and the two are
  identical.
