### PR TITLE
fix(esp32-wifi-manager): #1549 apply brute-force delay to all denied requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *.orig
+*.swp
+
+.env
+.venv/
 
 build/
 build-sonar/


### PR DESCRIPTION
Move the one-second brute-force protection delay to the common HTTP request handler so all 401 and 403 responses are delayed consistently.

Remove the unconditional delay from the ECDH POST handler, allowing successful interactive authentication to return immediately while protecting Basic, Digest, bearer, disabled, and interactive failures.

Close #1549