### PR TITLE
fix(nrf52fw): close #1329 report `flag_success=false` to `cb_after_updating` on update failure

### DIFF
--- a/main/nrf52fw.c
+++ b/main/nrf52fw.c
@@ -719,7 +719,7 @@ nrf52fw_update_fw_step3(
         p_nrf52_fw_ver);
     if (NULL != cb_params.cb_after_updating)
     {
-        cb_params.cb_after_updating(true);
+        cb_params.cb_after_updating(res);
     }
     if (!res)
     {

--- a/tests/test_nrf52fw/test_nrf52fw.cpp
+++ b/tests/test_nrf52fw/test_nrf52fw.cpp
@@ -194,6 +194,7 @@ protected:
         };
         this->m_calc_nrf52_sha256_digest_status    = true;
         this->m_uicr_fw_ver_num_reads_before_error = 0;
+        this->cb_after_updating_last_flag_success  = false;
     }
 
     void
@@ -252,6 +253,7 @@ public:
     list<ProgressInfo>        m_progress;
     uint32_t                  cb_before_updating_cnt;
     uint32_t                  cb_after_updating_cnt;
+    bool                      cb_after_updating_last_flag_success;
     uint32_t                  m_uicr_fw_ver;
     bool                      m_uicr_fw_ver_simulate_write_error;
     bool                      m_uicr_fw_ver_simulate_read_error;
@@ -3453,6 +3455,7 @@ static void
 cb_after_updating(const bool flag_success)
 {
     g_pTestClass->cb_after_updating_cnt += 1;
+    g_pTestClass->cb_after_updating_last_flag_success = flag_success;
 }
 
 TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required__with_callbacks) // NOLINT
@@ -3557,6 +3560,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__update_required__with_
     ASSERT_EQ(697, cb_progress_cnt);
     ASSERT_EQ(1, this->cb_before_updating_cnt);
     ASSERT_EQ(1, this->cb_after_updating_cnt);
+    ASSERT_TRUE(this->cb_after_updating_last_flag_success);
 
     ASSERT_EQ(1, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(3, this->m_memSegmentsWrite.size());
@@ -5495,6 +5499,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_write_firmware__
 
     ASSERT_EQ(1, this->cb_before_updating_cnt);
     ASSERT_EQ(1, this->cb_after_updating_cnt);
+    ASSERT_FALSE(this->cb_after_updating_last_flag_success);
     ASSERT_EQ(1, this->m_memSegmentsWrite.size());
     ASSERT_EQ(1, this->m_cnt_nrf52swd_erase_all);
     // nrf52fw_read_current_fw_ver should have been invoked to refresh fw_ver after the failure;
@@ -5597,6 +5602,7 @@ TEST_F(TestNRF52Fw, nrf52fw_update_firmware_if_necessary__error_read_current_fw_
 
     ASSERT_EQ(1, this->cb_before_updating_cnt);
     ASSERT_EQ(1, this->cb_after_updating_cnt);
+    ASSERT_FALSE(this->cb_after_updating_last_flag_success);
     ASSERT_LT(0, cb_prog_cnt);
     ASSERT_EQ(1, this->m_cnt_nrf52swd_erase_all);
     ASSERT_EQ(3, this->m_memSegmentsWrite.size());


### PR DESCRIPTION
Closes #1329.

## What

`nrf52fw_update_fw_step3()` always invoked `cb_after_updating(true)`, even when
`nrf52fw_update_fw_step4()` failed, so callers were told the nRF52 firmware
update succeeded on every error path. This PR passes the actual result to the
callback and adds the test coverage that was missing.

## Why

The callback contract for `cb_after_updating(bool flag_success)` is to report
the outcome of the update. Because a literal `true` was passed regardless of the
result, the `flag_success == false` notification was never emitted on failures
(failed `nrf52fw_flash_write_firmware()` or failed post-flash
`nrf52fw_read_current_fw_ver()`). Reported in review of the
callback-parameter refactor (#1301 / #1302).

The bug survived the existing test suite because the `cb_after_updating` mock
ignored its `flag_success` argument and only counted invocations — so `true`
and the correct `res` were indistinguishable to the tests.

## How

### 1. Production fix — `main/nrf52fw.c`

```diff
     const bool res = nrf52fw_update_fw_step4(
         p_ffs,
         p_tmp_data,
         cb_params.cb_progress,
         cb_params.p_param_cb_progress,
         p_nrf52_fw_ver);
     if (NULL != cb_params.cb_after_updating)
     {
-        cb_params.cb_after_updating(true);
+        cb_params.cb_after_updating(res);
     }
     if (!res)
     {
         return false;
     }
```

### 2. Close the test gap — `tests/test_nrf52fw/test_nrf52fw.cpp`

- Record the last value passed to the callback and reset it per test:
  ```c
  bool cb_after_updating_last_flag_success;   // new member, reset in SetUp()
  ...
  static void
  cb_after_updating(const bool flag_success)
  {
      g_pTestClass->cb_after_updating_cnt += 1;
      g_pTestClass->cb_after_updating_last_flag_success = flag_success;
  }
  ```
- Assert the value (not just the count) in the existing callback tests:
  - `…__update_required__with_callbacks` — `ASSERT_TRUE(...last_flag_success)`
  - `…__error_write_firmware__with_callbacks` — `ASSERT_FALSE(...last_flag_success)`
  - `…__error_read_current_fw_ver_after_flash` — `ASSERT_FALSE(...last_flag_success)`

## What this PR does *not* change

- The callback is still invoked exactly once, in the same place, with the same
  guard (`NULL != cb_params.cb_after_updating`).
- No change to the success path's externally observable result — only the
  failure paths now correctly report `false`.
- No public API/signature change.

## How to verify

1. Build and run the nRF52 firmware unit tests:
   ```bash
   cd tests
   cmake -S . -B cmake-build-unit-tests -G Ninja
   cmake --build cmake-build-unit-tests --target ruuvi_gateway_esp-test-nrf52fw
   ./cmake-build-unit-tests/test_nrf52fw/ruuvi_gateway_esp-test-nrf52fw
   ```
   All tests pass.
2. Mutation check: temporarily revert the production change back to
   `cb_after_updating(true)` and re-run — the two failure-path tests
   (`…__error_write_firmware__with_callbacks` and
   `…__error_read_current_fw_ver_after_flash`) now fail on
   `cb_after_updating_last_flag_success`, proving the new assertions guard the
   fix.

## Notes for reviewers

- The functional delta is a single line in `main/nrf52fw.c`; the rest is test
  instrumentation that makes the `flag_success` value observable so the
  behaviour can no longer regress silently.

