### PR TITLE
fix(url_encode): #1529 reject percent-decoded NUL bytes

### DIFF
--- a/main/url_encode.c
+++ b/main/url_encode.c
@@ -106,6 +106,10 @@ url_n_decode_to_str_buf(const char* const p_src, const size_t len, str_buf_t* co
             {
                 return false;
             }
+            if (0 == ch_val)
+            {
+                return false;
+            }
             str_buf_printf(p_dst, "%c", (char)ch_val);
             p_cur += URL_ENCODE_NUM_CHARS_PER_BYTE;
         }
@@ -142,6 +146,7 @@ url_n_decode_with_alloc(const char* const p_src, const size_t len)
     }
     if (!url_n_decode_to_str_buf(p_src, len, &str_buf))
     {
+        str_buf_free_buf(&str_buf);
         return str_buf_init_null();
     }
     return str_buf;

--- a/tests/test_http_server_cb/test_http_server_cb.cpp
+++ b/tests/test_http_server_cb/test_http_server_cb.cpp
@@ -1488,6 +1488,26 @@ TEST_F(TestHttpServerCb, http_server_get_from_params_with_decoding_key_not_found
     ASSERT_EQ(0, this->m_alloc_free_call_count);
 }
 
+TEST_F(TestHttpServerCb, http_server_get_from_params_with_decoding_rejects_percent_encoded_nul) // NOLINT
+{
+    esp_log_wrapper_clear();
+    str_buf_t result = http_server_get_from_params_with_decoding("url=https%3A%2F%2Fgood.example%00ignored", "url=");
+
+    ASSERT_EQ(nullptr, result.buf);
+    TEST_CHECK_LOG_RECORD_HTTP_SERVER(ESP_LOG_DEBUG, "HTTP params: url=https%3A%2F%2Fgood.example%00ignored");
+    TEST_CHECK_LOG_RECORD_HTTP_SERVER(
+        ESP_LOG_DEBUG,
+        "HTTP params: key 'url=': value (encoded): https%3A%2F%2Fgood.example%00ignored");
+    TEST_CHECK_LOG_RECORD_HTTP_SERVER(
+        ESP_LOG_ERROR,
+        "HTTP params: key 'url=': Can't decode value: https%3A%2F%2Fgood.example%00ignored");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
 TEST_F(TestHttpServerCb, http_server_get_from_params_with_decoding_malloc_fail_on_get_params) // NOLINT
 {
     g_pTestClass->m_malloc_fail_on_cnt = 1;

--- a/tests/test_url_encode/test_url_encode.cpp
+++ b/tests/test_url_encode/test_url_encode.cpp
@@ -201,3 +201,27 @@ TEST_F(TestUrlEncode, test_decode_fail_3) // NOLINT
     const str_buf_t val_decoded = url_decode_with_alloc(val_encoded.c_str());
     ASSERT_EQ(nullptr, val_decoded.buf);
 }
+
+TEST_F(TestUrlEncode, test_decode_fail_nul_at_beginning) // NOLINT
+{
+    const str_buf_t val_decoded = url_decode_with_alloc("%00ignored");
+
+    ASSERT_EQ(nullptr, val_decoded.buf);
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestUrlEncode, test_decode_fail_nul_in_middle) // NOLINT
+{
+    const str_buf_t val_decoded = url_decode_with_alloc("https%3A%2F%2Fgood.example%00ignored");
+
+    ASSERT_EQ(nullptr, val_decoded.buf);
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}
+
+TEST_F(TestUrlEncode, test_decode_fail_nul_at_end) // NOLINT
+{
+    const str_buf_t val_decoded = url_decode_with_alloc("https%3A%2F%2Fgood.example%00");
+
+    ASSERT_EQ(nullptr, val_decoded.buf);
+    ASSERT_TRUE(this->m_mem_alloc_trace.is_empty());
+}


### PR DESCRIPTION
Reject decoded NUL bytes before writing them to C-string buffers. Free allocated decode buffers when decoding fails and add regression coverage for NUL bytes at every position and HTTP request parameters.

Fixes #1529