### PR TITLE
fix(validate_url): #1530 fix dangling saved-password pointer in remote URL validation

### DIFF
--- a/main/validate_url.c
+++ b/main/validate_url.c
@@ -730,7 +730,6 @@ validate_url_check_remote_cfg(const validate_url_params_t* const p_params)
             p_saved_password = p_saved_remote_cfg->auth.auth_apikey.api_key.buf;
             break;
     }
-    os_free(p_saved_remote_cfg);
     const http_check_params_t params = {
         .p_url               = p_params->url.buf,
         .auth_type           = p_params->auth_type,
@@ -748,6 +747,7 @@ validate_url_check_remote_cfg(const validate_url_params_t* const p_params)
     LOG_INFO("Validate URL (GET remote_cfg): use_ssl_client_cert=%d", p_params->use_ssl_client_cert);
     LOG_INFO("Validate URL (GET remote_cfg): use_ssl_server_cert=%d", p_params->use_ssl_server_cert);
     const http_server_resp_t http_resp = validate_url_on_get_check_remote_cfg(&params);
+    os_free(p_saved_remote_cfg);
     return http_resp;
 }
 

--- a/main/validate_url.c
+++ b/main/validate_url.c
@@ -20,6 +20,10 @@
 #include "log.h"
 static const char TAG[] = "http_server";
 
+#if (LOG_LOCAL_LEVEL >= LOG_LEVEL_DEBUG) && !RUUVI_TESTS
+#warning Debug log level prints out the passwords as a "plaintext".
+#endif
+
 #define MQTT_URL_PREFIX_LEN (20)
 
 #define BASE_10 (10)

--- a/tests/test_http_server_cb/test_http_server_cb.cpp
+++ b/tests/test_http_server_cb/test_http_server_cb.cpp
@@ -7667,6 +7667,104 @@ TEST_F(
     ASSERT_EQ(0, this->m_alloc_free_call_count);
 }
 
+TEST_F(TestHttpServerCb, http_server_cb_on_get_validate_url_check_remote_cfg__uses_saved_basic_password) // NOLINT
+{
+    static const char saved_password[] = "saved-basic-password";
+    gw_cfg_t          gw_cfg           = { 0 };
+    gw_cfg_get_copy(&gw_cfg);
+    gw_cfg.ruuvi_cfg.remote.auth_type = GW_CFG_HTTP_AUTH_TYPE_BASIC;
+    (void)snprintf(
+        gw_cfg.ruuvi_cfg.remote.auth.auth_basic.password.buf,
+        sizeof(gw_cfg.ruuvi_cfg.remote.auth.auth_basic.password.buf),
+        "%s",
+        saved_password);
+    gw_cfg_update_ruuvi_cfg(&gw_cfg.ruuvi_cfg);
+
+    bool download_called                 = false;
+    this->m_mock_http_download_with_auth = [&](const http_download_param_with_auth_t* p_param,
+                                               http_download_cb_on_data_t,
+                                               void*,
+                                               bool) -> http_server_resp_t {
+        download_called = true;
+        EXPECT_STREQ("https://myserver.com/gw_cfg.json", p_param->base.p_url);
+        EXPECT_EQ(GW_CFG_HTTP_AUTH_TYPE_BASIC, p_param->auth_type);
+        EXPECT_NE(nullptr, p_param->p_http_auth);
+        if (nullptr != p_param->p_http_auth)
+        {
+            EXPECT_STREQ("test-user", p_param->p_http_auth->auth_basic.user.buf);
+            EXPECT_STREQ(saved_password, p_param->p_http_auth->auth_basic.password.buf);
+        }
+        return http_server_resp_400();
+    };
+
+    esp_log_wrapper_clear();
+    const char* const p_uri_params
+        = "validate_type=check_remote_cfg"
+          "&url=https://myserver.com/gw_cfg.json"
+          "&auth_type=basic"
+          "&user=test-user"
+          "&use_saved_password=true"
+          "&use_ssl_client_cert=false"
+          "&use_ssl_server_cert=false";
+    http_server_resp_t resp = http_server_cb_on_get("validate_url", p_uri_params, true, nullptr);
+
+    EXPECT_TRUE(download_called);
+    http_server_resp_free(&resp);
+    esp_log_wrapper_clear();
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerCb, http_server_cb_on_get_validate_url_check_remote_cfg__uses_saved_bearer_token) // NOLINT
+{
+    static const char saved_token[] = "saved-bearer-token";
+    gw_cfg_t          gw_cfg        = { 0 };
+    gw_cfg_get_copy(&gw_cfg);
+    gw_cfg.ruuvi_cfg.remote.auth_type = GW_CFG_HTTP_AUTH_TYPE_BEARER;
+    (void)snprintf(
+        gw_cfg.ruuvi_cfg.remote.auth.auth_bearer.token.buf,
+        sizeof(gw_cfg.ruuvi_cfg.remote.auth.auth_bearer.token.buf),
+        "%s",
+        saved_token);
+    gw_cfg_update_ruuvi_cfg(&gw_cfg.ruuvi_cfg);
+
+    bool download_called                 = false;
+    this->m_mock_http_download_with_auth = [&](const http_download_param_with_auth_t* p_param,
+                                               http_download_cb_on_data_t,
+                                               void*,
+                                               bool) -> http_server_resp_t {
+        download_called = true;
+        EXPECT_STREQ("https://myserver.com/gw_cfg.json", p_param->base.p_url);
+        EXPECT_EQ(GW_CFG_HTTP_AUTH_TYPE_BEARER, p_param->auth_type);
+        EXPECT_NE(nullptr, p_param->p_http_auth);
+        if (nullptr != p_param->p_http_auth)
+        {
+            EXPECT_STREQ(saved_token, p_param->p_http_auth->auth_bearer.token.buf);
+        }
+        return http_server_resp_400();
+    };
+
+    esp_log_wrapper_clear();
+    const char* const p_uri_params
+        = "validate_type=check_remote_cfg"
+          "&url=https://myserver.com/gw_cfg.json"
+          "&auth_type=bearer"
+          "&use_saved_password=true"
+          "&use_ssl_client_cert=false"
+          "&use_ssl_server_cert=false";
+    http_server_resp_t resp = http_server_cb_on_get("validate_url", p_uri_params, true, nullptr);
+
+    EXPECT_TRUE(download_called);
+    http_server_resp_free(&resp);
+    esp_log_wrapper_clear();
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
 TEST_F(TestHttpServerCb, test_http_server_cb_on_user_req__update_cycle_regular__latest_only) // NOLINT
 {
     {


### PR DESCRIPTION
- keep the saved remote configuration alive throughout URL validation
- prevent dangling credential reads for authenticated remote configurations
- cover saved Basic-password and Bearer-token validation
- retain allocation and leak assertions

Fixes #1530