### PR TITLE
chore(mbedtls): #1526 update documentation dependencies

### DIFF
--- a/components/mbedtls/mbedtls/docs/requirements.txt
+++ b/components/mbedtls/mbedtls/docs/requirements.txt
@@ -39,7 +39,7 @@ mdurl==0.1.2
     # via markdown-it-py
 packaging==23.0
     # via sphinx
-pygments==2.17.2
+pygments==2.20.0
     # via
     #   -r requirements.in
     #   rich

--- a/components/mbedtls/mbedtls/docs/requirements.txt
+++ b/components/mbedtls/mbedtls/docs/requirements.txt
@@ -48,7 +48,7 @@ pyyaml==6.0
     # via readthedocs-cli
 readthedocs-cli==4
     # via -r requirements.in
-requests==2.31.0
+requests==2.33.0
     # via
     #   -r requirements.in
     #   readthedocs-cli

--- a/components/mbedtls/mbedtls/docs/requirements.txt
+++ b/components/mbedtls/mbedtls/docs/requirements.txt
@@ -10,7 +10,7 @@ babel==2.12.1
     # via sphinx
 breathe==4.35.0
     # via -r requirements.in
-certifi==2024.2.2
+certifi==2024.7.4
     # via
     #   -r requirements.in
     #   requests

--- a/components/mbedtls/mbedtls/docs/requirements.txt
+++ b/components/mbedtls/mbedtls/docs/requirements.txt
@@ -23,7 +23,7 @@ docutils==0.17.1
     #   breathe
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.4
+idna==3.15
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/components/mbedtls/mbedtls/docs/requirements.txt
+++ b/components/mbedtls/mbedtls/docs/requirements.txt
@@ -27,7 +27,7 @@ idna==3.15
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.3
+jinja2==3.1.6
     # via
     #   -r requirements.in
     #   sphinx

--- a/components/mbedtls/mbedtls/docs/requirements.txt
+++ b/components/mbedtls/mbedtls/docs/requirements.txt
@@ -77,7 +77,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==2.2.0
+urllib3==2.7.0
     # via
     #   -r requirements.in
     #   requests


### PR DESCRIPTION
## Summary

Update Python dependencies used to build the mbedTLS documentation, resolving 18 Dependabot alerts: 4 high, 12 medium, and 2 low severity.

Updated dependencies:

- `urllib3`: 2.2.0 → 2.7.0
- `idna`: 3.4 → 3.15
- `Jinja2`: 3.1.3 → 3.1.6
- `requests`: 2.31.0 → 2.33.0
- `Pygments`: 2.17.2 → 2.20.0
- `certifi`: 2024.2.2 → 2024.7.4

## Vulnerabilities fixed

### urllib3

- CVE-2024-37891: `Proxy-Authorization` header exposure during cross-origin redirects
- CVE-2025-50181: redirects not disabled with retries on `PoolManager`
- CVE-2025-50182: ineffective redirect controls in browser and Node.js environments
- CVE-2025-66418: unbounded decompression-chain processing
- CVE-2025-66471: streaming API exposure to highly compressed data
- CVE-2026-21441: decompression-bomb safeguard bypass through HTTP redirects
- CVE-2026-44431: sensitive headers forwarded across origins during proxied redirects

### idna

- CVE-2024-3651: denial of service through crafted `idna.encode()` input
- CVE-2026-45409: resource exhaustion bypassing the original CVE-2024-3651 fix

### Jinja2

- CVE-2024-34064: HTML attribute injection through the `xmlattr` filter
- CVE-2024-56201: sandbox breakout through malicious filenames
- CVE-2024-56326: sandbox breakout through an indirect reference to `str.format`
- CVE-2025-27516: sandbox breakout through the `attr` filter

### requests

- CVE-2024-35195: TLS verification bypass after a session request using `verify=False`
- CVE-2024-47081: `.netrc` credential leakage through malicious URLs
- CVE-2026-25645: insecure temporary-file reuse in `extract_zipped_paths()`

### Pygments

- CVE-2026-4539: regular-expression denial of service during GUID highlighting

### certifi

- CVE-2024-39689: removes the distrusted GLOBALTRUST root certificate following Mozilla's investigation into unresolved CA compliance and incident-response failures

Closes #1526