### PR TITLE
fix(ci): #1523 publish production OTA binaries as separate release assets

### DIFF
--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -136,27 +136,6 @@ jobs:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
 
-      - name: Upload ruuvi_gateway_esp.bin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ruuvi_gateway_esp.bin
-          path: build/ruuvi_gateway_esp.bin
-          if-no-files-found: error
-
-      - name: Upload fatfs_gwui.bin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fatfs_gwui.bin
-          path: build/fatfs_gwui.bin
-          if-no-files-found: error
-
-      - name: Upload fatfs_nrf52.bin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fatfs_nrf52.bin
-          path: build/fatfs_nrf52.bin
-          if-no-files-found: error
-
       - name: Create release zip
         id: create_zip
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-fw-dev.yml
+++ b/.github/workflows/build-fw-dev.yml
@@ -136,6 +136,27 @@ jobs:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
 
+      - name: Upload ruuvi_gateway_esp.bin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ruuvi_gateway_esp.bin
+          path: build/ruuvi_gateway_esp.bin
+          if-no-files-found: error
+
+      - name: Upload fatfs_gwui.bin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fatfs_gwui.bin
+          path: build/fatfs_gwui.bin
+          if-no-files-found: error
+
+      - name: Upload fatfs_nrf52.bin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fatfs_nrf52.bin
+          path: build/fatfs_nrf52.bin
+          if-no-files-found: error
+
       - name: Create release zip
         id: create_zip
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -133,27 +133,6 @@ jobs:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
 
-      - name: Upload ruuvi_gateway_esp.bin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ruuvi_gateway_esp.bin
-          path: build/ruuvi_gateway_esp.bin
-          if-no-files-found: error
-
-      - name: Upload fatfs_gwui.bin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fatfs_gwui.bin
-          path: build/fatfs_gwui.bin
-          if-no-files-found: error
-
-      - name: Upload fatfs_nrf52.bin artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: fatfs_nrf52.bin
-          path: build/fatfs_nrf52.bin
-          if-no-files-found: error
-
       - name: Create release zip
         id: create_zip
         if: startsWith(github.ref, 'refs/tags/')
@@ -207,22 +186,10 @@ jobs:
       TAG: ${{ github.ref_name }}
       ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
     steps:
-      - name: Download ruuvi_gateway_esp.bin artifact
+      - name: Download firmware artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ruuvi_gateway_esp.bin
-          path: release_files
-
-      - name: Download fatfs_gwui.bin artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: fatfs_gwui.bin
-          path: release_files
-
-      - name: Download fatfs_nrf52.bin artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: fatfs_nrf52.bin
+          name: ruuvi_gateway_fw
           path: release_files
 
       - name: Download release zip artifact

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -133,6 +133,27 @@ jobs:
           name: ruuvi_gateway_fw
           path: ${{ env.RELEASE_FILES }}
 
+      - name: Upload ruuvi_gateway_esp.bin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ruuvi_gateway_esp.bin
+          path: build/ruuvi_gateway_esp.bin
+          if-no-files-found: error
+
+      - name: Upload fatfs_gwui.bin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fatfs_gwui.bin
+          path: build/fatfs_gwui.bin
+          if-no-files-found: error
+
+      - name: Upload fatfs_nrf52.bin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fatfs_nrf52.bin
+          path: build/fatfs_nrf52.bin
+          if-no-files-found: error
+
       - name: Create release zip
         id: create_zip
         if: startsWith(github.ref, 'refs/tags/')
@@ -186,10 +207,22 @@ jobs:
       TAG: ${{ github.ref_name }}
       ARTIFACT_NAME: ${{ needs.build.outputs.release_zip_name }}
     steps:
-      - name: Download firmware artifact
+      - name: Download ruuvi_gateway_esp.bin artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ruuvi_gateway_fw
+          name: ruuvi_gateway_esp.bin
+          path: release_files
+
+      - name: Download fatfs_gwui.bin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fatfs_gwui.bin
+          path: release_files
+
+      - name: Download fatfs_nrf52.bin artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: fatfs_nrf52.bin
           path: release_files
 
       - name: Download release zip artifact
@@ -198,29 +231,18 @@ jobs:
           name: ruuvi_gateway_fw-prod-release-zip
           path: release_asset
 
-      - name: Create release and upload assets
+      - name: Create release and upload asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          set -xeuo pipefail
+          set -xe
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
-          RELEASE_DIR="$GITHUB_WORKSPACE/release_files"
-          ZIP_PATH="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}.zip"
-          if [ ! -d "$RELEASE_DIR" ]; then
-            echo "Release files directory not found at $RELEASE_DIR"
+          ARTIFACT_PATH="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}.zip"
+          if [ ! -f "$ARTIFACT_PATH" ]; then
+            echo "Artifact not found at $ARTIFACT_PATH"; ls -la "$GITHUB_WORKSPACE/release_asset" || true
             exit 1
           fi
-          mapfile -t ASSETS < <(find "$RELEASE_DIR" -type f | sort)
-          if [ "${#ASSETS[@]}" -eq 0 ]; then
-            echo "No release files found under $RELEASE_DIR"
-            exit 1
-          fi
-          if [ ! -f "$ZIP_PATH" ]; then
-            echo "Artifact not found at $ZIP_PATH"; ls -la "$GITHUB_WORKSPACE/release_asset" || true
-            exit 1
-          fi
-          ASSETS+=("$ZIP_PATH")
           # create if missing; on failure re-check to tolerate races with the dev workflow
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Automated release" --prerelease; then
@@ -231,4 +253,24 @@ jobs:
               fi
             fi
           fi
+          gh release upload "$TAG" "$ARTIFACT_PATH" --repo "$GITHUB_REPOSITORY" --clobber
+
+      - name: Upload production firmware files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          RELEASE_DIR="$GITHUB_WORKSPACE/release_files"
+          ASSETS=(
+            "$RELEASE_DIR/ruuvi_gateway_esp.bin"
+            "$RELEASE_DIR/fatfs_gwui.bin"
+            "$RELEASE_DIR/fatfs_nrf52.bin"
+          )
+          for asset in "${ASSETS[@]}"; do
+            if [ ! -f "$asset" ]; then
+              echo "Release file not found at $asset"
+              exit 1
+            fi
+          done
           gh release upload "$TAG" "${ASSETS[@]}" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build-fw-prod.yml
+++ b/.github/workflows/build-fw-prod.yml
@@ -198,12 +198,12 @@ jobs:
           name: ruuvi_gateway_fw-prod-release-zip
           path: release_asset
 
-      - name: Create release and upload asset
+      - name: Create release and upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          set -xe
+          set -xeuo pipefail
           command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
           ARTIFACT_PATH="$GITHUB_WORKSPACE/release_asset/${ARTIFACT_NAME}.zip"
           if [ ! -f "$ARTIFACT_PATH" ]; then


### PR DESCRIPTION
## Summary

- Keep the production firmware ZIP upload in its existing dedicated step.
- Upload `ruuvi_gateway_esp.bin`, `fatfs_gwui.bin`, and `fatfs_nrf52.bin` in a separate release step.
- Publish each binary as an individual GitHub Release asset.
- Validate that all required binaries exist before uploading.
- Enable strict shell error handling for release publication.

The binaries are available through stable URLs such as:

```text
https://github.com/ruuvi/ruuvi.gateway_esp.c/releases/download/<tag>/ruuvi_gateway_esp.bin
```